### PR TITLE
Remove unused unpacking

### DIFF
--- a/lib/parser/ast/processor.rb
+++ b/lib/parser/ast/processor.rb
@@ -21,8 +21,6 @@ module Parser
       alias on_erange   process_regular_node
 
       def on_var(node)
-        name, = *node
-
         node
       end
 


### PR DESCRIPTION
This silences a warning under MRI 2.0.0
