### PR TITLE
a(&b) parses incorrectly

### DIFF
--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -2076,6 +2076,13 @@ class TestParser < MiniTest::Unit::TestCase
       %q{fun(*bar, &baz)})
   end
 
+  def test_args_block_pass
+    assert_parses(
+      s(:send, nil, :fun,
+        s(:block_pass, s(:lvar, :bar))),
+      %q{fun(&bar)})
+  end
+
   def test_args_assocs
     assert_parses(
       s(:send, nil, :fun,


### PR DESCRIPTION
`a(&b)` parses as `a(b)`. I've added a failing test, I'll have a shot at fixing it too.
