### PR TITLE
Enhance Range and Rewriter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in parser.gemspec
 gemspec
+
+# Workaround for bug in Bundler on JRuby
+# See https://github.com/bundler/bundler/issues/4157
+gem 'ast', '>= 1.1', '< 3.0'

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ GENERATED_FILES = %w(lib/parser/lexer.rb
 
 CLEAN.include(GENERATED_FILES)
 
-desc 'Generate the Ragel lexer and Bison parser.'
+desc 'Generate the Ragel lexer and Racc parser.'
 task :generate => GENERATED_FILES do
   Rake::Task[:ragel_check].invoke
   GENERATED_FILES.each do |filename|
@@ -45,7 +45,7 @@ end
 
 task :regenerate => [:clean, :generate]
 
-desc 'Generate the Ragel lexer and Bison parser in release mode.'
+desc 'Generate the Ragel lexer and Racc parser in release mode.'
 task :generate_release => [:clean_env, :regenerate]
 
 task :clean_env do

--- a/lib/parser/diagnostic.rb
+++ b/lib/parser/diagnostic.rb
@@ -82,23 +82,74 @@ module Parser
     # @return [Array<String>]
     #
     def render
-      source_line    = @location.source_line
+      if @location.line != @location.last_line
+        # multi-line diagnostic
+        first_line = first_line_only(@location)
+        last_line  = last_line_only(@location)
+        buffer     = @location.source_buffer
+
+        first_lineno, first_column = buffer.decompose_position(@location.begin_pos)
+        last_lineno,  last_column  = buffer.decompose_position(@location.end_pos)
+
+        ["#{@location}-#{last_lineno}:#{last_column}: #{@level}: #{message}"] +
+          render_line(first_line).
+            map { |line| "#{buffer.name}:#{first_lineno}: #{line}" }.
+            tap { |array| array.last << '...' } +
+          render_line(last_line).map  { |line| "#{buffer.name}:#{last_lineno}: #{line}" }
+      else
+        ["#{@location}: #{@level}: #{message}"] + render_line(@location)
+      end
+    end
+
+    private
+
+    ##
+    # Renders one source line in clang diagnostic style, with highlights.
+    #
+    # @return [Array<String>]
+    #
+    def render_line(range)
+      source_line    = range.source_line
       highlight_line = ' ' * source_line.length
 
       @highlights.each do |hilight|
-        range = hilight.column_range
-        highlight_line[range] = '~' * hilight.size
+       line_range = range.source_buffer.line_range(range.line)
+        if hilight = hilight.intersect(line_range)
+          highlight_line[hilight.column_range] = '~' * hilight.size
+        end
       end
 
-      range = @location.column_range
-      highlight_line[range] = '^' * @location.size
+      highlight_line[range.column_range] = '^' * range.size
 
-      [
-        "#{@location.to_s}: #{@level}: #{message}",
-        source_line,
-        highlight_line,
-      ]
+      [source_line, highlight_line]
+    end
+
+    ##
+    # If necessary, shrink a `Range` so as to include only the first line.
+    #
+    # @return [Parser::Source::Range]
+    #
+    def first_line_only(range)
+      if range.line != range.last_line
+        range.resize(range.source =~ /\n/)
+      else
+        range
+      end
+    end
+
+    ##
+    # If necessary, shrink a `Range` so as to include only the last line.
+    #
+    # @return [Parser::Source::Range]
+    #
+    def last_line_only(range)
+      if range.line != range.last_line
+        Source::Range.new(range.source_buffer,
+                          range.begin_pos + (range.source =~ /[^\n]*\Z/),
+                          range.end_pos)
+      else
+        range
+      end
     end
   end
-
 end

--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -210,6 +210,26 @@ module Parser
         @lines.fetch(lineno - @first_line).dup
       end
 
+      ##
+      # Extract line `lineno` as a new `Range`, taking `first_line` into account.
+      #
+      # @param  [Integer] lineno
+      # @return [Range]
+      # @raise  [IndexError] if `lineno` is out of bounds
+      #
+      def line_range(lineno)
+        index = lineno - @first_line + 1
+        if index <= 0 || index > line_begins.size
+          raise IndexError, 'Parser::Source::Buffer: range for line ' \
+            "#{lineno} requested, valid line numbers are #{@first_line}.." \
+            "#{@first_line + line_begins.size - 1}"
+        elsif index == line_begins.size
+          Range.new(self, line_begins[-index][1], @source.size)
+        else
+          Range.new(self, line_begins[-index][1], line_begins[-index - 1][1] - 1)
+        end
+      end
+
       private
 
       def line_begins

--- a/lib/parser/source/range.rb
+++ b/lib/parser/source/range.rb
@@ -189,6 +189,27 @@ module Parser
       end
 
       ##
+      # @param [Range] other
+      # @return [Range] overlapping region of this range and `other`, or `nil`
+      #   if they do not overlap
+      #
+      def intersect(other)
+        unless disjoint?(other)
+          Range.new(@source_buffer,
+            [@begin_pos, other.begin_pos].max,
+            [@end_pos,   other.end_pos].min)
+        end
+      end
+
+      ##
+      # @param [Range] other
+      # @return [Boolean] `true` if this range and `other` do not overlap
+      #
+      def disjoint?(other)
+        @begin_pos >= other.end_pos || other.begin_pos >= @end_pos
+      end
+
+      ##
       # Compares ranges.
       # @return [Boolean]
       #

--- a/lib/parser/source/range.rb
+++ b/lib/parser/source/range.rb
@@ -31,6 +31,10 @@ module Parser
       # @param [Integer] end_pos
       #
       def initialize(source_buffer, begin_pos, end_pos)
+        if end_pos < begin_pos
+          raise ArgumentError, 'Parser::Source::Range: end_pos must not be less than begin_pos'
+        end
+
         @source_buffer       = source_buffer
         @begin_pos, @end_pos = begin_pos, end_pos
 

--- a/lib/parser/source/rewriter.rb
+++ b/lib/parser/source/rewriter.rb
@@ -159,25 +159,10 @@ module Parser
       private
 
       def append(action)
-        if (clobber_action = clobbered?(action.range))
-          # cannot replace 3 characters with "foobar"
-          diagnostic = Diagnostic.new(:error,
-                                      :invalid_action,
-                                      { :action => action },
-                                      action.range)
-          @diagnostics.process(diagnostic)
-
-          # clobbered by: remove 3 characters
-          diagnostic = Diagnostic.new(:note,
-                                      :clobbered,
-                                      { :action => clobber_action },
-                                      clobber_action.range)
-          @diagnostics.process(diagnostic)
-
-          raise ClobberingError, "Parser::Source::Rewriter detected clobbering"
+        if (clobber_actions = clobbered?(action.range))
+          handle_clobber(action, clobber_actions)
         else
           clobber(action.range)
-
           active_queue << action
         end
 
@@ -190,10 +175,77 @@ module Parser
 
       def clobbered?(range)
         if active_clobber & ((2 ** range.size - 1) << range.begin_pos) != 0
-          active_queue.find do |action|
-            action.range.to_a & range.to_a
+          active_queue.select do |action|
+            action.range.end_pos > range.begin_pos &&
+              range.end_pos > action.range.begin_pos
           end
         end
+      end
+
+      def handle_clobber(action, existing)
+        if can_merge?(action, existing)
+          merge_actions!(action, existing)
+        else
+          # cannot replace 3 characters with "foobar"
+          diagnostic = Diagnostic.new(:error,
+                                      :invalid_action,
+                                      { :action => action },
+                                      action.range)
+          @diagnostics.process(diagnostic)
+
+          # clobbered by: remove 3 characters
+          diagnostic = Diagnostic.new(:note,
+                                      :clobbered,
+                                      { :action => existing[0] },
+                                      existing[0].range)
+          @diagnostics.process(diagnostic)
+
+          raise ClobberingError, "Parser::Source::Rewriter detected clobbering"
+        end
+      end
+
+      def can_merge?(action, existing)
+        existing.all? do |other|
+          overlap       = action.range.intersect(other.range)
+          action_offset = overlap.begin_pos - action.range.begin_pos
+          other_offset  = overlap.begin_pos - other.range.begin_pos
+
+          replacement1 = action.replacement[action_offset, overlap.size] || ''
+          replacement2 = other.replacement[other_offset, overlap.size] || ''
+          replacement1 == replacement2
+        end
+      end
+
+      def merge_actions!(action, existing)
+        actions      = existing.push(action).sort_by { |a| a.range.begin_pos }
+        merged_begin = actions.map { |act| act.range.begin_pos }.min
+        merged_end   = actions.map { |act| act.range.end_pos }.max
+        range        = Source::Range.new(@source_buffer,
+                                         merged_begin,
+                                         merged_end)
+        clobber(range)
+
+        replacement = merge_replacements(actions)
+        replace_actions(actions, Rewriter::Action.new(range, replacement))
+      end
+
+      def replace_actions(old, updated)
+        old.each { |act| active_queue.delete(act) }
+        active_queue << updated
+      end
+
+      def merge_replacements(actions)
+        # `actions` must be sorted by beginning position
+        begin_pos = actions.first.range.begin_pos
+        result    = ''
+
+        actions.each do |act|
+          offset = result.size - act.range.begin_pos + begin_pos
+          next if offset < 0 || offset >= act.replacement.size
+          result << act.replacement[offset..-1]
+        end
+
+        result
       end
 
       def in_transaction?

--- a/test/test_diagnostic.rb
+++ b/test/test_diagnostic.rb
@@ -46,4 +46,27 @@ class TestDiagnostic < Minitest::Test
       '                     ~~~~ ^ ~~~~ '
     ], diag.render)
   end
