### PR TITLE
Run tests on Ruby 2.1.0 and ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,14 @@ rvm:
  - 1.9.2
  - 1.9.3
  - 2.0.0
+ - 2.1.0
+ - ruby-head
  - jruby-18mode
  - jruby-19mode
  - rbx-2
+matrix:
+ allow_failures:
+  - rvm: ruby-head
 before_install:
  - gem update bundler
  - bundle --version


### PR DESCRIPTION
The title says it all. I noticed you weren't running the tests on 2.1 and ruby-head when I saw this https://travis-ci.org/bbatsov/rubocop/jobs/24101781
