### PR TITLE
`rake test` fails in confusing way when command-line dependency `ragel` not present.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,9 +51,9 @@ task :ragel_check do
   raise 'command-line dependency ragel not installed!' unless ragel_version
 
   _, version_str, major, minor = *ragel_version
-  if (major.to_i < major_req) || (major.to_i == major_req && minor.to_i < minor_req)
+  if (major.to_i != major_req || minor.to_i < minor_req) # ~> major.minor
     raise "command-line dependency ragel must be " +
-          ">= #{major_req}.#{minor_req}; got #{version_str}"
+          "~> #{major_req}.#{minor_req}; got #{version_str}"
   end
 end
 


### PR DESCRIPTION
``` sh
$ bundle exec rake test -t
** Invoke test (first_time)
** Invoke generate (first_time)
** Invoke lib/parser/lexer.rb (first_time)
** Invoke lib/parser/lexer.rl (first_time, not_needed)
** Execute lib/parser/lexer.rb
ragel -R lib/parser/lexer.rl -o lib/parser/lexer.rb
rake aborted!
Command failed with status (127): [ragel -R lib/parser/lexer.rl -o lib/parser...]
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/file_utils.rb:53:in `block in create_shell_runner'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/file_utils.rb:45:in `call'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/file_utils.rb:45:in `sh'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/file_utils_ext.rb:40:in `sh'
/Users/yaauie/src/parser/Rakefile:111:in `block in <top (required)>'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:226:in `call'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:226:in `block in execute'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:223:in `each'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:223:in `execute'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:166:in `block in invoke_with_call_chain'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:159:in `invoke_with_call_chain'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:187:in `block in invoke_prerequisites'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:185:in `each'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:185:in `invoke_prerequisites'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:165:in `block in invoke_with_call_chain'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:159:in `invoke_with_call_chain'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:187:in `block in invoke_prerequisites'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:185:in `each'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:185:in `invoke_prerequisites'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:165:in `block in invoke_with_call_chain'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:159:in `invoke_with_call_chain'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/task.rb:152:in `invoke'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/application.rb:143:in `invoke_task'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/application.rb:101:in `block (2 levels) in top_level'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/application.rb:101:in `each'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/application.rb:101:in `block in top_level'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/application.rb:110:in `run_with_threads'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/application.rb:95:in `top_level'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/application.rb:73:in `block in run'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/application.rb:160:in `standard_exception_handling'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/lib/rake/application.rb:70:in `run'
/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rake-0.9.6/bin/rake:37:in `<top (required)>'
/Users/yaauie/.rbenv/versions/1.9.3-p194/bin/rake:23:in `load'
/Users/yaauie/.rbenv/versions/1.9.3-p194/bin/rake:23:in `<main>'
Tasks: TOP => test => generate => lib/parser/lexer.rb

```
