### PR TITLE
Reduce object allocation in unescape_char lexer action

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -81,6 +81,12 @@ class Parser::Lexer
   %% write data nofinal;
   # %
 
+  ESCAPES = {
+    'a' => "\a", 'b'  => "\b", 'e'  => "\e", 'f' => "\f",
+    'n' => "\n", 'r'  => "\r", 's'  => "\s", 't' => "\t",
+    'v' => "\v", '\\' => "\\"
+  }
+
   attr_reader   :source_buffer
   attr_reader   :encoding
 
@@ -635,11 +641,7 @@ class Parser::Lexer
   }
 
   action unescape_char {
-    @escape = {
-      'a' => "\a", 'b'  => "\b", 'e'  => "\e", 'f' => "\f",
-      'n' => "\n", 'r'  => "\r", 's'  => "\s", 't' => "\t",
-      'v' => "\v", '\\' => "\\"
-    }.fetch(@source[p - 1].chr, @source[p - 1].chr)
+    @escape = ESCAPES.fetch(@source[p - 1].chr, @source[p - 1].chr)
   }
 
   action invalid_complex_escape {


### PR DESCRIPTION
This PR removes some object allocation that happened on all `unescape_char` ragel action calls.

It speeds up parser around 2% for some of my use cases. Its IMHO also cleaner code, even in the absence of a potential speedup.