+
+  def test_multiline_render
+    @buffer = Parser::Source::Buffer.new('(string)')
+    @buffer.source = "abc abc abc\ndef def def\nghi ghi ghi\n"
+
+    location = Parser::Source::Range.new(@buffer, 4, 27)
+
+    highlights = [
+      Parser::Source::Range.new(@buffer, 0, 3),
+      Parser::Source::Range.new(@buffer, 28, 31)
+    ]
+
+    diag = Parser::Diagnostic.new(:error, :unexpected_token, { :token => 'ghi' },
+                                  location, highlights)
+
+    assert_equal([
+      "(string):1:5-3:3: error: unexpected token ghi",
+      '(string):1: abc abc abc',
+      '(string):1: ~~~ ^^^^^^^...',
+      '(string):3: ghi ghi ghi',
+      '(string):3: ^^^ ~~~    '
+    ], diag.render)
+  end
 end

--- a/test/test_source_buffer.rb
+++ b/test/test_source_buffer.rb
@@ -100,4 +100,20 @@ class TestSourceBuffer < Minitest::Test
     assert_equal '1', @buffer.source_line(5)
     assert_equal 'foo', @buffer.source_line(6)
   end
+
+  def test_line_range
+    @buffer = Parser::Source::Buffer.new('(string)', 5)
+    @buffer.source = "abc\ndef\nghi\n"
+
+    assert_raises IndexError do
+      @buffer.line_range(4)
+    end
+    assert_equal 'abc', @buffer.line_range(5).source
+    assert_equal 'def', @buffer.line_range(6).source
+    assert_equal 'ghi', @buffer.line_range(7).source
+    assert_equal '', @buffer.line_range(8).source
+    assert_raises IndexError do
+      @buffer.line_range(9)
+    end
+  end
 end

