### PR TITLE
* bump warnings to 2.1.8 and 2.2.4

### DIFF
--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -34,16 +34,16 @@ module Parser
     CurrentRuby = Ruby20
 
   when /^2\.1\./
-    if RUBY_VERSION != '2.1.7'
-      warn_syntax_deviation 'parser/ruby21', '2.1.7'
+    if RUBY_VERSION != '2.1.8'
+      warn_syntax_deviation 'parser/ruby21', '2.1.8'
     end
 
     require 'parser/ruby21'
     CurrentRuby = Ruby21
 
   when /^2\.2\./
-    if RUBY_VERSION != '2.2.3'
-      warn_syntax_deviation 'parser/ruby22', '2.2.3'
+    if RUBY_VERSION != '2.2.4'
+      warn_syntax_deviation 'parser/ruby22', '2.2.4'
     end
 
     require 'parser/ruby22'

--- a/lib/parser/version.rb
+++ b/lib/parser/version.rb
@@ -1,3 +1,3 @@
 module Parser
-  VERSION = '2.3.0.pre.5'
+  VERSION = '2.3.0.pre.6'
 end


### PR DESCRIPTION
Ruby versions 2.1.8 and 2.2.4 were released yesterday:

  * https://www.ruby-lang.org/en/news/2015/12/16/ruby-2-1-8-released/
  * https://www.ruby-lang.org/en/news/2015/12/16/ruby-2-2-4-released/