### PR TITLE
Moving forward

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -841,7 +841,6 @@ class Parser::Lexer
     # tLABEL_END is only possible in non-cond context on >= 2.2
     if @version >= 22 && !@cond.active?
       lookahead = @source[@te...@te+2]
-      lookahead = lookahead.encode(@encoding) if @need_encode
     end
 
     current_literal = literal

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -299,6 +299,16 @@ class TestLexer < Minitest::Test
                    :tLABEL_END,       "'")
   end
 
+  def test_label_with_utf32_encoded_source__22
+    setup_lexer 22
+    @lex.force_utf32 = true
+    assert_scanned("{'a':",
+                   :tLBRACE,          '{',
+                   :tSTRING_BEG,      "'",
+                   :tSTRING_CONTENT,  'a',
+                   :tLABEL_END,       "'")
+  end
+
   def test_label_colon2__22
     setup_lexer 22
 


### PR DESCRIPTION
Please have a look.

On `lib/parser/lexer.rb`, which hardly contains a single string literal, this lexer (with special states for single-quoted and double-quoted strings) is about 5% slower. But on `lib/parser/ruby18.rb`, which has LOTS of single-quoted string literals, it is somewhat less than 2x faster.

My highly scientific "lex a file 10 times" benchmark measures 4.6 secs on `ruby18.rb`, down from 8.7 secs on `master`.