### PR TITLE
Update current to 2.1.5

### DIFF
--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -29,8 +29,8 @@ module Parser
     CurrentRuby = Ruby20
 
   when /^2\.1\./
-    if RUBY_VERSION != '2.1.4'
-      warn_syntax_deviation 'parser/ruby21', '2.1.4'
+    if RUBY_VERSION != '2.1.5'
+      warn_syntax_deviation 'parser/ruby21', '2.1.5'
     end
 
     require 'parser/ruby21'


### PR DESCRIPTION
I'm not sure if there are any real changes in the syntax for 2.1.5 -- from the README it doesn't look like it -- and i'd love to see the warning for 2.1.4 disappear :)
