### PR TITLE
Diagnostic takes symbolic error reasons instead of messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ API modifications:
  * lexer.rl: correctly handle __END__ with non-whitespace after it (Peter Zotov)
  * lexer.rl: handle \r in middle of a line as mere whitespace (Peter Zotov)
  * ruby{18,19,20,21}.y, builders/default: precisely point to tUMINUS_NUM. (Peter Zotov)
+ * Parser::Diagnostic: now takes and exposes a symbolic reason (Ian MacLeod)
 
 Features implemented:
  * lexer.rl, ruby21.y, builders/default: rational/complex literals. (Peter Zotov)

--- a/lib/parser.rb
+++ b/lib/parser.rb
@@ -114,6 +114,10 @@ module Parser
 
     # Parser warnings
     :useless_else            => 'else without rescue is useless',
+
+    # Rewriter diagnostics
+    :invalid_action          => 'cannot %{action}',
+    :clobbered               => 'clobbered by: %{action}',
   }.freeze
 
   ##

--- a/lib/parser/base.rb
+++ b/lib/parser/base.rb
@@ -235,11 +235,11 @@ module Parser
       when /^[a-z_]/
         # OK
       when /^[A-Z]/
-        diagnostic :error, :argument_const, name_t
+        diagnostic :error, :argument_const, nil, name_t
       end
     end
 
-    def diagnostic(level, kind, location_t, highlights_ts=[])
+    def diagnostic(level, reason, arguments, location_t, highlights_ts=[])
       _, location = location_t
 
       highlights = highlights_ts.map do |token|
@@ -247,9 +247,8 @@ module Parser
         range
       end
 
-      message = ERRORS[kind]
       @diagnostics.process(
-          Diagnostic.new(level, message, location, highlights))
+          Diagnostic.new(level, reason, arguments, location, highlights))
 
       if level == :error
         yyerror
@@ -260,9 +259,8 @@ module Parser
       token_name = token_to_str(error_token_id)
       _, location = error_value
 
-      message = ERRORS[:unexpected_token] % { :token => token_name }
-      @diagnostics.process(
-          Diagnostic.new(:error, message, location))
+      @diagnostics.process(Diagnostic.new(
+          :error, :unexpected_token, { :token => token_name }, location))
     end
   end
 

--- a/lib/parser/diagnostic.rb
+++ b/lib/parser/diagnostic.rb
@@ -7,6 +7,14 @@ module Parser
   #  @see LEVELS
   #  @return [Symbol] diagnostic level
   #
+  # @!attribute [r] reason
+  #  @see Parser::ERRORS
+  #  @return [Symbol] reason for error
+  #
+  # @!attribute [r] arguments
+  #  @see Parser::ERRORS
+  #  @return [Symbol] extended arguments that describe the error
+  #
   # @!attribute [r] message
   #  @return [String] error message
   #
@@ -26,28 +34,42 @@ module Parser
     #
     LEVELS = [:note, :warning, :error, :fatal].freeze
 
-    attr_reader :level, :message
+    attr_reader :level, :reason, :arguments
     attr_reader :location, :highlights
 
     ##
     # @param [Symbol] level
-    # @param [String] message
+    # @param [Symbol] reason
+    # @param [Hash, nil] arguments
     # @param [Parser::Source::Range] location
     # @param [Array<Parser::Source::Range>] highlights
     #
-    def initialize(level, message, location, highlights=[])
+    def initialize(level, reason, arguments, location, highlights=[])
       unless LEVELS.include?(level)
         raise ArgumentError,
               "Diagnostic#level must be one of #{LEVELS.join(', ')}; " \
               "#{level.inspect} provided."
       end
+      raise 'Expected a location' unless location
 
       @level       = level
-      @message     = message.to_s.dup.freeze
+      @reason      = reason
+      @arguments   = arguments.dup.freeze if arguments
       @location    = location
       @highlights  = highlights.dup.freeze
 
       freeze
+    end
+
+    ##
+    # @return [String] the rendered message.
+    #
+    def message
+      message = ERRORS[@reason].to_s.dup
+      message = message % @arguments if defined? @arguments
+      message.freeze
+
+      message
     end
 
     ##
@@ -76,7 +98,7 @@ module Parser
       highlight_line[range] = '^' * @location.size
 
       [
-        "#{@location.to_s}: #{@level}: #{@message}",
+        "#{@location.to_s}: #{@level}: #{message}",
         source_line,
         highlight_line,
       ]

