### PR TITLE
Ruby has no such thing as backslash-delimited strings

### DIFF
--- a/lib/parser/lexer/literal.rb
+++ b/lib/parser/lexer/literal.rb
@@ -102,6 +102,10 @@ module Parser
       !!@heredoc_e
     end
 
+    def backslash_delimited?
+      @end_delim == '\\'
+    end
+
     def type
       @start_tok
     end

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -2159,6 +2159,48 @@ class TestLexer < Minitest::Test
                    :tSTRING_END,     ')')
   end
 
+  def test_string_pct_backslash
+    assert_scanned("%\\a\\",
+                   :tSTRING_BEG, "%\\",
+                   :tSTRING_CONTENT, "a",
+                   :tSTRING_END, "\\")
+  end
+
+  def test_string_pct_backslash_with_bad_escape
+    # No escapes are allowed in a backslash-delimited string
+    refute_scanned("%\\a\\n\\",
+                   :tSTRING_BEG, "%\\",
+                   :tSTRING_CONTENT, "a",
+                   :tSTRING_END, "\\",
+                   :tIDENTIFIER, "n")
+  end
+
+  def test_string_pct_intertwined_with_heredoc
+    assert_scanned("<<-foo + %\\a\nbar\nfoo\nb\\",
+                   :tSTRING_BEG, "<<\"",
+                   :tSTRING_CONTENT, "bar\n",
+                   :tSTRING_END, "foo",
+                   :tPLUS, "+",
+                   :tSTRING_BEG, "%\\",
+                   :tSTRING_CONTENT, "a\n",
+                   :tSTRING_CONTENT, "b",
+                   :tSTRING_END, "\\")
+  end
+
+  def test_string_pct_q_backslash
+    assert_scanned("%q\\a\\",
+                   :tSTRING_BEG, "%q\\",
+                   :tSTRING_CONTENT, "a",
+                   :tSTRING_END, "\\")
+  end
+
+  def test_string_pct_Q_backslash
+    assert_scanned("%Q\\a\\",
+                   :tSTRING_BEG, "%Q\\",
+                   :tSTRING_CONTENT, "a",
+                   :tSTRING_END, "\\")
+  end
+
   def test_string_single
     assert_scanned("'string'",
                    :tSTRING, "string")


### PR DESCRIPTION
Hey, @whitequark, please check and see if I'm totally off base here.

If I am right about this, then I think the only reason to store error lambdas in `@escape` rather than just calling `diagnostic` directly has just disappeared.