### PR TITLE
Add column method to source map

### DIFF
--- a/lib/parser/source/map.rb
+++ b/lib/parser/source/map.rb
@@ -19,6 +19,10 @@ module Parser
         @expression.line
       end
 
+      def column
+        @expression.column
+      end
+
       def with_expression(expression_l)
         with { |map| map.update_expression(expression_l) }
       end


### PR DESCRIPTION
A simple complement to the already existing `#line` method.
