### PR TITLE
* Changed Comment::Associator#associate API and way of associating comments

### DIFF
--- a/lib/parser/source/comment.rb
+++ b/lib/parser/source/comment.rb
@@ -24,12 +24,13 @@ module Parser
       #
       # @param [Parser::AST::Node] ast
       # @param [Array(Comment)]    comments
-      # @return [Hash(Parser::AST::Node, Array(Comment))]
+      # @param [Boolean] map_using_locations if true the returned map uses node.loc as key
+      # @return [Hash(Parser::AST::Node, Array(Comment))] or [Hash(Parser::Source::Map, Array(Comment))]
       # @see Parser::Source::Comment::Associator
       #
-      def self.associate(ast, comments)
+      def self.associate(ast, comments, map_using_locations = false)
         associator = Associator.new(ast, comments)
-        associator.associate
+        associator.associate(map_using_locations)
       end
 
       ##

--- a/lib/parser/source/comment/associator.rb
+++ b/lib/parser/source/comment/associator.rb
@@ -80,74 +80,93 @@ module Parser
       #
       def associate
         @mapping     = Hash.new { |h, k| h[k] = [] }
-        @comment_num = 0
+        @decorative_comment = {}
+        @comment_num = -1
+        advance_comment
 
         advance_through_directives if @skip_directives
 
         process(nil, @ast)
 
-        @mapping
+        return @mapping, @decorative_comment
       end
 
       private
 
-      def process(upper_node, node)
-        if node.type == :begin
-          prev_node, next_node = nil, upper_node
-        else
+      def process(prev_node, node)
+        if node.type != :begin
           while current_comment_between?(prev_node, node)
-            associate_and_advance_comment(node)
+            associate_and_advance_comment(prev_node, node)
           end
-
-          prev_node, next_node = nil, upper_node
-        end
-
-        node.children.each do |child|
-          if child.is_a?(AST::Node) && child.loc && child.loc.expression
-            prev_node, next_node = next_node, child
-
-            process(prev_node, child)
+          if current_comment_decorates?(node)
+            associate_and_advance_comment(node, nil)
           end
         end
-      end
 
-      def current_comment
-        @comments[@comment_num]
+        if node.children.length > 0
+          node.children.each do |child|
+            if child.is_a?(AST::Node) && child.loc && child.loc.expression
+              process(prev_node, child)
+              prev_node = child
+            end
+          end
+          while current_comment_at_end?(node, nil)
+            associate_and_advance_comment(prev_node, nil)
+          end
+        end
       end
 
       def advance_comment
         @comment_num += 1
+        @current_comment = @comments[@comment_num]
       end
 
       def current_comment_between?(prev_node, next_node)
-        return false if current_comment.nil?
+        return false if !@current_comment
+        comment_loc = @current_comment.location.expression
 
-        comment_loc = current_comment.location.expression
-        next_loc    = next_node.location.expression
-
-        if prev_node.nil?
-          comment_loc.end_pos <= next_loc.begin_pos
-        else
-          prev_loc  = prev_node.location.expression
-
-          comment_loc.begin_pos >= prev_loc.end_pos &&
-                comment_loc.end_pos <= next_loc.begin_pos
+        if next_node
+          next_loc = next_node.location.expression
+          return false if comment_loc.end_pos > next_loc.begin_pos
         end
+        if prev_node
+          prev_loc = prev_node.location.expression
+          return false if comment_loc.begin_pos < prev_loc.end_pos
+        end
+        return true
       end
 
-      def associate_and_advance_comment(node)
-        @mapping[node] << current_comment
+      def current_comment_decorates?(prev_node)
+        return false if !@current_comment
+        return @current_comment.location.line == prev_node.location.line
+      end
+
+      def current_comment_at_end?(parent, last_node)
+        return false if !@current_comment
+        comment_loc = @current_comment.location.expression
+        parent_loc = parent.location.expression
+        return comment_loc.end_pos <= parent_loc.end_pos
+      end
+
+      def associate_and_advance_comment(prev_node, node)
+        if prev_node and node
+          n = (@current_comment.location.line == prev_node.location.line) ? prev_node : node
+        else
+          n = prev_node ? prev_node : node
+        end
+        @mapping[n.location] << @current_comment
+        @decorative_comment[@current_comment] = (n == prev_node)
         advance_comment
       end
 
       def advance_through_directives
         # Skip shebang.
-        if current_comment && current_comment.text =~ /^#!/
+        if @current_comment && @current_comment.text =~ /^#!/
           advance_comment
         end
 
         # Skip encoding line.
-        if current_comment && current_comment.text =~ Buffer::ENCODING_RE
+        if @current_comment && @current_comment.text =~ Buffer::ENCODING_RE
           advance_comment
         end
       end

--- a/lib/parser/source/comment/associator.rb
+++ b/lib/parser/source/comment/associator.rb
@@ -51,7 +51,6 @@ module Parser
         @comments    = comments
 
         @skip_directives = true
-        @map_using_node = true
       end
 
       ##