--- a/test/test_source_range.rb
+++ b/test/test_source_range.rb
@@ -18,6 +18,12 @@ class TestSourceRange < Minitest::Test
     assert_equal 2, sr.size
   end
 
+  def test_bad_size
+    assert_raises ArgumentError do
+      Parser::Source::Range.new(@buf, 2, 1)
+    end
+  end
+
   def test_join
     sr1 = Parser::Source::Range.new(@buf, 1, 2)
     sr2 = Parser::Source::Range.new(@buf, 5, 8)

--- a/test/test_source_range.rb
+++ b/test/test_source_range.rb
@@ -33,6 +33,28 @@ class TestSourceRange < Minitest::Test
     assert_equal 8, sr.end_pos
   end
 
+  def test_intersect
+    sr1 = Parser::Source::Range.new(@buf, 1, 3)
+    sr2 = Parser::Source::Range.new(@buf, 2, 6)
+    sr3 = Parser::Source::Range.new(@buf, 5, 8)
+
+    assert_equal 2, sr1.intersect(sr2).begin_pos
+    assert_equal 3, sr1.intersect(sr2).end_pos
+    assert_equal 5, sr2.intersect(sr3).begin_pos
+    assert_equal 6, sr2.intersect(sr3).end_pos
+    assert sr1.intersect(sr3) == nil
+  end
+
+  def test_disjoint
+    sr1 = Parser::Source::Range.new(@buf, 1, 3)
+    sr2 = Parser::Source::Range.new(@buf, 2, 6)
+    sr3 = Parser::Source::Range.new(@buf, 5, 8)
+
+    assert sr1.disjoint?(sr3)
+    assert !sr1.disjoint?(sr2)
+    assert !sr2.disjoint?(sr3)
+  end
+
   def test_line
     sr = Parser::Source::Range.new(@buf, 7, 8)
     assert_equal 2, sr.line

