### PR TITLE
Fix a bug where "ambiguous first argument" diagnostic was not emitted

### DIFF
--- a/test/parse_helper.rb
+++ b/test/parse_helper.rb
@@ -161,6 +161,23 @@ module ParseHelper
     end
   end
 
+  def refute_diagnoses(code, versions=ALL_VERSIONS)
+    with_versions(versions) do |version, parser|
+      source_file = Parser::Source::Buffer.new('(refute_diagnoses)')
+      source_file.source = code
+
+      begin
+        parser = parser.parse(source_file)
+      rescue Parser::SyntaxError
+        # do nothing; the diagnostic was reported
+      end
+
+      assert_empty @diagnostics,
+                   "(#{version}) emits no diagnostics, not\n" \
+                   "#{@diagnostics.map(&:render).join("\n")}"
+    end
+  end
+
   SOURCE_MAP_DESCRIPTION_RE =
       /(?x)
        ^(?# $1 skip)            ^(\s*)

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -2578,6 +2578,16 @@ class TestParser < Minitest::Test
         |~~~~~~~~~~~~ expression})
   end
 
+  def test_send_plain_cmd_ambiguous_literal
+    assert_diagnoses(
+      [:warning, :ambiguous_literal],
+      %q{m /foo/},
+      %q{  ^ location})
+
+    refute_diagnoses(
+      %q{m %[1]})
+  end
+
   def test_send_plain_cmd_ambiguous_prefix
     assert_diagnoses(
       [:warning, :ambiguous_prefix, { :prefix => '+' }],


### PR DESCRIPTION
Let me know if this isn't a smart way.
