### PR TITLE
lexer.rl: reduce literal method calls

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -848,8 +848,8 @@ class Parser::Lexer
       lookahead = lookahead.encode(@encoding) if @has_encode
     end
 
-    lit = literal
-    if !lit.heredoc? && (token = lit.nest_and_try_closing(string, @ts, @te, lookahead))
+    current_literal = literal
+    if !current_literal.heredoc? && (token = current_literal.nest_and_try_closing(string, @ts, @te, lookahead))
       if token[0] == :tLABEL_END
         p += 1
         pop_literal
@@ -859,13 +859,13 @@ class Parser::Lexer
       end
       fbreak;
     else
-      lit.extend_string(string, @ts, @te)
+      current_literal.extend_string(string, @ts, @te)
     end
   }
 
   action extend_string_escaped {
-    lit = literal
-    if lit.nest_and_try_closing('\\', @ts, @ts + 1)
+    current_literal = literal
+    if current_literal.nest_and_try_closing('\\', @ts, @ts + 1)
       # If the literal is actually closed by the backslash,
       # rewind the input prior to consuming the escape sequence.
       p = @escape_s - 1
@@ -874,12 +874,12 @@ class Parser::Lexer
       # Get the first character after the backslash.
       escaped_char = @source[@escape_s].chr
 
-      if lit.munge_escape? escaped_char
+      if current_literal.munge_escape? escaped_char
         # If this particular literal uses this character as an opening
         # or closing delimiter, it is an escape sequence for that
         # particular character. Write it without the backslash.
 
-        if lit.regexp? && REGEXP_META_CHARACTERS.match(escaped_char)
+        if current_literal.regexp? && REGEXP_META_CHARACTERS.match(escaped_char)
           # Regular expressions should include escaped delimiters in their
           # escaped form, except when the escaped character is
           # a closing delimiter but not a regexp metacharacter.
@@ -888,9 +888,9 @@ class Parser::Lexer
           # at the same time as an escape symbol, but it is always munged,
           # so this branch also executes for the non-closing-delimiter case
           # for the backslash.
-          lit.extend_string(tok, @ts, @te)
+          current_literal.extend_string(tok, @ts, @te)
         else
-          lit.extend_string(escaped_char, @ts, @te)
+          current_literal.extend_string(escaped_char, @ts, @te)
         end
       else
         # It does not. So this is an actual escape sequence, yay!
@@ -905,12 +905,12 @@ class Parser::Lexer
 
         @escape.call if @escape.respond_to? :call
 
-        if lit.regexp?
+        if current_literal.regexp?
           # Regular expressions should include escape sequences in their
           # escaped form. On the other hand, escaped newlines are removed.
-          lit.extend_string(tok.gsub(ESCAPED_NEXT_LINE, BLANK_STRING), @ts, @te)
+          current_literal.extend_string(tok.gsub(ESCAPED_NEXT_LINE, BLANK_STRING), @ts, @te)
         else
-          lit.extend_string(@escape || tok, @ts, @te)
+          current_literal.extend_string(@escape || tok, @ts, @te)
         end
       end
     end
@@ -920,13 +920,13 @@ class Parser::Lexer
   # As heredoc closing line can immediately precede EOF, this action
   # has to handle such case specially.
   action extend_string_eol {
-    lit = literal
+    current_literal = literal
     if @te == pe
       diagnostic :fatal, :string_eof, nil,
-                 range(lit.str_s, lit.str_s + 1)
+                 range(current_literal.str_s, current_literal.str_s + 1)
     end
 
-    if lit.heredoc?
+    if current_literal.heredoc?
       line = tok(@herebody_s, @ts).gsub(/\r+$/, BLANK_STRING)
 
       if version?(18, 19, 20)
@@ -936,12 +936,12 @@ class Parser::Lexer
 
       # Try ending the heredoc with the complete most recently
       # scanned line. @herebody_s always refers to the start of such line.
-      if lit.nest_and_try_closing(line, @herebody_s, @ts)
+      if current_literal.nest_and_try_closing(line, @herebody_s, @ts)
         # Adjust @herebody_s to point to the next line.
         @herebody_s = @te
 
         # Continue regular lexing after the heredoc reference (<<END).
-        p = lit.heredoc_e - 1
+        p = current_literal.heredoc_e - 1
         fnext *pop_literal; fbreak;
       else
         # Ditto.
@@ -949,7 +949,7 @@ class Parser::Lexer
       end
     else
       # Try ending the literal with a newline.
-      if lit.nest_and_try_closing(tok, @ts, @te)
+      if current_literal.nest_and_try_closing(tok, @ts, @te)
         fnext *pop_literal; fbreak;
       end
 
@@ -967,14 +967,14 @@ class Parser::Lexer
       end
     end
 
-    if lit.words? && !eof_codepoint?(@source_pts[p])
-      lit.extend_space @ts, @te
+    if current_literal.words? && !eof_codepoint?(@source_pts[p])
+      current_literal.extend_space @ts, @te
     else
       # A literal newline is appended if the heredoc was _not_ closed
       # this time (see fbreak above). See also Literal#nest_and_try_closing
       # for rationale of calling #flush_string here.
-      lit.extend_string tok, @ts, @te
-      lit.flush_string
+      current_literal.extend_string tok, @ts, @te
+      current_literal.flush_string
     end
   }
 
@@ -992,9 +992,9 @@ class Parser::Lexer
   interp_var = '#' ( global_var | class_var_v | instance_var_v );
 
   action extend_interp_var {
-    lit = literal
-    lit.flush_string
-    lit.extend_content
+    current_literal = literal
+    current_literal.flush_string
+    current_literal.extend_content
 
     emit(:tSTRING_DVAR, nil, @ts, @ts + 1)
 
@@ -1019,24 +1019,24 @@ class Parser::Lexer
   e_lbrace = '{' % {
     @cond.push(false); @cmdarg.push(false)
 
-    lit = literal
-    if lit
-      lit.start_interp_brace
+    current_literal = literal
+    if current_literal
+      current_literal.start_interp_brace
     end
   };
 
   e_rbrace = '}' % {
-    lit = literal
-    if lit
-      if lit.end_interp_brace_and_try_closing
+    current_literal = literal
+    if current_literal
+      if current_literal.end_interp_brace_and_try_closing
         if version?(18, 19)
           emit(:tRCURLY, '}', p - 1, p)
         else
           emit(:tSTRING_DEND, '}', p - 1, p)
         end
 
-        if lit.saved_herebody_s
-          @herebody_s = lit.saved_herebody_s
+        if current_literal.saved_herebody_s
+          @herebody_s = current_literal.saved_herebody_s
         end
 
         fhold;
@@ -1047,18 +1047,18 @@ class Parser::Lexer
   };
 
   action extend_interp_code {
-    lit = literal
-    lit.flush_string
-    lit.extend_content
+    current_literal = literal
+    current_literal.flush_string
+    current_literal.extend_content
 
     emit(:tSTRING_DBEG, '#{')
 
-    if lit.heredoc?
-      lit.saved_herebody_s = @herebody_s
+    if current_literal.heredoc?
+      current_literal.saved_herebody_s = @herebody_s
       @herebody_s = nil
     end
 
-    lit.start_interp_brace
+    current_literal.start_interp_brace
     fcall expr_value;
   }
 


### PR DESCRIPTION
I try to profile using ruby-prof followings:

```
$ time ruby-prof -f before ./bin/ruby-parse test/**/*.rb
$ time ruby-prof -f after ./bin/ruby-parse test/**/*.rb
$ diff -W 170 -y before after | less
```

Lexer#literal can be cached before calling Lexer#pop_literal

This patch reduce literal method call from 132825 times to 45291 times.
Time changed from 0.283 ms to 0.096
And also changed Array#last method calls from 134027 times to 46493.
Time changed from 0.118 ms to 0.051.

```
Measure Mode: wall_time                                                                 Measure Mode: wall_time
Thread ID: 2280563160                                                               |   Thread ID: 2211357140
Fiber ID: 2282587940                                                                |   Fiber ID: 2213381980
Total: 39.815373                                                                    |   Total: 39.454364
Sort by: self_time                                                                      Sort by: self_time

 %self      total      self      wait     child     calls  name                          %self      total      self      wait     child     calls  name
 43.75     37.442    17.420     0.000    20.022    41421   Parser::Lexer#advance    |    44.17     37.055    17.426     0.000    19.629    41421   Parser::Lexer#advance
  8.65      3.444     3.444     0.000     0.000  1270749   Fixnum#==                |     8.74      3.448     3.448     0.000     0.000  1270749   Fixnum#==
  7.67      3.055     3.055     0.000     0.000  2415744   Fixnum#<=                |     7.65      3.017     3.017     0.000     0.000  2415744   Fixnum#<=
  7.33      2.918     2.918     0.000     0.000   142618   String#[]                |     7.18      2.831     2.831     0.000     0.000   142618   String#[]
  6.60      2.628     2.628     0.000     0.000  4274010   Array#[]                 |     6.58      2.595     2.595     0.000     0.000  4274010   Array#[]
  6.06      2.411     2.411     0.000     0.000  1394919   Fixnum#+                 |     6.13      2.419     2.419     0.000     0.000  1394919   Fixnum#+
  4.91      3.668     1.953     0.000     1.714   690327   BasicObject#!=           |     4.94      3.668     1.950     0.000     1.717   690327   BasicObject#!=
  0.83      0.331     0.331     0.000     0.000    38898   String#length            |     0.81      0.321     0.321     0.000     0.000    38898   String#length
  0.80      0.317     0.317     0.000     0.000   382750   Fixnum#-                 |     0.80      0.315     0.315     0.000     0.000   382750   Fixnum#-
  0.75      0.298     0.298     0.000     0.000   133957   String#encode            |     0.74      0.290     0.290     0.000     0.000   133957   String#encode
  0.60      0.239     0.239     0.000     0.000    41422   Array#shift              |     0.65      0.571     0.255     0.000     0.315       24   Kernel#p
  0.58      0.559     0.231     0.000     0.328       24   Kernel#p                 |     0.60      0.236     0.236     0.000     0.000    41422   Array#shift
  0.56      0.222     0.222     0.000     0.000   189474   BasicObject#!            |     0.56      0.221     0.221     0.000     0.000    82195  *Array#any?
  0.55      0.220     0.220     0.000     0.000    82195  *Array#any?               |     0.54      0.215     0.215     0.000     0.000   189474   BasicObject#!
  0.49     39.026     0.194     0.000    38.831       24   Racc::Parser#_racc_do_p  |     0.48     38.586     0.191     0.000    38.395       24   Racc::Parser#_racc_do_p
  0.44      0.897     0.175     0.000     0.723   103299  *Class#new                |     0.41      0.865     0.161     0.000     0.705   103299  *Class#new
  0.42      0.283     0.166     0.000     0.117   132825   Parser::Lexer#literal    |     0.31      0.121     0.121     0.000     0.000   120473   Kernel#freeze
  0.36      0.143     0.143     0.000     0.000   120473   Kernel#freeze            |     0.30      0.117     0.117     0.000     0.000   379179   Fixnum#<<
  0.32     37.569     0.126     0.000    37.442    41421   Parser::Base#next_token  |     0.29     37.171     0.116     0.000    37.055    41421   Parser::Base#next_token
  0.30      0.118     0.118     0.000     0.000   379179   Fixnum#<<                |     0.27      0.194     0.105     0.000     0.089    52167  *Kernel#dup
  0.30      0.118     0.118     0.000     0.000   134027   Array#last               |     0.26      0.342     0.101     0.000     0.241    41397   Parser::Lexer#emit
  0.24      0.095     0.095     0.000     0.000    71164   Kernel#class             |     0.23      0.992     0.092     0.000     0.900    46542   Parser::Lexer#tok
  0.24      1.019     0.094     0.000     0.924    46542   Parser::Lexer#tok        |     0.23      0.092     0.092     0.000     0.000    71164   Kernel#class
  0.24      0.094     0.094     0.000     0.000   364002   Fixnum#>                 |     0.23      0.090     0.090     0.000     0.000   364002   Fixnum#>
  0.23      0.369     0.091     0.000     0.278    41397   Parser::Lexer#emit       |     0.23      0.319     0.089     0.000     0.230    50749   Parser::Lexer::Literal#
  0.22      0.462     0.087     0.000     0.375    43808   Parser::Lexer::Literal#  |     0.21      0.141     0.084     0.000     0.057    57938   Parser::Source::Range#i
  0.22      0.287     0.086     0.000     0.201    50749   Parser::Lexer::Literal#  |     0.21      0.479     0.083     0.000     0.396    43808   Parser::Lexer::Literal#
  0.19      0.162     0.077     0.000     0.085    52167  *Kernel#dup               |     0.17      0.068     0.068     0.000     0.000       24   <Class::IO>#read
  0.17      0.145     0.069     0.000     0.076    57938   Parser::Source::Range#i  |     0.17      0.093     0.067     0.000     0.026    41780   Parser::Lexer::Literal#
  0.17      0.410     0.066     0.000     0.344    21194   AST::Node#initialize     |     0.16      0.398     0.063     0.000     0.335    21194   AST::Node#initialize
  0.16      0.246     0.063     0.000     0.183    41425   Parser::Lexer#range      |     0.15      0.059     0.059     0.000     0.000    61508   Kernel#hash
  0.14      0.086     0.057     0.000     0.030    41780   Parser::Lexer::Literal#  |     0.14      0.071     0.054     0.000     0.018    57423   Parser::Builders::Defau
  0.14      0.056     0.056     0.000     0.000    61508   Kernel#hash              |     0.13      0.051     0.051     0.000     0.000    46493   Array#last
  0.13      0.139     0.054     0.000     0.086    42388  *Array#hash               |     0.13      0.138     0.051     0.000     0.087    42388  *Array#hash
  0.13      0.069     0.051     0.000     0.018    57423   Parser::Builders::Defau  |     0.13      0.049     0.049     0.000     0.000    62727   Fixnum#>=
  0.13      0.051     0.051     0.000     0.000    56088   String#force_encoding    |     0.12      0.092     0.049     0.000     0.043    53586   Kernel#initialize_dup
  0.12      0.049     0.049     0.000     0.000    62727   Fixnum#>=                |     0.12      0.048     0.048     0.000     0.000    56088   String#force_encoding
  0.12      0.470     0.049     0.000     0.421    19775   Parser::Builders::Defau  |     0.12      0.454     0.046     0.000     0.408    19775   Parser::Builders::Defau
  0.12      0.088     0.047     0.000     0.041    53586   Kernel#initialize_dup    |     0.11      0.093     0.042     0.000     0.050    45291   Parser::Lexer#literal
  0.10      0.100     0.042     0.000     0.058    21194   Parser::AST::Node#assig  |     0.10      0.096     0.040     0.000     0.057    21194   Parser::AST::Node#assig
```