--- a/test/test_source_rewriter.rb
+++ b/test/test_source_rewriter.rb
@@ -111,6 +111,42 @@ class TestSourceRewriter < Minitest::Test
     assert rescued
   end
 
+  def test_overlapping_delete
+    assert_equal 'faz',
+                 @rewriter.
+                   remove(range(1, 4)).
+                   remove(range(6, 3)).
+                   remove(range(4, 3)).
+                   process
+  end
+
+  def test_overlapping_replace
+    assert_equal 'flippin flyin flapjackz',
+                 @rewriter.
+                   replace(range(1, 4), 'lippin f').
+                   replace(range(4, 4), 'pin flyin flap').
+                   replace(range(7, 3), ' flyin flapjack').
+                   process
+  end
+
+  def test_subsuming_delete
+    assert_equal 'foo',
+                 @rewriter.
+                   remove(range(6, 3)).
+                   remove(range(7, 2)).
+                   remove(range(3, 8)).
+                   process
+  end
+
+  def test_subsuming_replace
+    assert_equal 'freebie',
+                 @rewriter.
+                   replace(range(3, 3), 'ebi').
+                   replace(range(1, 10), 'reebie').
+                   replace(range(5, 2), 'ie').
+                   process
+  end
+
   def test_transaction_returns_self
     assert_equal @rewriter, @rewriter.transaction {}
   end


### PR DESCRIPTION
I just ran into a couple problems when working on some RuboCop code which prompted me to make these enhancements.

It started with a RC cop which deletes some unneeded things. In some circumstances, it may try to autocorrect overlapping ranges of code. This causes `parser` to vomit up a `ClobberingError`.

The thing is that there is no conflict at all between the overlapping edits. They are just all deleting code anyways. So this PR amends `Rewriter` so that it is smart enough to notice when there is no conflict between overlapping deletions *or* replacements, and merge them when possible.

Another thing: some of those deletions span newlines. So at first, I couldn't even see that the problem was a `ClobberingError`, because `Diagnostic#render` calls `column_range`, and that fails if the `Range` spans more than one line.

To avoid such annoyances, make `Diagnostic` aware of the fact that ranges may span more than one line, and specifically make it only attempt to display (and highlight) the first line in the erroneous range.