--- a/lib/parser/diagnostic/engine.rb
+++ b/lib/parser/diagnostic/engine.rb
@@ -13,9 +13,10 @@ module Parser
   #  end
   #
   #  engine     = Parser::Diagnostic::Engine.new(consumer)
-  #  diagnostic = Parser::Diagnostic.new(:warning, 'warning!', buffer, 1..2)
+  #  diagnostic = Parser::Diagnostic.new(
+  #      :warning, :unexpected_token, { :token => 'abc' }, buffer, 1..2)
   #
-  #  engine.process(diagnostic) # => "warning!"
+  #  engine.process(diagnostic) # => "unexpected token abc"
   #
   # @api public
   #

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -348,9 +348,9 @@ class Parser::Lexer
     nil
   end
 
-  def diagnostic(type, message, location=range, highlights=[])
+  def diagnostic(type, reason, arguments=nil, location=range, highlights=[])
     @diagnostics.process(
-        Parser::Diagnostic.new(type, message, location, highlights))
+        Parser::Diagnostic.new(type, reason, arguments, location, highlights))
   end
 
   #
@@ -622,7 +622,7 @@ class Parser::Lexer
 
       if codepoint >= 0x110000
         @escape = lambda do
-          diagnostic :error, Parser::ERRORS[:unicode_point_too_large],
+          diagnostic :error, :unicode_point_too_large, nil,
                      range(codepoint_s, codepoint_s + codepoint_str.length)
         end
 
@@ -644,7 +644,7 @@ class Parser::Lexer
 
   action invalid_complex_escape {
     @escape = lambda do
-      diagnostic :error, Parser::ERRORS[:invalid_escape]
+      diagnostic :error, :invalid_escape
     end
   }
 
@@ -684,7 +684,7 @@ class Parser::Lexer
     | 'x' ( c_any - xdigit )
       % {
         @escape = lambda do
-          diagnostic :error, Parser::ERRORS[:invalid_hex_escape],
+          diagnostic :error, :invalid_hex_escape, nil,
                      range(@escape_s - 1, p + 2)
         end
       }
@@ -699,7 +699,7 @@ class Parser::Lexer
           )
       % {
         @escape = lambda do
-          diagnostic :error, Parser::ERRORS[:invalid_unicode_escape],
+          diagnostic :error, :invalid_unicode_escape, nil,
                      range(@escape_s - 1, p)
         end
       }
@@ -713,7 +713,7 @@ class Parser::Lexer
         | xdigit{7,}
         ) % {
           @escape = lambda do
-            diagnostic :fatal, Parser::ERRORS[:unterminated_unicode],
+            diagnostic :fatal, :unterminated_unicode, nil,
                        range(p - 1, p)
           end
         }
@@ -741,8 +741,7 @@ class Parser::Lexer
     | ( c_any - [0-7xuCMc] ) %unescape_char
 
     | c_eof % {
-      diagnostic :fatal, Parser::ERRORS[:escape_eof],
-                 range(p - 1, p)
+      diagnostic :fatal, :escape_eof, nil, range(p - 1, p)
     }
   );
 