@@ -80,15 +79,8 @@ module Parser
       # @return [Hash(Parser::AST::Node, Array(Parser::Source::Comment))]
       #
       def associate
-        @mapping     = Hash.new { |h, k| h[k] = [] }
-        @comment_num = -1
-        advance_comment
-
-        advance_through_directives if @skip_directives
-
-        process(nil, @ast)
-
-        return @mapping
+        @map_using_node = true
+        associate_comments
       end
 
       # #associate is broken for nodes which have the same content.
@@ -97,10 +89,22 @@ module Parser
       # node.location as a key to retrieve the comments for this node.
       def associate_locations
         @map_using_node = false
-        return associate
+        associate_comments
       end
 
       private
+
+      def associate_comments
+        @mapping     = Hash.new { |h, k| h[k] = [] }
+        @comment_num = -1
+        advance_comment
+
+        advance_through_directives if @skip_directives
+
+        process(nil, @ast)
+
+        @mapping
+      end
 
       def process(prev_node, node)
         if node.type != :begin
@@ -142,28 +146,28 @@ module Parser
           prev_loc = prev_node.location.expression
           return false if comment_loc.begin_pos < prev_loc.end_pos
         end
-        return true
+        true
       end
 
       def current_comment_decorates?(prev_node)
         return false if !@current_comment
-        return @current_comment.location.line == prev_node.location.line
+        @current_comment.location.line == prev_node.location.line
       end
 
       def current_comment_at_end?(parent, last_node)
         return false if !@current_comment
         comment_loc = @current_comment.location.expression
         parent_loc = parent.location.expression
-        return comment_loc.end_pos <= parent_loc.end_pos
+        comment_loc.end_pos <= parent_loc.end_pos
       end
 
       def associate_and_advance_comment(prev_node, node)
-        if prev_node and node
-          n = (@current_comment.location.line == prev_node.location.line) ? prev_node : node
+        if prev_node && node
+          owner_node = (@current_comment.location.line == prev_node.location.line) ? prev_node : node
         else
-          n = prev_node ? prev_node : node
+          owner_node = prev_node ? prev_node : node
         end
-        key = @map_using_node ? n : n.location
+        key = @map_using_node ? owner_node : owner_node.location
         @mapping[key] << @current_comment
         advance_comment
       end

--- a/test/test_source_comment_associator.rb
+++ b/test/test_source_comment_associator.rb
@@ -9,11 +9,7 @@ class TestSourceCommentAssociator < Minitest::Test
     buffer.source = code
 
     ast, comments = parser.parse_with_comments(buffer)
-    if map_using_location
-      associations  = Parser::Source::Comment::Associator.new(ast, comments).associate_locations
-    else
-      associations  = Parser::Source::Comment.associate(ast, comments)
-    end
+    associations  = Parser::Source::Comment.associate(ast, comments, map_using_location)
 
     [ ast, associations ]
   end
@@ -188,6 +184,8 @@ end
     END
 
     assert_equal 1, associations.size
+    assert_equal ['# foo'],
+                 associations[ast].map(&:text)
   end
 
   def test_associate___ENCODING__

--- a/test/test_source_comment_associator.rb
+++ b/test/test_source_comment_associator.rb
@@ -1,17 +1,25 @@
-require 'helper'
+require './helper'
 require 'parser/ruby18'
 
 class TestSourceCommentAssociator < Minitest::Test
-  def associate(code)
+  def associate(code, map_using_location=false)
     parser = Parser::Ruby18.new
 
     buffer = Parser::Source::Buffer.new('(comments)')
     buffer.source = code
 
     ast, comments = parser.parse_with_comments(buffer)
-    associations  = Parser::Source::Comment.associate(ast, comments)
+    if map_using_location
+      associations  = Parser::Source::Comment::Associator.new(ast, comments).associate_locations
+    else
+      associations  = Parser::Source::Comment.associate(ast, comments)
+    end
 
     [ ast, associations ]
+  end
+
+  def associate_locations(code)
+    associate(code, true)
   end
 
   def test_associate
@@ -36,9 +44,9 @@ end
 
     klass_node         = ast
     attr_accessor_node = ast.children[2].children[0]
-    method_node        = ast.children[2].children[1]
-    expr_node          = method_node.children[2]
-    intermediate_node  = expr_node.children[2]
+    method_node        = ast.children[2].children[1] # def bar
+    expr_node          = method_node.children[2] # 1 + 2
+    intermediate_node  = expr_node.children[0] # 1
 
     assert_equal 5, associations.size
     assert_equal ['# Class comment', '# another class comment'],
@@ -47,10 +55,98 @@ end
                  associations[attr_accessor_node].map(&:text)
     assert_equal ['# method comment'],
                  associations[method_node].map(&:text)
-    assert_equal ['# expr comment'],
+    assert_equal ['# expr comment', "# stray comment"],
                  associations[expr_node].map(&:text)
     assert_equal ['# intermediate comment'],
                  associations[intermediate_node].map(&:text)
