### PR TITLE
Fix rake test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rake/clean'
 
-task :default => [:generate, :test]
+task :default => [:test]
 
 Rake::TestTask.new do |t|
   t.libs       = %w(test/ lib/)
@@ -59,3 +59,4 @@ rule '.rb' => '.y' do |t|
   sh "racc", *opts
 end
 
+task :test => [:generate]


### PR DESCRIPTION
Made `rake test` depend on `generate` and the default task invokes only
test now. A little convenience for people who're not used to set `test` as
the default task and would otherwise see an error.
