### PR TITLE
use HTTPS URLs in gemspec and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parser
 
-[![Gem Version](https://badge.fury.io/rb/parser.png)](http://badge.fury.io/rb/parser)
+[![Gem Version](https://badge.fury.io/rb/parser.png)](https://badge.fury.io/rb/parser)
 [![Build Status](https://travis-ci.org/whitequark/parser.png?branch=master)](https://travis-ci.org/whitequark/parser)
 [![Code Climate](https://codeclimate.com/github/whitequark/parser.png)](https://codeclimate.com/github/whitequark/parser)
 [![Coverage Status](https://coveralls.io/repos/whitequark/parser/badge.png?branch=master)](https://coveralls.io/r/whitequark/parser)
@@ -41,7 +41,7 @@ Access the AST's source map:
     p Parser::CurrentRuby.parse("2 + 2").loc.selector.source
     # "+"
 
-Traverse the AST: see the documentation for [gem ast](http://whitequark.github.io/ast/).
+Traverse the AST: see the documentation for [gem ast](https://whitequark.github.io/ast/).
 
 Parse a chunk of code and display all diagnostics:
 
@@ -111,14 +111,14 @@ with Parser:
 * Readable, commented source code.
 
 [clang-like]: http://clang.llvm.org/diagnostics.html
-[ast]: http://rubygems.org/gems/ast
-[slop]: http://rubygems.org/gems/slop
+[ast]: https://rubygems.org/gems/ast
+[slop]: https://rubygems.org/gems/slop
 [insane-lexer]: http://whitequark.org/blog/2013/04/01/ruby-hacking-guide-ch-11-finite-state-lexer/
 [rewriting]: http://whitequark.org/blog/2013/04/26/lets-play-with-ruby-code/
 
 ## Documentation
 
-Documentation for parser is available [online](http://whitequark.github.io/parser/).
+Documentation for parser is available [online](https://whitequark.github.io/parser/).
 
 ### Node names
 
@@ -210,7 +210,7 @@ Adding support for the following Ruby MRI features in Parser would needlessly co
 
 Parser has been extensively tested; in particular, it parses almost entire [Rubygems][rg] corpus. For every issue, a breakdown of affected gems is offered.
 
- [rg]: http://rubygems.org
+ [rg]: https://rubygems.org
 
 ### Void value expressions
 
@@ -264,9 +264,9 @@ No known code is affected by this issue.
 ## Acknowledgements
 
 The lexer testsuite is derived from
-[ruby\_parser](http://github.com/seattlerb/ruby_parser).
+[ruby\_parser](https://github.com/seattlerb/ruby_parser).
 
-The Bison parser rules are derived from [Ruby MRI](http://github.com/ruby/ruby)
+The Bison parser rules are derived from [Ruby MRI](https://github.com/ruby/ruby)
 parse.y.
 
 ## Contributing

--- a/parser.gemspec
+++ b/parser.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['whitequark@whitequark.org']
   spec.description   = 'A Ruby parser written in pure Ruby.'
   spec.summary       = spec.description
-  spec.homepage      = 'http://github.com/whitequark/parser'
+  spec.homepage      = 'https://github.com/whitequark/parser'
   spec.license       = 'MIT'
   spec.has_rdoc      = 'yard'
 


### PR DESCRIPTION
This pull request updates the parser gemspec metadata to use an encrypted HTTPS URL for the gem's homepage.

It also updates the README to use encrypted connections to sites that support HTTPS (GitHub, RubyGems, etc)