### PR TITLE
- Add :csend to Parser::Meta::NODE_TYPES

### DIFF
--- a/lib/parser/meta.rb
+++ b/lib/parser/meta.rb
@@ -16,7 +16,7 @@ module Parser
         match_with_lvasgn match_current_line
         module class sclass def defs undef alias args
         cbase arg optarg restarg blockarg block_pass args def kwarg kwoptarg
-        kwrestarg send super zsuper yield block send
+        kwrestarg send csend super zsuper yield block
         and not or if when case while until while_post
         until_post for break next redo return resbody
         kwbegin begin retry preexe postexe iflipflop eflipflop


### PR DESCRIPTION
Also fixes a duplicate `send` member.