### PR TITLE
Add missing source map for match-current-line

### DIFF
--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -1531,6 +1531,7 @@ Format:
 ~~~
 (match-current-line (regexp (str "a") (regopt)))
 "if /a/; end"
+    ~~~ expression
 ~~~
 
 ### Local variable injecting matches

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -958,7 +958,7 @@ module Parser
         end
 
       when :regexp
-        n(:match_current_line, [ cond ], nil)
+        n(:match_current_line, [ cond ], expr_map(cond.loc.expression))
 
       else
         cond

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -3873,7 +3873,8 @@ class TestParser < Minitest::Test
             s(:str, 'wat'),
             s(:regopt))),
         nil, nil),
-      %q{if /wat/; end})
+      %q{if /wat/; end},
+      %q{   ~~~~~ expression (match_current_line)})
   end
 
   # Case matching


### PR DESCRIPTION
Currently `match-current-line` nodes don't have source map information. However Parser itself assumes that every node has source map information:
- `ruby-parse -L -e 'if /foo/; end'` crashes
  - https://github.com/whitequark/parser/blob/v2.1.2/lib/parser/runner/ruby_parse.rb#L32
- `Parser::Source::Comment.associate` with AST including `match-current-line` node crashes
  - https://github.com/whitequark/parser/blob/v2.1.2/lib/parser/source/comment/associator.rb#L106

This PR adds the missing source map information to `match-current-line` node.

On a related note, I've found [another source map missing node](https://github.com/whitequark/parser/blob/v2.1.2/lib/parser/builders/default.rb#L334) but I couldn't figure out how to handle it, so I left it.