+  end
+
+  # The bug below is fixed by using associate_locations
+  def test_associate_dupe_statement
+    ast, associations = associate(<<-END)
+class Foo
+  def bar
+    f1 # comment on 1st call to f1
+    f2
+    f1 # comment on 2nd call to f1
+  end
+end
+    END
+
+    klass_node         = ast
+    method_node        = ast.children[2]
+    body               = method_node.children[2]
+    f1_1_node          = body.children[0]
+    f1_2_node          = body.children[2]
+
+    assert_equal 1, associations.size
+    assert_equal ['# comment on 1st call to f1', '# comment on 2nd call to f1'],
+                 associations[f1_1_node].map(&:text)
+    assert_equal ['# comment on 1st call to f1', '# comment on 2nd call to f1'],
+                 associations[f1_2_node].map(&:text)
+  end
+
+  def test_associate_locations
+    ast, associations = associate_locations(<<-END)
+#!/usr/bin/env ruby
+# coding: utf-8
+# Class comment
+# another class comment
+class Foo
+  # attr_accessor comment
+  attr_accessor :foo
+
+  # method comment
+  def bar
+    # expr comment
+    1 + # intermediate comment
+      2
+    # stray comment
+  end
+end
+    END
+
+    klass_node         = ast
+    attr_accessor_node = ast.children[2].children[0]
+    method_node        = ast.children[2].children[1]
+    expr_node          = method_node.children[2]
+    intermediate_node  = expr_node.children[0]
+
+    assert_equal 5, associations.size
+    assert_equal ['# Class comment', '# another class comment'],
+                 associations[klass_node.loc].map(&:text)
+    assert_equal ['# attr_accessor comment'],
+                 associations[attr_accessor_node.loc].map(&:text)
+    assert_equal ['# method comment'],
+                 associations[method_node.loc].map(&:text)
+    assert_equal ['# expr comment', '# stray comment'],
+                 associations[expr_node.loc].map(&:text)
+    assert_equal ['# intermediate comment'],
+                 associations[intermediate_node.loc].map(&:text)
+  end
+
+  def test_associate_locations_dupe_statement
+    ast, associations = associate_locations(<<-END)
+class Foo
+  def bar
+    f1 # comment on 1st call to f1
+    f2
+    f1 # comment on 2nd call to f1
+  end
+end
+    END
+
+    klass_node         = ast
+    method_node        = ast.children[2]
+    body               = method_node.children[2]
+    f1_1_node          = body.children[0]
+    f1_2_node          = body.children[2]
+
+    assert_equal 2, associations.size
+    assert_equal ['# comment on 1st call to f1'],
+                 associations[f1_1_node.loc].map(&:text)
+    assert_equal ['# comment on 2nd call to f1'],
+                 associations[f1_2_node.loc].map(&:text)
   end
 
   def test_associate_no_body
@@ -91,7 +187,7 @@ def foo
 end
     END
 
-    assert_equal 0, associations.size
+    assert_equal 1, associations.size
   end
 
   def test_associate___ENCODING__

--- a/test/test_source_comment_associator.rb
+++ b/test/test_source_comment_associator.rb
@@ -1,4 +1,4 @@
-require './helper'
+require 'helper'
 require 'parser/ruby18'
 
 class TestSourceCommentAssociator < Minitest::Test


### PR DESCRIPTION
This PR makes the "Comment Associator" behave differently to solve 2 issues and allow callers to make the difference between "heading" comments, which come before a piece of code, and "decorative" comments which come right after the code they are associated to.

Changes:
- associator#associate now returns 2 hashes: @commentMap and @decorative_comment
- @commentMap corresponds to the hash which the function used to return, but with a different key to fix the issue of "merged" comments for similar nodes (issue #184). The key is now the node's location instead of the node itself (the value is an array of comments, this did not change).
- The new returned hash @decorative_comment uses the comment as key. The value is a boolean which is true if the comment is "decorative" (false for heading comments).

NB: Most of the time, a decorative comment is on the same line as the node it is associated to. The exception is for trailing comments in a file, which are after the last function of a file. The code in this PR will associate these comments correctly to the last function. This fixes issue #185.

Fixes https://github.com/whitequark/parser/issues/184
Fixes https://github.com/whitequark/parser/issues/185

Example of use:
```code:ruby
  # Parse the source and comments
  ast, comments = Parser::CurrentRuby.new.parse_with_comments(srcFile)
  associator = Parser::Source::Comment::Associator.new(ast, comments)
  @commentMap, @decorative_comment = associator.associate
  ...

  # Returns comments of a node, ready for JavaScript format (a paragraph of heading comments, and a line of decorative comments)
  def getComments(node)
    comments = @commentMap[node.location] # used to be comments = @commentMap[node]
    parag = ""
    deco = ""
    comments.each do |c|
      txt = c.text[1..-1] # get rid of leading "#"
      txt = txt[1..-1] if txt[0]==" " # get rid of first space if any
      if @decorative_comment[c]
        deco << " // #{txt}"
      else
        parag << "// #{txt}\n"
      end
    end
    return parag, deco
  end
```