### PR TITLE
Fix shadow local variable warnings

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -600,19 +600,19 @@ class Parser::Lexer
   flo_pow  = [eE] [+\-]? ( digit+ '_' )* digit+;
 
   int_suffix =
-    ''   % { @num_xfrm = lambda { |value|  emit(:tINTEGER,   value) } }
-  | 'r'  % { @num_xfrm = lambda { |value|  emit(:tRATIONAL,  Rational(value)) } }
-  | 'i'  % { @num_xfrm = lambda { |value|  emit(:tIMAGINARY, Complex(0, value)) } }
-  | 'ri' % { @num_xfrm = lambda { |value|  emit(:tIMAGINARY, Complex(0, Rational(value))) } };
+    ''   % { @num_xfrm = lambda { |chars|  emit(:tINTEGER,   chars) } }
+  | 'r'  % { @num_xfrm = lambda { |chars|  emit(:tRATIONAL,  Rational(chars)) } }
+  | 'i'  % { @num_xfrm = lambda { |chars|  emit(:tIMAGINARY, Complex(0, chars)) } }
+  | 'ri' % { @num_xfrm = lambda { |chars|  emit(:tIMAGINARY, Complex(0, Rational(chars))) } };
 
   flo_pow_suffix =
-    ''   % { @num_xfrm = lambda { |digits| emit(:tFLOAT,     Float(digits)) } }
-  | 'i'  % { @num_xfrm = lambda { |digits| emit(:tIMAGINARY, Complex(0, Float(digits))) } };
+    ''   % { @num_xfrm = lambda { |chars| emit(:tFLOAT,     Float(chars)) } }
+  | 'i'  % { @num_xfrm = lambda { |chars| emit(:tIMAGINARY, Complex(0, Float(chars))) } };
 
   flo_suffix =
     flo_pow_suffix
-  | 'r'  % { @num_xfrm = lambda { |digits| emit(:tRATIONAL,  Rational(digits)) } }
-  | 'ri' % { @num_xfrm = lambda { |digits| emit(:tIMAGINARY, Complex(0, Rational(digits))) } };
+  | 'r'  % { @num_xfrm = lambda { |chars| emit(:tRATIONAL,  Rational(chars)) } }
+  | 'ri' % { @num_xfrm = lambda { |chars| emit(:tIMAGINARY, Complex(0, Rational(chars))) } };
 
   #
   # === ESCAPE SEQUENCE PARSING ===


### PR DESCRIPTION
This branch fixes the following warnings when loading parser:

```
/home/mbj/devel/parser/lib/parser/lexer.rb:14335: warning: shadowing outer local variable - value
/home/mbj/devel/parser/lib/parser/lexer.rb:14373: warning: shadowing outer local variable - value
/home/mbj/devel/parser/lib/parser/lexer.rb:14411: warning: shadowing outer local variable - value
/home/mbj/devel/parser/lib/parser/lexer.rb:17902: warning: shadowing outer local variable - value
/home/mbj/devel/parser/lib/parser/lexer.rb:19748: warning: shadowing outer local variable - value
/home/mbj/devel/parser/lib/parser/lexer.rb:19758: warning: shadowing outer local variable - value
/home/mbj/devel/parser/lib/parser/lexer.rb:19765: warning: shadowing outer local variable - value
/home/mbj/devel/parser/lib/parser/lexer.rb:20327: warning: shadowing outer local variable - value
/home/mbj/devel/parser/lib/parser/lexer.rb:20371: warning: shadowing outer local variable - value
/home/mbj/devel/parser/lib/parser/lexer.rb:20415: warning: shadowing outer local variable - value
/home/mbj/devel/parser/lib/parser/lexer.rb:20459: warning: shadowing outer local variable - value
/home/mbj/devel/parser/lib/parser/lexer.rb:20503: warning: shadowing outer local variable - value
/home/mbj/devel/parser/lib/parser/lexer.rb:20547: warning: shadowing outer local variable - value
/home/mbj/devel/parser/lib/parser/lexer.rb:20613: warning: shadowing outer local variable - value
/home/mbj/devel/parser/lib/parser/lexer.rb:20630: warning: shadowing outer local variable - value
/home/mbj/devel/parser/lib/parser/lexer.rb:20647: warning: shadowing outer local variable - value
```

The warnings can be reproduced via:

```
ruby -I lib -r parser/current -w -e ''
```

There is another (last) warning:

```
/home/mbj/devel/parser/lib/parser/lexer.rb:10616: warning: assigned but unused variable - testEof
```

This one needs to be fixed in the ragel code emitter.
