### PR TITLE
Add Source::Buffer#lines

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -191,6 +191,26 @@ module Parser
       end
 
       ##
+      # Return an `Array` of source code lines.
+      #
+      # @return [Array<String>]
+      #
+      def source_lines
+        @lines ||= begin
+          # If a file ends with a newline, the EOF token will appear
+          # to be one line further than the end of file.
+          lines = @source.lines.to_a.push('')
+
+          lines.each do |line|
+            line.chomp!(NEW_LINE)
+            line.freeze
+          end
+
+          lines.freeze
+        end
+      end
+
+      ##
       # Extract line `lineno` from source, taking `first_line` into account.
       #
       # @param  [Integer] lineno
@@ -198,16 +218,7 @@ module Parser
       # @raise  [IndexError] if `lineno` is out of bounds
       #
       def source_line(lineno)
-        unless @lines
-          @lines = @source.lines.to_a
-          @lines.each { |line| line.chomp!(NEW_LINE) }
-
-          # If a file ends with a newline, the EOF token will appear
-          # to be one line further than the end of file.
-          @lines << ""
-        end
-
-        @lines.fetch(lineno - @first_line).dup
+        source_lines.fetch(lineno - @first_line).dup
       end
 
       ##

--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -197,9 +197,8 @@ module Parser
       #
       def source_lines
         @lines ||= begin
-          # If a file ends with a newline, the EOF token will appear
-          # to be one line further than the end of file.
-          lines = @source.lines.to_a.push('')
+          lines = @source.lines.to_a
+          lines << '' if @source.end_with?("\n")
 
           lines.each do |line|
             line.chomp!(NEW_LINE)

--- a/test/test_source_buffer.rb
+++ b/test/test_source_buffer.rb
@@ -129,4 +129,12 @@ class TestSourceBuffer < Minitest::Test
     @buffer.source = "abc\n"
     assert_equal 6, @buffer.last_line
   end
+
+  def test_source_lines
+    @buffer.source = "1\nfoo\nbar\n"
+
+    assert_equal ['1', 'foo', 'bar', ''], @buffer.source_lines
+    assert @buffer.source_lines.frozen?
+    assert @buffer.source_lines.all?(&:frozen?)
+  end
 end

--- a/test/test_source_buffer.rb
+++ b/test/test_source_buffer.rb
@@ -136,5 +136,9 @@ class TestSourceBuffer < Minitest::Test
     assert_equal ['1', 'foo', 'bar', ''], @buffer.source_lines
     assert @buffer.source_lines.frozen?
     assert @buffer.source_lines.all?(&:frozen?)
+
+    @buffer = Parser::Source::Buffer.new('(string)', 5)
+    @buffer.source = "foo\nbar"
+    assert_equal ['foo', 'bar'], @buffer.source_lines
   end
 end


### PR DESCRIPTION
@whitequark Please have a look at this and see if you want it. Commit log message:

Almost any application which processes Ruby source code will want to access
specific lines. `Buffer#source_line` is provided for that purpose; however,
sometimes one wants an `Enumerable` object, which `#map`, `#select`, and so
on can be called on.

`Parser::Source::Buffer` already maintains such an array, but it wasn't exposed.
This caused RuboCop to maintain its own array of lines for each `Buffer`,
at a not-insignificant performance cost.

Exposing the `@lines` array to client code means that it and its contents must
all be frozen to prevent unwanted mutation. This means that accessing source
lines using `#lines` is more efficient than `#source_line`, since there is no
extra copying.