### PR TITLE
support enable fronzen_string_literal for over ruby 2.3.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ task :generate => GENERATED_FILES do
   Rake::Task[:ragel_check].invoke
   GENERATED_FILES.each do |filename|
     content = File.read(filename)
-    content = "# -*- encoding:utf-8; warn-indent:false -*-\n" + content
+    content = "# -*- encoding:utf-8; warn-indent:false; frozen_string_literal: true  -*-\n" + content
 
     File.open(filename, 'w') do |io|
       io.write content

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -190,7 +190,7 @@ class Parser::Lexer
 
         # This is a workaround for 1.9.2, which (without force_encoding)
         # would convert the result to UTF-8 (source encoding of lexer.rl).
-        @source    += "\0".force_encoding(@encoding)
+        @source    += "\0".dup.force_encoding(@encoding)
       else
         @source    += "\0"
       end


### PR DESCRIPTION
I tried to use ruby 2.3.0-preview1 feature "frozen_string_literal: true".
It does not improve performance now.

But generated lexer.rb include some string literal. and it may affect some performance improvement in future.

BEFORE
```
run "ruby bin/ruby-parse test/*.rb"
4.161907772s
4.07406064s
4.034552265s
4.153820199s
4.07035989s
4.047238321s
4.077487832s
3.979082707s
4.025522643s
3.98664261s
count:  10 times executed
avg:    4.061067487s
stdev:  55.362386ms
```

AFTER
```
run "ruby bin/ruby-parse test/*.rb"
4.030414207s
4.256804907s
4.215693019s
4.032238326s
4.045159886s
3.982182805s
4.015422779s
3.998105521s
4.054807781s
4.045414991s
count:  10 times executed
avg:    4.067624422s
stdev:  83.323401ms
```