### PR TITLE
Fix warning in lexer

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -119,6 +119,8 @@ class Parser::Lexer
       @cmdarg_stack = []
     end
 
+    @force_utf32   = false # Set to true by some tests
+
     @source        = nil # source string
     @source_pts    = nil # @source as a codepoint array
     @encoding      = nil # target encoding for output strings


### PR DESCRIPTION
This change fixes a warning about uninitialized ivar in lexer.

```
/home/mbj/devel/parser/lib/parser/lexer.rb:10532: warning: instance variable @force_utf32 not initialized
```
