### PR TITLE
Fix the warning for Ruby 2.1 (latest is 2.1.6)

### DIFF
--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -33,8 +33,8 @@ module Parser
     CurrentRuby = Ruby20
 
   when /^2\.1\./
-    if RUBY_VERSION != '2.1.7'
-      warn_syntax_deviation 'parser/ruby21', '2.1.7'
+    if RUBY_VERSION != '2.1.6'
+      warn_syntax_deviation 'parser/ruby21', '2.1.6'
     end
 
     require 'parser/ruby21'


### PR DESCRIPTION
Hi,

It seems like https://github.com/whitequark/parser/commit/e93b9080f58fe57c217b0c3f16cb61ed1ad45d73 has incorrectly bumped the latest 2.1 Ruby check to 2.1.7. 

Since I can't find any reference to such minor I reverted it back to 2.1.6.