### PR TITLE
Source::Rewriter applies insertions at same location in insertion order

### DIFF
--- a/lib/parser/source/rewriter.rb
+++ b/lib/parser/source/rewriter.rb
@@ -35,11 +35,12 @@ module Parser
       end
 
       def process
-        adjustment = 0
-        source     = @source_buffer.source.dup
-
-        @queue.sort_by { |action| action.range.begin_pos }.
-               each do |action|
+        adjustment   = 0
+        source       = @source_buffer.source.dup
+        sorted_queue = @queue.sort_by.with_index do |action, index|
+          [action.range.begin_pos, index]
+        end
+        sorted_queue.each do |action|
           begin_pos = action.range.begin_pos + adjustment
           end_pos   = begin_pos + action.range.length
 

--- a/test/test_source_rewriter.rb
+++ b/test/test_source_rewriter.rb
@@ -56,6 +56,18 @@ class TestSourceRewriter < Minitest::Test
                     process
   end
 
+  def test_multiple_insertions_at_same_location
+    assert_equal '<([foo] bar) baz>',
+                 @rewriter.
+                   insert_before(range(0, 11), '<').
+                   insert_after( range(0, 11), '>').
+                   insert_before(range(0, 7), '(').
+                   insert_after( range(0, 7), ')').
+                   insert_before(range(0, 3), '[').
+                   insert_after( range(0, 3), ']').
+                   process
+  end
+
   def test_clobber
     diagnostics = []
     @rewriter.diagnostics.consumer = lambda do |diag|


### PR DESCRIPTION
Since Ruby sorting isn't stable, insertions at the same location can get ordered arbitrarily. This stabilizes the sorting.

For reference, here was the failure (because the ordering is arbitrary, I don't know that it's guaranteed to be reproducible)

```
$ ruby -I test test/test_source_rewriter.rb
Warning: you should require 'minitest/autorun' instead.
Warning: or add 'gem "minitest"' before 'require "minitest/autorun"'
From:
  /Users/joshcheek/.rbenv/versions/1.9.3-p327-perf/lib/ruby/1.9.1/minitest/autorun.rb:14:in `<top (required)>'
  /Users/joshcheek/code/foss/parser/test/helper.rb:42:in `<top (required)>'
  test/test_source_rewriter.rb:1:in `<main>'
MiniTest::Unit.autorun is now Minitest.autorun. From /Users/joshcheek/.rbenv/versions/1.9.3-p327-perf/lib/ruby/1.9.1/minitest/autorun.rb:18:in `<top (required)>'
Run options: --seed 59361

# Running:

..F.....

Finished in 0.012682s, 630.8153 runs/s, 1103.9268 assertions/s.

  1) Failure:
TestSourceRewriter#test_multiple_insertions_at_same_location [test/test_source_rewriter.rb:60]:
Expected: "<([foo] bar) baz>"
  Actual: "<[(foo] bar) baz>"

8 runs, 14 assertions, 1 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /Users/joshcheek/code/foss/parser/coverage. 635 / 1354 LOC (46.9%) covered.
Coverage report generated for Unit Tests to /Users/joshcheek/code/foss/parser/coverage/sublime-ruby-coverage
[Coveralls] Outside the Travis environment, not sending data.
```
