### PR TITLE
lexer.rl: recude encode method calls if not need

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -335,9 +335,9 @@ class Parser::Lexer
     end
 
     def tok(s = @ts, e = @te)
-      s = @source[s...e]
-      return s unless @need_encode
-      s.encode(@encoding)
+      source = @source[s...e]
+      return source unless @need_encode
+      source.encode(@encoding)
     end
   else
     def encode_escape(ord)

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -134,6 +134,7 @@ class Parser::Lexer
     @source        = nil # source string
     @source_pts    = nil # @source as a codepoint array
     @encoding      = nil # target encoding for output strings
+    @need_encode = nil
 
     @p             = 0   # stream position (saved manually in #advance)
     @ts            = nil # token start
@@ -196,6 +197,7 @@ class Parser::Lexer
 
       if defined?(Encoding) && @source.encoding == Encoding::UTF_8
         @source_pts = @source.unpack('U*')
+        @need_encode = @has_encode && @encoding != Encoding::UTF_8
       else
         @source_pts = @source.unpack('C*')
       end
@@ -214,6 +216,7 @@ class Parser::Lexer
         #
         # Patches accepted.
         @source = @source.encode(Encoding::UTF_32LE)
+        @need_encode = @has_encode && @encoding != Encoding::UTF_32LE
       end
 
       if @source_pts[0] == 0xfeff
@@ -332,7 +335,9 @@ class Parser::Lexer
     end
 
     def tok(s = @ts, e = @te)
-      @source[s...e].encode(@encoding)
+      s = @source[s...e]
+      return s unless @need_encode
+      s.encode(@encoding)
     end
   else
     def encode_escape(ord)
@@ -840,12 +845,12 @@ class Parser::Lexer
 
   action extend_string {
     string = @source[@ts...@te]
-    string = string.encode(@encoding) if @has_encode
+    string = string.encode(@encoding) if @need_encode
 
     # tLABEL_END is only possible in non-cond context on >= 2.2
     if @version >= 22 && !@cond.active?
       lookahead = @source[@te...@te+2]
-      lookahead = lookahead.encode(@encoding) if @has_encode
+      lookahead = lookahead.encode(@encoding) if @need_encode
     end
 
     if !literal.heredoc? && (token = literal.nest_and_try_closing(string, @ts, @te, lookahead))


### PR DESCRIPTION
I try to profile using ruby-prof followings:

```
$ time ruby-prof -f before ./bin/ruby-parse test/**/*.rb
$ time ruby-prof -f after ./bin/ruby-parse test/**/*.rb
$ diff -W 170 -y before after | less
```

This patch reduce String#encode calls from 133957 times to 1 times if encoding is same.
total time changes 0.298 to 0.00.

```
Measure Mode: wall_time                                                                 Measure Mode: wall_time
Thread ID: 2280563160                                                               |   Thread ID: 2272174560
Fiber ID: 2282587940                                                                |   Fiber ID: 2272047580
Total: 39.815373                                                                    |   Total: 39.309657
Sort by: self_time                                                                      Sort by: self_time

 %self      total      self      wait     child     calls  name                          %self      total      self      wait     child     calls  name
 43.75     37.442    17.420     0.000    20.022    41421   Parser::Lexer#advance    |    44.14     36.860    17.353     0.000    19.507    41421   Parser::Lexer#advance
  8.65      3.444     3.444     0.000     0.000  1270749   Fixnum#==                |     8.70      3.418     3.418     0.000     0.000  1270749   Fixnum#==
  7.67      3.055     3.055     0.000     0.000  2415744   Fixnum#<=                |     7.63      3.000     3.000     0.000     0.000  2415744   Fixnum#<=
  7.33      2.918     2.918     0.000     0.000   142618   String#[]                |     7.34      2.885     2.885     0.000     0.000   142618   String#[]
  6.60      2.628     2.628     0.000     0.000  4274010   Array#[]                 |     6.43      2.527     2.527     0.000     0.000  4274010   Array#[]
  6.06      2.411     2.411     0.000     0.000  1394919   Fixnum#+                 |     6.09      2.393     2.393     0.000     0.000  1394919   Fixnum#+
  4.91      3.668     1.953     0.000     1.714   690327   BasicObject#!=           |     4.96      3.648     1.949     0.000     1.699   690349   BasicObject#!=
  0.83      0.331     0.331     0.000     0.000    38898   String#length            |     0.82      0.323     0.323     0.000     0.000    38898   String#length
  0.80      0.317     0.317     0.000     0.000   382750   Fixnum#-                 |     0.79      0.312     0.312     0.000     0.000   382750   Fixnum#-
  0.75      0.298     0.298     0.000     0.000   133957   String#encode            |     0.61      0.238     0.238     0.000     0.000    41422   Array#shift
  0.60      0.239     0.239     0.000     0.000    41422   Array#shift              |     0.60      0.236     0.236     0.000     0.000   189474   BasicObject#!
  0.58      0.559     0.231     0.000     0.328       24   Kernel#p                 |     0.59      0.560     0.231     0.000     0.328       24   Kernel#p
  0.56      0.222     0.222     0.000     0.000   189474   BasicObject#!            |     0.56      0.218     0.218     0.000     0.000    82195  *Array#any?
  0.55      0.220     0.220     0.000     0.000    82195  *Array#any?               |     0.52     38.497     0.203     0.000    38.294       24   Racc::Parser#_racc_do_p
  0.49     39.026     0.194     0.000    38.831       24   Racc::Parser#_racc_do_p  |     0.49      0.933     0.193     0.000     0.741   103299  *Class#new
  0.44      0.897     0.175     0.000     0.723   103299  *Class#new                |     0.35      0.253     0.139     0.000     0.114   132825   Parser::Lexer#literal
  0.42      0.283     0.166     0.000     0.117   132825   Parser::Lexer#literal    |     0.33     36.992     0.131     0.000    36.860    41421   Parser::Base#next_token
  0.36      0.143     0.143     0.000     0.000   120473   Kernel#freeze            |     0.32      0.125     0.125     0.000     0.000   120473   Kernel#freeze
  0.32     37.569     0.126     0.000    37.442    41421   Parser::Base#next_token  |     0.29      0.115     0.115     0.000     0.000   379179   Fixnum#<<
  0.30      0.118     0.118     0.000     0.000   379179   Fixnum#<<                |     0.29      0.115     0.115     0.000     0.000   134027   Array#last
  0.30      0.118     0.118     0.000     0.000   134027   Array#last               |     0.27      0.381     0.107     0.000     0.273    41397   Parser::Lexer#emit
  0.24      0.095     0.095     0.000     0.000    71164   Kernel#class             |     0.26      0.930     0.102     0.000     0.828    46542   Parser::Lexer#tok
  0.24      1.019     0.094     0.000     0.924    46542   Parser::Lexer#tok        |     0.26      0.494     0.101     0.000     0.393    43808   Parser::Lexer::Literal#
  0.24      0.094     0.094     0.000     0.000   364002   Fixnum#>                 |     0.25      0.189     0.100     0.000     0.089    52167  *Kernel#dup
  0.23      0.369     0.091     0.000     0.278    41397   Parser::Lexer#emit       |     0.23      0.091     0.091     0.000     0.000   364002   Fixnum#>
  0.22      0.462     0.087     0.000     0.375    43808   Parser::Lexer::Literal#  |     0.23      0.091     0.091     0.000     0.000    71164   Kernel#class
```