### PR TITLE
Add rational node type to meta

### DIFF
--- a/lib/parser/meta.rb
+++ b/lib/parser/meta.rb
@@ -19,7 +19,7 @@ module Parser
         and not or if when case while until while_post
         until_post for break next redo return resbody
         kwbegin begin retry preexe postexe iflipflop eflipflop
-        shadowarg
+        shadowarg rational
       ).map(&:to_sym).to_set.freeze
 
   end # Meta


### PR DESCRIPTION
Adds the `:rational` node type to `Parser::Meta::NODE_TYPES`.

I wounder if others also got added between 2.1 and 2.2.

Please release another .pre for the 2.2 series.
