### PR TITLE
* lexer.rl: reduce .class method call on #advance

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -270,20 +270,21 @@ class Parser::Lexer
     end
 
     # Ugly, but dependent on Ragel output. Consider refactoring it somehow.
-    _lex_trans_keys         = self.class.send :_lex_trans_keys
-    _lex_key_spans          = self.class.send :_lex_key_spans
-    _lex_index_offsets      = self.class.send :_lex_index_offsets
-    _lex_indicies           = self.class.send :_lex_indicies
-    _lex_trans_targs        = self.class.send :_lex_trans_targs
-    _lex_trans_actions      = self.class.send :_lex_trans_actions
-    _lex_to_state_actions   = self.class.send :_lex_to_state_actions
-    _lex_from_state_actions = self.class.send :_lex_from_state_actions
-    _lex_eof_trans          = self.class.send :_lex_eof_trans
+    klass = self.class
+    _lex_trans_keys         = klass.send :_lex_trans_keys
+    _lex_key_spans          = klass.send :_lex_key_spans
+    _lex_index_offsets      = klass.send :_lex_index_offsets
+    _lex_indicies           = klass.send :_lex_indicies
+    _lex_trans_targs        = klass.send :_lex_trans_targs
+    _lex_trans_actions      = klass.send :_lex_trans_actions
+    _lex_to_state_actions   = klass.send :_lex_to_state_actions
+    _lex_from_state_actions = klass.send :_lex_from_state_actions
+    _lex_eof_trans          = klass.send :_lex_eof_trans
 
     p, pe, eof = @p, @source.length + 1, @source.length + 1
 
-    @command_state = (@cs == self.class.lex_en_expr_value ||
-                      @cs == self.class.lex_en_line_begin)
+    @command_state = (@cs == klass.lex_en_expr_value ||
+                      @cs == klass.lex_en_line_begin)
 
     %% write exec;
     # %
@@ -292,7 +293,7 @@ class Parser::Lexer
 
     if @token_queue.any?
       @token_queue.shift
-    elsif @cs == self.class.lex_error
+    elsif @cs == klass.lex_error
       [ false, [ '$error', range(p - 1, p) ] ]
     else
       eof = @source.length


### PR DESCRIPTION
I try to profile using ruby-prof followings:

```
$ time ruby-prof -f before ./bin/ruby-parse test/**/*.rb
$ time ruby-prof -f after ./bin/ruby-parse test/**/*.rb
$ diff -W 170 -y before after | less
```

This patch reduce Kernel#class method call on Parser::Lexcer#advance.
Method call changes from 446708 calls to 71174 calls.
Total time changes from 0.401 ms to 0.22 ms.
That reduce Parser::Lexer#advance total time 36.697 to 36.520

Result detail is followings:

