### PR TITLE
Fix directive advancement

### DIFF
--- a/lib/parser/source/comment/associator.rb
+++ b/lib/parser/source/comment/associator.rb
@@ -86,12 +86,12 @@ module Parser
 
       def advance_through_directives
         # Skip shebang.
-        if current_comment.text =~ /^#!/
+        if current_comment && current_comment.text =~ /^#!/
           advance_comment
         end
 
         # Skip encoding line.
-        if current_comment.text =~ Buffer::ENCODING_RE
+        if current_comment && current_comment.text =~ Buffer::ENCODING_RE
           advance_comment
         end
       end

--- a/test/test_source_comment_associator.rb
+++ b/test/test_source_comment_associator.rb
@@ -65,4 +65,22 @@ end
                  associations[ast].map(&:text)
   end
 
+  def test_associate_shebang_only
+    ast, associations = associate(<<-END)
+#!ruby
+class Foo
+end
+    END
+
+    assert_equal 0, associations.size
+  end
+
+  def test_associate_no_comments
+    ast, associations = associate(<<-END)
+class Foo
+end
+    END
+
+    assert_equal 0, associations.size
+  end
 end


### PR DESCRIPTION
This branch fixes a bug in the directive advancement comment handling code.

The previous code assumed that current_comment would always return an object, but if @comments is empty, or the first comment is a shebang, then a NoMethodError would be thrown because current_comment returns nil.

Fixes: https://github.com/whitequark/parser/issues/98
