### PR TITLE
Fix 2.1.3 bug syntax

### DIFF
--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -29,8 +29,8 @@ module Parser
     CurrentRuby = Ruby20
 
   when /^2\.1\./
-    if RUBY_VERSION != '2.1.2'
-      warn_syntax_deviation 'parser/ruby21', '2.1.2'
+    if RUBY_VERSION != '2.1.4'
+      warn_syntax_deviation 'parser/ruby21', '2.1.4'
     end
 
     require 'parser/ruby21'


### PR DESCRIPTION
Release 2.1.4 https://www.ruby-lang.org/en/news/2014/10/27/ruby-2-1-4-released/

Fixed 2.1.3 bug syntax https://bugs.ruby-lang.org/issues/10279

so, Not warn to version 2.1.4 ruby.
