### PR TITLE
Added rubysl to Gemfile for Travic CI.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 
 platforms :rbx do
   gem 'rubysl', '~> 2.0'
+  gem 'rubinius', '~> 2.0'
 end


### PR DESCRIPTION
I'm submitting a patch to Bundler after discussing with Andre that will
enable Rubinius to designate rubysl as gems that are bundled with the
distribution and Bundler will use that information while resolving.

This patch is a stop-gap measure and I can submit another PR to remove
this once Bundler with that patch is released.
