### PR TITLE
Node#equivalent? for testing runtime equivalence

### DIFF
--- a/lib/parser/ast/node.rb
+++ b/lib/parser/ast/node.rb
@@ -30,6 +30,66 @@ module Parser
           @location = location
         end
       end
+
+      ##
+      # Compares `self` to `other` for runtime equivalence. An AST for Ruby
+      # source that has superfluous parentheses, for instance, is equivalent to
+      # the AST for the source without them.
+      #
+      # @param [#to_ast] other
+      #
+      # @return [Boolean]
+      #
+      def equivalent?(other)
+        if equal?(other)
+          true
+        elsif other.respond_to? :to_ast
+          other = other.to_ast
+          if equivalent_type? other
+            equivalent_children? other
+          elsif begin_type? && self.children.size == 1
+            self.children.first.equivalent? other
+          elsif other.begin_type? && other.children.size == 1
+            other.children.first.equivalent? self
+          else
+            false
+          end
+        else
+          false
+        end
+      end
+
+      protected
+
+      # @return [Boolean] is the node a begin type?
+      def begin_type?
+        [:begin, :kwbegin].include? self.type
+      end
+
+      private
+
+      # @param [Parser::AST::Node] other
+      #
+      # @return [Boolean] is the node's type equivalent to other's?
+      def equivalent_type?(other)
+        other.type == self.type || (other.begin_type? && begin_type?)
+      end
+
+      # @param [Parser::AST::Node] other
+      #
+      # @return [Boolean] are the node's children equivalent to other's?
+      def equivalent_children?(other)
+        return false if other.children.size != self.children.size
+        self.children.each_with_index do |child, index|
+          other_child = other.children[index]
+          if child.respond_to? :equivalent?
+            return false unless child.equivalent?(other_child)
+          else
+            return false unless child == other_child
+          end
+        end
+        true
+      end
     end
 
   end

--- a/test/test_node.rb
+++ b/test/test_node.rb
@@ -1,0 +1,68 @@
+require 'helper'
+
+class TestNode < Minitest::Test
+
+  def setup
+  end
+
+  def test_equivalent
+    ast = s(:begin,
+            s(:send,
+              s(:int, 1), :==,
+              s(:int, 2)))
+
+    equivalent = [
+      ast,
+      s(:send,
+        s(:int, 1), :==,
+        s(:int, 2)),
+      s(:begin,
+        s(:send,
+          s(:int, 1), :==,
+          s(:int, 2))),
+      s(:kwbegin,
+        s(:send,
+          s(:int, 1), :==,
+          s(:int, 2))),
+      s(:send,
+        s(:begin, s(:int, 1)), :==,
+        s(:begin, s(:int, 2))),
+      s(:begin,
+        s(:send,
+          s(:begin, s(:int, 1)), :==,
+          s(:begin, s(:int, 2)))),
+      s(:begin,
+        s(:begin,
+          s(:send,
+            s(:begin, s(:int, 1)), :==,
+            s(:begin, s(:int, 2)))))
+    ]
+
+    equivalent.each do |other_ast|
+      assert ast.equivalent?(other_ast)
+      assert other_ast.equivalent?(ast)
+    end
+
+    not_equivalent = [
+      s(:send,
+        s(:int, 1), :==,
+        s(:int, 3)),
+      s(:begin,
+        s(:begin,
+          s(:send,
+            s(:begin, s(:int, 1)), :==,
+            s(:begin, s(:int, 3)))))
+    ]
+
+    not_equivalent.each do |other_ast|
+      refute ast.equivalent?(other_ast)
+      refute other_ast.equivalent?(ast)
+    end
+  end
+
+  private
+
+  def s(type, *children)
+    Parser::AST::Node.new(type, children)
+  end
+end


### PR DESCRIPTION
After formatting code, I'd like to be able to check whether I've changed the AST or not. If superfluous parens were removed or added, for instance, the new AST is not `==` to the original, but it's still equivalent. I added a method to check for this kind of equivalence.