```
Measure Mode: wall_time                                                                 Measure Mode: wall_time
Thread ID: 2225978120                                                                   Thread ID: 2225978120
Fiber ID: 2229069920                                                                    Fiber ID: 2229069920
Total: 38.818560                                                                    |   Total: 38.640807
Sort by: self_time                                                                      Sort by: self_time

 %self      total      self      wait     child     calls  name                          %self      total      self      wait     child     calls  name
 43.53     36.697    16.896     0.000    19.801    41421   Parser::Lexer#advance    |    43.84     36.520    16.941     0.000    19.579    41421   Parser::Lexer#advance
  8.54      3.317     3.317     0.000     0.000  1270749   Fixnum#==                |     8.59      3.319     3.319     0.000     0.000  1270749   Fixnum#==
  7.44      2.890     2.890     0.000     0.000  2415744   Fixnum#<=                |     7.53      2.910     2.910     0.000     0.000  2415744   Fixnum#<=
  6.90      2.678     2.678     0.000     0.000   142618   String#[]                |     7.01      2.707     2.707     0.000     0.000   142618   String#[]
  6.52      2.529     2.529     0.000     0.000  4274010   Array#[]                 |     6.48      2.503     2.503     0.000     0.000  4274010   Array#[]
  6.00      2.329     2.329     0.000     0.000  1432497   Fixnum#+                 |     6.06      2.343     2.343     0.000     0.000  1432497   Fixnum#+
  4.82      3.519     1.871     0.000     1.649   690326   BasicObject#!=           |     4.86      3.533     1.879     0.000     1.654   690326   BasicObject#!=
  1.59      0.616     0.616     0.000     0.000    76473   String#length            |     1.61      0.622     0.622     0.000     0.000    76473   String#length
  1.03      0.401     0.401     0.000     0.000   446708   Kernel#class             |     0.79      0.305     0.305     0.000     0.000   382750   Fixnum#-
  0.77      0.298     0.298     0.000     0.000   382750   Fixnum#-                 |     0.67      0.260     0.260     0.000     0.000   133957   String#encode
  0.69      0.268     0.268     0.000     0.000   133957   String#encode            |     0.60      0.231     0.231     0.000     0.000   189474   BasicObject#!
  0.61      0.237     0.237     0.000     0.000   189474   BasicObject#!            |     0.60      0.231     0.231     0.000     0.000    41422   Array#shift
  0.60      0.232     0.232     0.000     0.000    41422   Array#shift              |     0.56      0.215     0.215     0.000     0.000    82221  *Array#any?
  0.54      0.212     0.211     0.000     0.000    82221  *Array#any?               |     0.52      0.515     0.202     0.000     0.313       24   Kernel#p
  0.54      0.513     0.211     0.000     0.302       24   Kernel#p                 |     0.46      0.823     0.177     0.000     0.647   103323  *Class#new
  0.46      0.824     0.178     0.000     0.645   103323  *Class#new                |     0.40      0.286     0.155     0.000     0.131   132825   Parser::Lexer#literal
  0.41      0.290     0.158     0.000     0.132   132825   Parser::Lexer#literal    |     0.40     37.924     0.154     0.000    37.770       24   Racc::Parser#_racc_do_p
  0.39     38.103     0.153     0.000    37.950       24   Racc::Parser#_racc_do_p  <
  0.34      0.133     0.133     0.000     0.000   134037   Array#last                     0.34      0.133     0.133     0.000     0.000   134037   Array#last
  0.32      0.123     0.123     0.000     0.000   379179   Fixnum#<<                |     0.33      0.126     0.126     0.000     0.000   379179   Fixnum#<<
  0.28     36.803     0.107     0.000    36.697    41421   Parser::Base#next_token  |     0.29     36.633     0.113     0.000    36.520    41421   Parser::Base#next_token
  0.27      0.104     0.104     0.000     0.000   120471   Kernel#freeze            |     0.27      0.105     0.105     0.000     0.000   120471   Kernel#freeze
  0.26      0.099     0.099     0.000     0.000    88830   Kernel#respond_to?       |     0.26      0.101     0.101     0.000     0.000    88830   Kernel#respond_to?
  0.24      0.091     0.091     0.000     0.000   364002   Fixnum#>                 |     0.25      0.342     0.098     0.000     0.244    50749   Parser::Lexer::Literal#
  0.23      0.474     0.090     0.000     0.384    43808   Parser::Lexer::Literal#  |     0.24      0.094     0.094     0.000     0.000   364002   Fixnum#>
  0.23      0.957     0.089     0.000     0.868    46542   Parser::Lexer#tok        |     0.23      0.954     0.088     0.000     0.866    46542   Parser::Lexer#tok
  0.20      0.198     0.079     0.000     0.120    53605  *Kernel#dup               |     0.23      0.212     0.088     0.000     0.124    53605  *Kernel#dup
  0.20      0.123     0.078     0.000     0.045    57938   Parser::Source::Range#i  |     0.22      0.501     0.085     0.000     0.416    43808   Parser::Lexer::Literal#
  0.19      0.305     0.075     0.000     0.229    50749   Parser::Lexer::Literal#  |     0.22      0.084     0.084     0.000     0.000    71174   Kernel#class
  0.19      0.338     0.074     0.000     0.264    41397   Parser::Lexer#emit       |     0.20      0.125     0.078     0.000     0.047    57938   Parser::Source::Range#i
  0.18      0.119     0.071     0.000     0.048    53605   Kernel#initialize_dup    |     0.19      0.344     0.075     0.000     0.269    41397   Parser::Lexer#emit
  0.16      0.362     0.061     0.000     0.301    21194   AST::Node#initialize     |     0.19      0.124     0.072     0.000     0.052    53605   Kernel#initialize_dup
  0.15      0.086     0.058     0.000     0.027    41780   Parser::Lexer::Literal#  |     0.17      0.092     0.065     0.000     0.028    41780   Parser::Lexer::Literal#
  0.15      0.228     0.056     0.000     0.171    41425   Parser::Lexer#range      |     0.15      0.360     0.060     0.000     0.301    21194   AST::Node#initialize
  0.13      0.069     0.052     0.000     0.017    57423   Parser::Builders::Defau  |     0.15      0.233     0.058     0.000     0.175    41425   Parser::Lexer#range
                                                                                    >     0.13      0.067     0.050     0.000     0.017    57423   Parser::Builders::Defau
  0.13      0.049     0.049     0.000     0.000    56088   String#force_encoding          0.13      0.049     0.049     0.000     0.000    56088   String#force_encoding
  0.12      0.048     0.048     0.000     0.000    61484   Kernel#hash              |     0.13      0.049     0.049     0.000     0.000    61484   Kernel#hash
  0.12      0.121     0.047     0.000     0.074    42388  *Array#hash               |     0.12      0.048     0.048     0.000     0.000    50754   String#initialize_copy
                                                                                    >     0.12      0.122     0.047     0.000     0.075    42388  *Array#hash
```

```
$ ruby -v
ruby 2.3.0preview1 (2015-11-11 trunk 52539) [x86_64-darwin14]
```

