### PR TITLE
Add Source::Buffer#last_line

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -230,6 +230,15 @@ module Parser
         end
       end
 
+      ##
+      # Number of last line in the buffer
+      #
+      # @return [Integer]
+      #
+      def last_line
+        line_begins.size + @first_line - 1
+      end
+
       private
 
       def line_begins

--- a/test/test_source_buffer.rb
+++ b/test/test_source_buffer.rb
@@ -116,4 +116,17 @@ class TestSourceBuffer < Minitest::Test
       @buffer.line_range(9)
     end
   end
+
+  def test_last_line
+    @buffer.source = "1\nfoo\nbar"
+    assert_equal 3, @buffer.last_line
+
+    @buffer = Parser::Source::Buffer.new('(string)', 5)
+    @buffer.source = ""
+    assert_equal 5, @buffer.last_line
+
+    @buffer = Parser::Source::Buffer.new('(string)', 5)
+    @buffer.source = "abc\n"
+    assert_equal 6, @buffer.last_line
+  end
 end


### PR DESCRIPTION
Buffer already has `#first_line`. `#last_line` is symmetrical with
`#first_line`, and will be generally useful. (Specifically, it will be helpful
with some work I am doing on RuboCop.)