### PR TITLE
* lexer.rl: reduce Stirng.length method call on #advance

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -280,7 +280,8 @@ class Parser::Lexer
     _lex_from_state_actions = self.class.send :_lex_from_state_actions
     _lex_eof_trans          = self.class.send :_lex_eof_trans
 
-    p, pe, eof = @p, @source.length + 1, @source.length + 1
+    pe = @source.length + 1
+    p, eof = @p, pe
 
     @command_state = (@cs == self.class.lex_en_expr_value ||
                       @cs == self.class.lex_en_line_begin)


### PR DESCRIPTION
I try to profile using ruby-prof followings:

```
$ time ruby-prof -f before ./bin/ruby-parse test/**/*.rb
$ time ruby-prof -f after ./bin/ruby-parse test/**/*.rb
$ diff -W 170 -y before after | less
```

This patch reduce String#length method call on Parser::Lexcer#advance.
Method call changes from 76473 calls to 38898 calls.
Total time changes from 0.616 ms to 0.303 ms.

Result detail is followings:

```
Measure Mode: wall_time                                                                 Measure Mode: wall_time
Thread ID: 2225978120                                                               |   Thread ID: 2280504080
Fiber ID: 2229069920                                                                |   Fiber ID: 2283604480
Total: 38.818560                                                                    |   Total: 37.913590
Sort by: self_time                                                                      Sort by: self_time

 %self      total      self      wait     child     calls  name                          %self      total      self      wait     child     calls  name
 43.53     36.697    16.896     0.000    19.801    41421   Parser::Lexer#advance    |    44.00     35.828    16.683     0.000    19.145    41421   Parser::Lexer#advance
  8.54      3.317     3.317     0.000     0.000  1270749   Fixnum#==                |     8.64      3.275     3.275     0.000     0.000  1270749   Fixnum#==
  7.44      2.890     2.890     0.000     0.000  2415744   Fixnum#<=                |     7.45      2.825     2.825     0.000     0.000  2415744   Fixnum#<=
  6.90      2.678     2.678     0.000     0.000   142618   String#[]                |     7.01      2.658     2.658     0.000     0.000   142618   String#[]
  6.52      2.529     2.529     0.000     0.000  4274010   Array#[]                 |     6.46      2.447     2.447     0.000     0.000  4274010   Array#[]
  6.00      2.329     2.329     0.000     0.000  1432497   Fixnum#+                 |     6.04      2.291     2.291     0.000     0.000  1394922   Fixnum#+
  4.82      3.519     1.871     0.000     1.649   690326   BasicObject#!=           |     4.86      3.472     1.844     0.000     1.628   690326   BasicObject#!=
  1.59      0.616     0.616     0.000     0.000    76473   String#length            |     1.05      0.400     0.400     0.000     0.000   446708   Kernel#class
  1.03      0.401     0.401     0.000     0.000   446708   Kernel#class             |     0.80      0.303     0.303     0.000     0.000    38898   String#length
  0.77      0.298     0.298     0.000     0.000   382750   Fixnum#-                 |     0.77      0.293     0.293     0.000     0.000   382750   Fixnum#-
  0.69      0.268     0.268     0.000     0.000   133957   String#encode            |     0.69      0.262     0.262     0.000     0.000   133957   String#encode
  0.61      0.237     0.237     0.000     0.000   189474   BasicObject#!            |     0.61      0.232     0.232     0.000     0.000    41422   Array#shift
  0.60      0.232     0.232     0.000     0.000    41422   Array#shift              |     0.58      0.221     0.221     0.000     0.000   189474   BasicObject#!
  0.54      0.212     0.211     0.000     0.000    82221  *Array#any?               |     0.55      0.209     0.209     0.000     0.000    82221  *Array#any?
  0.54      0.513     0.211     0.000     0.302       24   Kernel#p                 |     0.54      0.498     0.204     0.000     0.294       24   Kernel#p
  0.46      0.824     0.178     0.000     0.645   103323  *Class#new                |     0.46      0.807     0.173     0.000     0.634   103323  *Class#new
  0.41      0.290     0.158     0.000     0.132   132825   Parser::Lexer#literal    |     0.37     37.208     0.141     0.000    37.066       24   Racc::Parser#_racc_do_p
  0.39     38.103     0.153     0.000    37.950       24   Racc::Parser#_racc_do_p  |     0.35      0.260     0.132     0.000     0.127   132825   Parser::Lexer#literal
  0.34      0.133     0.133     0.000     0.000   134037   Array#last               |     0.34      0.129     0.129     0.000     0.000   134037   Array#last
  0.32      0.123     0.123     0.000     0.000   379179   Fixnum#<<                      0.32      0.123     0.123     0.000     0.000   379179   Fixnum#<<
  0.28     36.803     0.107     0.000    36.697    41421   Parser::Base#next_token  |     0.29     35.936     0.108     0.000    35.828    41421   Parser::Base#next_token
  0.27      0.104     0.104     0.000     0.000   120471   Kernel#freeze            |     0.28      0.105     0.105     0.000     0.000   120471   Kernel#freeze
  0.26      0.099     0.099     0.000     0.000    88830   Kernel#respond_to?             0.26      0.099     0.099     0.000     0.000    88830   Kernel#respond_to?
  0.24      0.091     0.091     0.000     0.000   364002   Fixnum#>                 |     0.24      0.090     0.090     0.000     0.000   364002   Fixnum#>
```

```
$ ruby -v
ruby 2.3.0preview1 (2015-11-11 trunk 52539) [x86_64-darwin14]
```
