### PR TITLE
lexer.rl: reduce Array literal object allocations

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -92,6 +92,8 @@ class Parser::Lexer
   REGEXP_META_CHARACTERS = Regexp.union(*"\\$()*+.<>?[]^{|}".chars).freeze
   UNDERSCORE_STRING = '_'.freeze
 
+  RBRACE_OR_RPAREN = %w"} ]".freeze
+
   attr_reader   :source_buffer
   attr_reader   :encoding
 
@@ -2131,7 +2133,7 @@ class Parser::Lexer
         emit_table(PUNCTUATION)
         @cond.lexpop; @cmdarg.lexpop
 
-        if %w"} ]".include?(tok)
+        if RBRACE_OR_RPAREN.include?(tok)
           fnext expr_endarg;
         else # )
           # fnext expr_endfn; ?


### PR DESCRIPTION
in #220, I found more allocation points.

```
diff --git bin/ruby-parse bin/ruby-parse
index e55c2f4..7f34f91 100755
--- bin/ruby-parse
+++ bin/ruby-parse
@@ -3,4 +3,14 @@
 $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 require 'parser/runner/ruby_parse'

+require 'pp'
+require 'allocation_tracer'
+
+trace_result = ObjectSpace::AllocationTracer.trace{
 Parser::Runner::RubyParse.go(ARGV)
+}.select {|key| key[0].include?('parser/lexer.rb') }
+.each_with_object({}) {|(key,val),j| j[key] = val[0] }
+trace_result.sort_by {|key,val| key[1] }.each do |key,val|
+  puts "#{key[0]}:#{key[1]} :#{val}"
+end
+p trace_result.inject(0) {|sum,(key,val)| sum += val; sum }
```

and

BEFORE: 601599
AFTER: 590269


