### PR TITLE
* lexer.rl: reduce respond_to?(:encode) method call on #advance

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -105,6 +105,8 @@ class Parser::Lexer
     @tokens     = nil
     @comments   = nil
 
+    @has_encode = ''.respond_to?(:encode)
+
     reset
   end
 
@@ -191,7 +193,7 @@ class Parser::Lexer
         @source_pts = @source.unpack('C*')
       end
 
-      if (@source_pts.size > 1_000_000 && @source.respond_to?(:encode)) ||
+      if (@source_pts.size > 1_000_000 && @has_encode) ||
          @force_utf32
         # A heuristic: if the buffer is larger than 1M, then
         # store it in UTF-32 and convert the tokens as they're
@@ -829,12 +831,12 @@ class Parser::Lexer
 
   action extend_string {
     string = @source[@ts...@te]
-    string = string.encode(@encoding) if string.respond_to?(:encode)
+    string = string.encode(@encoding) if @has_encode
 
     # tLABEL_END is only possible in non-cond context on >= 2.2
     if @version >= 22 && !@cond.active?
       lookahead = @source[@te...@te+2]
-      lookahead = lookahead.encode(@encoding) if lookahead.respond_to?(:encode)
+      lookahead = lookahead.encode(@encoding) if @has_encode
     end
 
     if !literal.heredoc? && (token = literal.nest_and_try_closing(string, @ts, @te, lookahead))


### PR DESCRIPTION
I try to profile using ruby-prof followings:

```
$ time ruby-prof -f before ./bin/ruby-parse test/**/*.rb
$ time ruby-prof -f after ./bin/ruby-parse test/**/*.rb
$ diff -W 170 -y before after | less
```

This patch reduce respond_to?(:encode) method call on Parser::Lexcer#advance.
String#encode can detect statically.

Method call changes from 88830 calls to 1417 calls.
Total time changes from 0.099 ms to 0.002 ms.

Result detail is followings:

```
Measure Mode: wall_time                                                                 Measure Mode: wall_time
Thread ID: 2225978120                                                               |   Thread ID: 2196618000
Fiber ID: 2229069920                                                                |   Fiber ID: 2199718400
Total: 38.818560                                                                    |   Total: 39.810661
Sort by: self_time                                                                      Sort by: self_time

 %self      total      self      wait     child     calls  name                          %self      total      self      wait     child     calls  name
 43.53     36.697    16.896     0.000    19.801    41421   Parser::Lexer#advance    |    43.55     37.591    17.338     0.000    20.253    41421   Parser::Lexer#advance
  8.54      3.317     3.317     0.000     0.000  1270749   Fixnum#==                |     8.53      3.396     3.396     0.000     0.000  1270749   Fixnum#==
  7.44      2.890     2.890     0.000     0.000  2415744   Fixnum#<=                |     7.35      2.927     2.927     0.000     0.000  2415744   Fixnum#<=
  6.90      2.678     2.678     0.000     0.000   142618   String#[]                |     6.98      2.778     2.778     0.000     0.000   142618   String#[]
  6.52      2.529     2.529     0.000     0.000  4274010   Array#[]                 |     6.30      2.509     2.509     0.000     0.000  4274010   Array#[]
  6.00      2.329     2.329     0.000     0.000  1432497   Fixnum#+                 |     6.02      2.397     2.397     0.000     0.000  1432497   Fixnum#+
  4.82      3.519     1.871     0.000     1.649   690326   BasicObject#!=           |     4.80      3.600     1.912     0.000     1.688   690326   BasicObject#!=
  1.59      0.616     0.616     0.000     0.000    76473   String#length            |     1.59      0.633     0.633     0.000     0.000    76473   String#length
  1.03      0.401     0.401     0.000     0.000   446708   Kernel#class             |     1.04      0.412     0.412     0.000     0.000   446708   Kernel#class
  0.77      0.298     0.298     0.000     0.000   382750   Fixnum#-                 |     0.76      0.302     0.302     0.000     0.000   382750   Fixnum#-
  0.69      0.268     0.268     0.000     0.000   133957   String#encode            |     0.74      0.295     0.295     0.000     0.000   133957   String#encode
  0.61      0.237     0.237     0.000     0.000   189474   BasicObject#!            |     0.62      0.249     0.249     0.000     0.000   189474   BasicObject#!
  0.60      0.232     0.232     0.000     0.000    41422   Array#shift              |     0.60      0.240     0.240     0.000     0.000    41422   Array#shift
  0.54      0.212     0.211     0.000     0.000    82221  *Array#any?               |     0.55      0.218     0.218     0.000     0.000    82221  *Array#any?
  0.54      0.513     0.211     0.000     0.302       24   Kernel#p                 |     0.46      0.896     0.183     0.000     0.713   103323  *Class#new
  0.46      0.824     0.178     0.000     0.645   103323  *Class#new                |     0.44     39.130     0.175     0.000    38.955       24   Racc::Parser#_racc_do_p
  0.41      0.290     0.158     0.000     0.132   132825   Parser::Lexer#literal    |     0.42      0.471     0.167     0.000     0.304       24   Kernel#p
  0.39     38.103     0.153     0.000    37.950       24   Racc::Parser#_racc_do_p  |     0.39      0.294     0.157     0.000     0.137   132825   Parser::Lexer#literal
  0.34      0.133     0.133     0.000     0.000   134037   Array#last               |     0.35      0.139     0.139     0.000     0.000   134037   Array#last
  0.32      0.123     0.123     0.000     0.000   379179   Fixnum#<<                |     0.33      0.130     0.130     0.000     0.000   379179   Fixnum#<<
  0.28     36.803     0.107     0.000    36.697    41421   Parser::Base#next_token  |     0.30      0.118     0.118     0.000     0.000   120471   Kernel#freeze
  0.27      0.104     0.104     0.000     0.000   120471   Kernel#freeze            |     0.29     37.707     0.116     0.000    37.591    41421   Parser::Base#next_token
  0.26      0.099     0.099     0.000     0.000    88830   Kernel#respond_to?       |     0.25      1.007     0.100     0.000     0.907    46542   Parser::Lexer#tok
  0.24      0.091     0.091     0.000     0.000   364002   Fixnum#>                 |     0.25      0.381     0.099     0.000     0.281    41397   Parser::Lexer#emit
  0.23      0.474     0.090     0.000     0.384    43808   Parser::Lexer::Literal#  |     0.24      0.095     0.095     0.000     0.000   364002   Fixnum#>
  0.23      0.957     0.089     0.000     0.868    46542   Parser::Lexer#tok        |     0.22      0.511     0.089     0.000     0.422    43808   Parser::Lexer::Literal#
  0.20      0.198     0.079     0.000     0.120    53605  *Kernel#dup               |     0.22      0.140     0.087     0.000     0.053    53605   Kernel#initialize_dup
  0.20      0.123     0.078     0.000     0.045    57938   Parser::Source::Range#i  |     0.22      0.340     0.086     0.000     0.254    50749   Parser::Lexer::Literal#
  0.19      0.305     0.075     0.000     0.229    50749   Parser::Lexer::Literal#  |     0.21      0.140     0.085     0.000     0.054    57938   Parser::Source::Range#i
  0.19      0.338     0.074     0.000     0.264    41397   Parser::Lexer#emit       |     0.20      0.221     0.081     0.000     0.140    53605  *Kernel#dup
  0.18      0.119     0.071     0.000     0.048    53605   Kernel#initialize_dup    |     0.16      0.389     0.063     0.000     0.327    21194   AST::Node#initialize
  0.16      0.362     0.061     0.000     0.301    21194   AST::Node#initialize     |     0.16      0.241     0.062     0.000     0.179    41425   Parser::Lexer#range
  0.15      0.086     0.058     0.000     0.027    41780   Parser::Lexer::Literal#  |     0.14      0.086     0.057     0.000     0.029    41780   Parser::Lexer::Literal#
  0.15      0.228     0.056     0.000     0.171    41425   Parser::Lexer#range      |     0.14      0.071     0.056     0.000     0.016    57423   Parser::Builders::Defau
  0.13      0.069     0.052     0.000     0.017    57423   Parser::Builders::Defau  |     0.13      0.134     0.053     0.000     0.081    42388  *Array#hash
```

extracted diff from respond_to?
```
0.26      0.099     0.099     0.000     0.000    88830   Kernel#respond_to? | 0.01      0.002     0.002     0.000     0.000     1417   Kernel#respond_to?
```


```
$ ruby -v
ruby 2.3.0preview1 (2015-11-11 trunk 52539) [x86_64-darwin14]
```
