### PR TITLE
* lib/parser/source/buffer: reduce respond_to?(:bsearch)

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -228,13 +228,15 @@ module Parser
         @line_begins
       end
 
-      def line_for(position)
-        if line_begins.respond_to? :bsearch
+      if [].respond_to?(:bsearch)
+        def line_for(position)
           # Fast O(log n) variant for Ruby >=2.0.
           line_begins.bsearch do |line, line_begin|
             line_begin <= position
           end
-        else
+        end
+      else
+        def line_for(position)
           # Slower O(n) variant for Ruby <2.0.
           line_begins.find do |line, line_begin|
             line_begin <= position


### PR DESCRIPTION

```
$ time ruby-prof -f before_rubocop  ./bin/ruby-rubocop -- --cache false test/**/*.rb
$ time ruby-prof -f after_rubocop  ./bin/ruby-rubocop -- --cache false test/**/*.rb
$ diff -W 170 -y before-rubocop after-rubocop | less
```

bin/ruby-rubocop is followings:

```
#!/usr/bin/env ruby

$LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
require 'parser'
require 'rubocop'

require 'benchmark'

cli = RuboCop::CLI.new
result = 0

time = Benchmark.realtime do
    result = cli.run
end

puts "Finished in #{time} seconds" if cli.options[:debug]
exit result
```

This patch reduce respond_to? calls from 5172087 to 4541354.
and total time reduce 2.620 to 2.439.

```
Measure Mode: wall_time                                                                 Measure Mode: wall_time
Thread ID: 2184094160                                                               |   Thread ID: 2165219800
Fiber ID: 2183997220                                                                |   Fiber ID: 2165121240
Total: 77.723940                                                                    |   Total: 76.970621
Sort by: self_time                                                                      Sort by: self_time

 %self      total      self      wait     child     calls  name                          %self      total      self      wait     child     calls  name
 21.55     37.352    16.752     0.000    20.600    41569   Parser::Lexer#advance    |    21.79     37.264    16.772     0.000    20.492    41569   Parser::Lexer#advance
  5.70      4.433     4.433     0.000     0.000   278904   String#[]                |     5.69      4.376     4.376     0.000     0.000   278904   String#[]
  4.98      3.867     3.867     0.000     0.000  9770716   Fixnum#<=                |     4.96      3.819     3.819     0.000     0.000  9770716   Fixnum#<=
  4.48      3.482     3.482     0.000     0.000  2532749   Fixnum#==                |     4.53      3.488     3.488     0.000     0.000  2532749   Fixnum#==
  3.89      4.008     3.022     0.000     0.987   630734   Array#bsearch            |     3.99      4.035     3.069     0.000     0.966   630734   Array#bsearch
  3.20      2.488     2.488     0.000     0.000  2342927   Fixnum#+                 |     3.61      2.775     2.775     0.000     0.000  2155376   Kernel#hash
  3.11      2.420     2.420     0.000     0.000  4449875   Array#[]                 |     3.19      2.455     2.455     0.000     0.000  2342927   Fixnum#+
  3.09      2.402     2.402     0.000     0.000  2155376   Kernel#hash              |     3.15      2.424     2.424     0.000     0.000  4449875   Array#[]
  2.70      2.620     2.095     0.000     0.525  5172087   Kernel#respond_to?       |     2.50      2.439     1.926     0.000     0.513  4541354   Kernel#respond_to?
  2.45      3.554     1.901     0.000     1.652   796373   BasicObject#!=           |     2.46      3.551     1.891     0.000     1.660   796373   BasicObject#!=
  1.97      1.770     1.533     0.000     0.237  1261468   Parser::Source::Buffer#  |     1.37      6.275     1.056     0.000     5.219   630734   Parser::Source::Buffer#
  1.72      8.718     1.334     0.000     7.384   630734   Parser::Source::Buffer#  |     1.23      7.429     0.944     0.000     6.484   630734   Parser::Source::Buffer#
  1.58      7.167     1.229     0.000     5.938   630734   Parser::Source::Buffer#  |     1.22      1.184     0.941     0.000     0.244   630734   Parser::Source::Buffer#
  1.00      2.179     0.778     0.000     1.401   133340  *Array#any?               |     1.00      2.224     0.766     0.000     1.458   133340  *Array#any?
  0.98      7.928     0.763     0.000     7.166   516962   Parser::Source::Range#l  |     0.94     23.716     0.721     0.000    22.995   336413   RuboCop::Cop::Commissio
  0.91     24.628     0.709     0.000    23.919   336413   RuboCop::Cop::Commissio  |     0.93      6.785     0.720     0.000     6.066   516962   Parser::Source::Range#l
  0.91      1.351     0.706     0.000     0.644  1101191   Parser::Source::Range#=  |     0.92      1.403     0.711     0.000     0.692  1101191   Parser::Source::Range#=
  0.76      0.591     0.591     0.000     0.000    15582   IO#write                 |     0.78      0.604     0.604     0.000     0.000    15582   IO#write
  0.72      0.560     0.560     0.000     0.000   261612   Kernel#class             |     0.74      0.567     0.567     0.000     0.000  1591091   Kernel#is_a?
  0.70      0.542     0.542     0.000     0.000  1591091   Kernel#is_a?             |     0.72      0.556     0.556     0.000     0.000   261612   Kernel#class
  0.68      0.525     0.525     0.000     0.000  3861072   Kernel#respond_to_missi  |     0.67      0.513     0.513     0.000     0.000  3861072   Kernel#respond_to_missi
```