### PR TITLE
Build against latest Ruby 2.1 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
  - 1.9.2
  - 1.9.3
  - 2.0.0
- - 2.1.0
+ - 2.1
  - ruby-head
  - jruby-18mode
  - jruby-19mode

--- a/test/test_current.rb
+++ b/test/test_current.rb
@@ -10,7 +10,7 @@ class TestCurrent < Minitest::Test
       assert_equal Parser::Ruby19, Parser::CurrentRuby
     when '2.0.0'
       assert_equal Parser::Ruby20, Parser::CurrentRuby
-    when '2.1.0', '2.1.1'
+    when '2.1.0', '2.1.1', '2.1.2'
       assert_equal Parser::Ruby21, Parser::CurrentRuby
     when '2.2.0'
       assert_equal Parser::Ruby22, Parser::CurrentRuby


### PR DESCRIPTION
In contrast to prior versions, we can specify the latest Ruby 2.1 as `2.1` due to the new versioning policy.

https://github.com/travis-ci/travis-ci/issues/2220#issuecomment-42263699