@@ -856,7 +855,7 @@ class Parser::Lexer
   # has to handle such case specially.
   action extend_string_eol {
     if @te == pe
-      diagnostic :fatal, Parser::ERRORS[:string_eof],
+      diagnostic :fatal, :string_eof, nil,
                  range(literal.str_s, literal.str_s + 1)
     end
 
@@ -1031,8 +1030,8 @@ class Parser::Lexer
       => {
         unknown_options = tok.scan(/[^imxouesn]/)
         if unknown_options.any?
-          message = Parser::ERRORS[:regexp_options] % { :options => unknown_options.join }
-          diagnostic :error, message
+          diagnostic :error, :regexp_options,
+                     { :options => unknown_options.join }
         end
 
         emit(:tREGEXP_OPT)
@@ -1183,8 +1182,7 @@ class Parser::Lexer
       class_var_v
       => {
         if tok =~ /^@@[0-9]/
-          message = Parser::ERRORS[:cvar_name] % { :name => tok }
-          diagnostic :error, message
+          diagnostic :error, :cvar_name, { :name => tok }
         end
 
         emit(:tCVAR)
@@ -1194,8 +1192,7 @@ class Parser::Lexer
       instance_var_v
       => {
         if tok =~ /^@[0-9]/
-          message = Parser::ERRORS[:ivar_name] % { :name => tok }
-          diagnostic :error, message
+          diagnostic :error, :ivar_name, { :name => tok }
         end
 
         emit(:tIVAR)
@@ -1369,8 +1366,7 @@ class Parser::Lexer
       # Ambiguous regexp literal.
       w_space+ '/'
       => {
-        diagnostic :warning, Parser::ERRORS[:ambiguous_literal],
-                   range(@te - 1, @te)
+        diagnostic :warning, :ambiguous_literal, nil, range(@te - 1, @te)
 
         fhold; fgoto expr_beg;
       };
@@ -1379,8 +1375,7 @@ class Parser::Lexer
       # Ambiguous splat, kwsplat or block-pass.
       w_space+ %{ tm = p } ( '+' | '-' | '*' | '&' | '**' )
       => {
-        message = Parser::ERRORS[:ambiguous_prefix] % { :prefix => tok(tm, @te) }
-        diagnostic :warning, message,
+        diagnostic :warning, :ambiguous_prefix, { :prefix => tok(tm, @te) },
                    range(tm, @te)
 
         p = tm - 1
@@ -1581,8 +1576,7 @@ class Parser::Lexer
 
       '%' c_eof
       => {
-        diagnostic :fatal, Parser::ERRORS[:string_eof],
-                   range(@ts, @ts + 1)
+        diagnostic :fatal, :string_eof, nil, range(@ts, @ts + 1)
       };
 
       # Heredoc start.
@@ -1660,8 +1654,7 @@ class Parser::Lexer
       => {
         escape = { " "  => '\s', "\r" => '\r', "\n" => '\n', "\t" => '\t',
                    "\v" => '\v', "\f" => '\f' }[tok[1]]
-        message = Parser::ERRORS[:invalid_escape_use] % { :escape => escape }
-        diagnostic :warning, message, range
+        diagnostic :warning, :invalid_escape_use, { :escape => escape }, range
 
         p = @ts - 1
         fgoto expr_end;
@@ -1669,8 +1662,7 @@ class Parser::Lexer
 
       '?' c_eof
       => {
-        diagnostic :fatal, Parser::ERRORS[:incomplete_escape],
-                   range(@ts, @ts + 1)
+        diagnostic :fatal, :incomplete_escape, nil, range(@ts, @ts + 1)
       };
 
       # f ?aa : b: Disambiguate with a character literal.
@@ -1914,16 +1906,16 @@ class Parser::Lexer
         digits = tok(@num_digits_s, @num_suffix_s)
 
         if digits.end_with? '_'
-          diagnostic :error, Parser::ERRORS[:trailing_in_number] % { :character => '_' },
+          diagnostic :error, :trailing_in_number, { :character => '_' },
                      range(@te - 1, @te)
         elsif digits.empty? && @num_base == 8 && version?(18)
           # 1.8 did not raise an error on 0o.
           digits = "0"
         elsif digits.empty?
-          diagnostic :error, Parser::ERRORS[:empty_numeric]
+          diagnostic :error, :empty_numeric
         elsif @num_base == 8 && (invalid_idx = digits.index(/[89]/))
           invalid_s = @num_digits_s + invalid_idx
-          diagnostic :error, Parser::ERRORS[:invalid_octal],
+          diagnostic :error, :invalid_octal, nil,
                      range(invalid_s, invalid_s + 1)
         end
 
@@ -1938,14 +1930,14 @@ class Parser::Lexer
 
       flo_frac flo_pow?
       => {
-        diagnostic :error, Parser::ERRORS[:no_dot_digit_literal]
+        diagnostic :error, :no_dot_digit_literal
       };
 
       flo_int [eE]
       => {
         if version?(18, 19, 20)
           diagnostic :error,
-                     Parser::ERRORS[:trailing_in_number] % { :character => tok(@te - 1, @te) },
+                     :trailing_in_number, { :character => tok(@te - 1, @te) },
                      range(@te - 1, @te)
         else
           emit(:tINTEGER, tok(@ts, @te - 1).to_i)
@@ -1957,7 +1949,7 @@ class Parser::Lexer
       => {
         if version?(18, 19, 20)
           diagnostic :error,
-                     Parser::ERRORS[:trailing_in_number] % { :character => tok(@te - 1, @te) },
+                     :trailing_in_number, { :character => tok(@te - 1, @te) },
                      range(@te - 1, @te)
         else
           emit(:tFLOAT, tok(@ts, @te - 1).to_f)
@@ -2078,15 +2070,13 @@ class Parser::Lexer
            fnext expr_value; fbreak; };
 
       '\\' c_line {
-        diagnostic :error, Parser::ERRORS[:bare_backslash],
-                   range(@ts, @ts + 1)
+        diagnostic :error, :bare_backslash, nil, range(@ts, @ts + 1)
         fhold;
       };
 
       c_any
       => {
-        message = Parser::ERRORS[:unexpected] % { :character => tok.inspect[1..-2] }
-        diagnostic :fatal, message
+        diagnostic :fatal, :unexpected, { :character => tok.inspect[1..-2] }
       };
 
       c_eof => do_eof;
@@ -2120,7 +2110,7 @@ class Parser::Lexer
 
       c_line* zlen
       => {
-        diagnostic :fatal, Parser::ERRORS[:embedded_document],
+        diagnostic :fatal, :embedded_document, nil,
                    range(@eq_begin_s, @eq_begin_s + '=begin'.length)
       };
   *|;

--- a/lib/parser/lexer/literal.rb
+++ b/lib/parser/lexer/literal.rb
@@ -44,8 +44,8 @@ module Parser
       delimiter    = coerce_encoding(delimiter)
 
       unless TYPES.include?(str_type)
-        message = ERRORS[:unexpected_percent_str] % { :type => str_type }
-        lexer.send(:diagnostic, :error, message, @lexer.send(:range, str_s, str_s + 2))
+        lexer.send(:diagnostic, :error, :unexpected_percent_str,
+                   { :type => str_type }, @lexer.send(:range, str_s, str_s + 2))
       end
 
       # String type. For :'foo', it is :'

--- a/lib/parser/ruby18.y
+++ b/lib/parser/ruby18.y
@@ -55,7 +55,7 @@ rule
                       ensure_t, ensure_ = val[3]
 
                       if rescue_bodies.empty? && !else_.nil?
-                        diagnostic :warning, :useless_else, else_t
+                        diagnostic :warning, :useless_else, nil, else_t
                       end
 
                       result = @builder.begin_body(val[0],
@@ -108,7 +108,7 @@ rule
                     }
                 | kALIAS tGVAR tNTH_REF
                     {
-                      diagnostic(:error, :nth_ref_alias, val[2])
+                      diagnostic :error, :nth_ref_alias, nil, val[2]
                     }
                 | kUNDEF undef_list
                     {
@@ -143,7 +143,7 @@ rule
                 | klBEGIN tLCURLY compstmt tRCURLY
                     {
                       if in_def?
-                        diagnostic(:error, :begin_in_method, val[0])
+                        diagnostic :error, :begin_in_method, nil, val[0]
                       end
 
                       result = @builder.preexe(val[0], val[1], val[2], val[3])
@@ -468,7 +468,7 @@ rule
 
            cname: tIDENTIFIER
                     {
-                      diagnostic(:error, :module_name_const, val[0])
+                      diagnostic :error, :module_name_const, nil, val[0]
                     }
                 | tCONSTANT
 
@@ -573,11 +573,11 @@ rule
                     }
                 | primary_value tCOLON2 tCONSTANT tOP_ASGN arg
                     {
-                      diagnostic(:error, :dynamic_const, val[2], [ val[3] ])
+                      diagnostic :error, :dynamic_const, nil, val[2], [ val[3] ]
                     }
                 | tCOLON3 tCONSTANT tOP_ASGN arg
                     {
-                      diagnostic(:error, :dynamic_const, val[1], [ val[2] ])
+                      diagnostic :error, :dynamic_const, nil, val[1], [ val[2] ]
                     }
                 | backref tOP_ASGN arg
                     {
@@ -1126,7 +1126,7 @@ rule
                     bodystmt kEND
                     {
                       if in_def?
-                        diagnostic(:error, :class_in_def, val[0])
+                        diagnostic :error, :class_in_def, nil, val[0]
                       end
 
                       lt_t, superclass = val[2]
@@ -1159,7 +1159,7 @@ rule
                     bodystmt kEND
                     {
                       if in_def?
-                        diagnostic(:error, :module_in_def, val[0])
+                        diagnostic :error, :module_in_def, nil, val[0]
                       end
 
                       result = @builder.def_module(val[0], val[1],
@@ -1768,19 +1768,19 @@ xstring_contents: # nothing
 
       f_norm_arg: tCONSTANT
                     {
-                      diagnostic(:error, :argument_const, val[0])
+                      diagnostic :error, :argument_const, nil, val[0]
                     }
                 | tIVAR
                     {
-                      diagnostic(:error, :argument_ivar, val[0])
+                      diagnostic :error, :argument_ivar, nil, val[0]
                     }
                 | tGVAR
                     {
-                      diagnostic(:error, :argument_gvar, val[0])
+                      diagnostic :error, :argument_gvar, nil, val[0]
                     }
                 | tCVAR
                     {
-                      diagnostic(:error, :argument_cvar, val[0])
+                      diagnostic :error, :argument_cvar, nil, val[0]
                     }
                 | tIDENTIFIER
                     {

--- a/lib/parser/ruby19.y
+++ b/lib/parser/ruby19.y
@@ -82,7 +82,7 @@ rule
                       ensure_t, ensure_ = val[3]
 
                       if rescue_bodies.empty? && !else_.nil?
-                        diagnostic :warning, :useless_else, else_t
+                        diagnostic :warning, :useless_else, nil, else_t
                       end
 
                       result = @builder.begin_body(val[0],
@@ -135,7 +135,7 @@ rule
                     }
                 | kALIAS tGVAR tNTH_REF
                     {
-                      diagnostic(:error, :nth_ref_alias, val[2])
+                      diagnostic :error, :nth_ref_alias, nil, val[2]
                     }
                 | kUNDEF undef_list
                     {
@@ -528,7 +528,7 @@ rule
 
            cname: tIDENTIFIER
                     {
-                      diagnostic(:error, :module_name_const, val[0])
+                      diagnostic :error, :module_name_const, nil, val[0]
                     }
                 | tCONSTANT
 
@@ -645,11 +645,11 @@ rule
                     }
                 | primary_value tCOLON2 tCONSTANT tOP_ASGN arg
                     {
-                      diagnostic(:error, :dynamic_const, val[2], [ val[3] ])
+                      diagnostic :error, :dynamic_const, nil, val[2], [ val[3] ]
                     }
                 | tCOLON3 tCONSTANT tOP_ASGN arg
                     {
-                      diagnostic(:error, :dynamic_const, val[1], [ val[2] ])
+                      diagnostic :error, :dynamic_const, nil, val[1], [ val[2] ]
                     }
                 | backref tOP_ASGN arg
                     {
@@ -1088,7 +1088,7 @@ rule
                     bodystmt kEND
                     {
                       if in_def?
-                        diagnostic(:error, :class_in_def, val[0])
+                        diagnostic :error, :class_in_def, nil, val[0]
                       end
 
                       lt_t, superclass = val[2]
@@ -1121,7 +1121,7 @@ rule
                     bodystmt kEND
                     {
                       if in_def?
-                        diagnostic(:error, :module_in_def, val[0])
+                        diagnostic :error, :module_in_def, nil, val[0]
                       end
 
                       result = @builder.def_module(val[0], val[1],
@@ -1952,19 +1952,19 @@ keyword_variable: kNIL
 
        f_bad_arg: tCONSTANT
                     {
-                      diagnostic(:error, :argument_const, val[0])
+                      diagnostic :error, :argument_const, nil, val[0]
                     }
                 | tIVAR
                     {
-                      diagnostic(:error, :argument_ivar, val[0])
+                      diagnostic :error, :argument_ivar, nil, val[0]
                     }
                 | tGVAR
                     {
-                      diagnostic(:error, :argument_gvar, val[0])
+                      diagnostic :error, :argument_gvar, nil, val[0]
                     }
                 | tCVAR
                     {
-                      diagnostic(:error, :argument_cvar, val[0])
+                      diagnostic :error, :argument_cvar, nil, val[0]
                     }
 
       f_norm_arg: f_bad_arg

--- a/lib/parser/ruby20.y
+++ b/lib/parser/ruby20.y
@@ -82,7 +82,7 @@ rule
                       ensure_t, ensure_ = val[3]
 
                       if rescue_bodies.empty? && !else_.nil?
-                        diagnostic :warning, :useless_else, else_t
+                        diagnostic :warning, :useless_else, nil, else_t
                       end
 
                       result = @builder.begin_body(val[0],
@@ -117,7 +117,7 @@ rule
                 | klBEGIN tLCURLY top_compstmt tRCURLY
                     {
                       if in_def?
-                        diagnostic(:error, :begin_in_method, val[0])
+                        diagnostic :error, :begin_in_method, nil, val[0]
                       end
 
                       result = @builder.preexe(val[0], val[1], val[2], val[3])
@@ -145,7 +145,7 @@ rule
                     }
                 | kALIAS tGVAR tNTH_REF
                     {
-                      diagnostic(:error, :nth_ref_alias, val[2])
+                      diagnostic :error, :nth_ref_alias, nil, val[2]
                     }
                 | kUNDEF undef_list
                     {
@@ -535,7 +535,7 @@ rule
 
            cname: tIDENTIFIER
                     {
-                      diagnostic(:error, :module_name_const, val[0])
+                      diagnostic :error, :module_name_const, nil, val[0]
                     }
                 | tCONSTANT
 
@@ -1116,7 +1116,7 @@ rule
                     bodystmt kEND
                     {
                       if in_def?
-                        diagnostic(:error, :class_in_def, val[0])
+                        diagnostic :error, :class_in_def, nil, val[0]
                       end
 
                       lt_t, superclass = val[2]
@@ -1149,7 +1149,7 @@ rule
                     bodystmt kEND
                     {
                       if in_def?
-                        diagnostic(:error, :module_in_def, val[0])
+                        diagnostic :error, :module_in_def, nil, val[0]
                       end
 
                       result = @builder.def_module(val[0], val[1],
@@ -2075,19 +2075,19 @@ keyword_variable: kNIL
 
        f_bad_arg: tCONSTANT
                     {
-                      diagnostic(:error, :argument_const, val[0])
+                      diagnostic :error, :argument_const, nil, val[0]
                     }
                 | tIVAR
                     {
-                      diagnostic(:error, :argument_ivar, val[0])
+                      diagnostic :error, :argument_ivar, nil, val[0]
                     }
                 | tGVAR
                     {
-                      diagnostic(:error, :argument_gvar, val[0])
+                      diagnostic :error, :argument_gvar, nil, val[0]
                     }
                 | tCVAR
                     {
-                      diagnostic(:error, :argument_cvar, val[0])
+                      diagnostic :error, :argument_cvar, nil, val[0]
                     }
 
       f_norm_arg: f_bad_arg

--- a/lib/parser/ruby21.y
+++ b/lib/parser/ruby21.y
@@ -83,7 +83,7 @@ rule
                       ensure_t, ensure_ = val[3]
 
                       if rescue_bodies.empty? && !else_.nil?
-                        diagnostic :warning, :useless_else, else_t
+                        diagnostic :warning, :useless_else, nil, else_t
                       end
 
                       result = @builder.begin_body(val[0],
@@ -117,7 +117,7 @@ rule
    stmt_or_begin: stmt
                 | klBEGIN tLCURLY top_compstmt tRCURLY
                     {
-                      diagnostic(:error, :begin_in_method, val[0])
+                      diagnostic :error, :begin_in_method, nil, val[0]
                     }
 
             stmt: kALIAS fitem
@@ -142,7 +142,7 @@ rule
                     }
                 | kALIAS tGVAR tNTH_REF
                     {
-                      diagnostic(:error, :nth_ref_alias, val[2])
+                      diagnostic :error, :nth_ref_alias, nil, val[2]
                     }
                 | kUNDEF undef_list
                     {
@@ -527,7 +527,7 @@ rule
 
            cname: tIDENTIFIER
                     {
-                      diagnostic(:error, :module_name_const, val[0])
+                      diagnostic :error, :module_name_const, nil, val[0]
                     }
                 | tCONSTANT
 
@@ -1106,7 +1106,7 @@ rule
                     bodystmt kEND
                     {
                       if in_def?
-                        diagnostic(:error, :class_in_def, val[0])
+                        diagnostic :error, :class_in_def, nil, val[0]
                       end
 
                       lt_t, superclass = val[2]
@@ -1139,7 +1139,7 @@ rule
                     bodystmt kEND
                     {
                       if in_def?
-                        diagnostic(:error, :module_in_def, val[0])
+                        diagnostic :error, :module_in_def, nil, val[0]
                       end
 
                       result = @builder.def_module(val[0], val[1],
@@ -2062,19 +2062,19 @@ keyword_variable: kNIL
 
        f_bad_arg: tCONSTANT
                     {
-                      diagnostic(:error, :argument_const, val[0])
+                      diagnostic :error, :argument_const, nil, val[0]
                     }
                 | tIVAR
                     {
-                      diagnostic(:error, :argument_ivar, val[0])
+                      diagnostic :error, :argument_ivar, nil, val[0]
                     }
                 | tGVAR
                     {
-                      diagnostic(:error, :argument_gvar, val[0])
+                      diagnostic :error, :argument_gvar, nil, val[0]
                     }
                 | tCVAR
                     {
-                      diagnostic(:error, :argument_cvar, val[0])
+                      diagnostic :error, :argument_cvar, nil, val[0]
                     }
 
       f_norm_arg: f_bad_arg

--- a/lib/parser/source/rewriter.rb
+++ b/lib/parser/source/rewriter.rb
@@ -118,13 +118,15 @@ module Parser
         if (clobber_action = clobbered?(action.range))
           # cannot replace 3 characters with "foobar"
           diagnostic = Diagnostic.new(:error,
-                                      "cannot #{action}",
+                                      :invalid_action,
+                                      { :action => action },
                                       action.range)
           @diagnostics.process(diagnostic)
 
           # clobbered by: remove 3 characters
           diagnostic = Diagnostic.new(:note,
-                                      "clobbered by: #{clobber_action}",
+                                      :clobbered,
+                                      { :action => clobber_action },
                                       clobber_action.range)
           @diagnostics.process(diagnostic)
 

--- a/test/parse_helper.rb
+++ b/test/parse_helper.rb
@@ -129,10 +129,12 @@ module ParseHelper
 
       emitted_diagnostic = @diagnostics.first
 
-      level, kind, substitutions = diagnostic
-      message = Parser::ERRORS[kind] % substitutions
+      level, reason, arguments = diagnostic
+      message = Parser::ERRORS[reason] % arguments
 
       assert_equal level, emitted_diagnostic.level
+      assert_equal reason, emitted_diagnostic.reason
+      assert_equal arguments, emitted_diagnostic.arguments
       assert_equal message, emitted_diagnostic.message
 
       parse_source_map_descriptions(source_maps) \

--- a/test/test_diagnostic.rb
+++ b/test/test_diagnostic.rb
@@ -11,7 +11,7 @@ class TestDiagnostic < Minitest::Test
 
   def test_verifies_levels
     assert_raises ArgumentError, /level/ do
-      Parser::Diagnostic.new(:foobar, 'foo', @range1)
+      Parser::Diagnostic.new(:foobar, :escape_eof, @range1)
     end
   end
 
@@ -19,8 +19,9 @@ class TestDiagnostic < Minitest::Test
     string     = 'foo'
     highlights = [@range2]
 
-    diag = Parser::Diagnostic.new(:error, string, @range1, highlights)
+    diag = Parser::Diagnostic.new(:error, :escape_eof, @range1, highlights)
     assert diag.frozen?
+    assert diag.arguments.frozen?
     assert diag.message.frozen?
     assert diag.highlights.frozen?
 
@@ -36,10 +37,10 @@ class TestDiagnostic < Minitest::Test
       Parser::Source::Range.new(@buffer, 28, 32)
     ]
 
-    diag  = Parser::Diagnostic.new(:error, 'code far too bad',
+    diag  = Parser::Diagnostic.new(:error, :unexpected, { :character => '+' },
                                    location, highlights)
     assert_equal([
-      '(string):1:27: error: code far too bad',
+      "(string):1:27: error: unexpected `+'",
       'if (this is some bad code + bugs)',
       '                     ~~~~ ^ ~~~~ '
     ], diag.render)


### PR DESCRIPTION
Addresses #115

There's a bit more refactoring here than I expected, though:
- All calls to the various `diagnostic` DSL methods are now parenthesis-less for easier automatic transforms.
- Rather than overloading the signature of each DSL method (to make `reason_info` optional), it seems a lot cleaner & clearer to just pass `nil`.

As best I can tell ([GitHub](https://github.com/search?q=%22Parser%3A%3ADiagnostic.new%28%22&type=Code&ref=searchresults), [Google](https://www.google.com/search?q=%22Parser%3A%3ADiagnostic.new%22&oq=%22Parser%3A%3ADiagnostic.new%22&aqs=chrome..69i57.3403j0j4&sourceid=chrome&espv=210&es_sm=91&ie=UTF-8)), Rubocop is the only downstream user that will be broken by this (and only in their tests). I'll be submitting a follow-up pull request there.
