### PR TITLE
Lexer emits string/symbol literals in source file encoding

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -95,9 +95,7 @@ module Parser
         elsif detected_encoding == Encoding::BINARY
           input
         else
-          input.
-            force_encoding(detected_encoding).
-            encode(Encoding::UTF_8)
+          input.force_encoding(detected_encoding)
         end
       end
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -4976,10 +4976,11 @@ class TestParser < Minitest::Test
     end
 
     def test_magic_encoding_comment
+      funny_russian_sym = "проверка".encode(Encoding::KOI8_R).to_sym
       assert_parses(
         s(:begin,
-          s(:lvasgn, :"проверка", s(:int, 42)),
-          s(:send, nil, :puts, s(:lvar, :"проверка"))),
+          s(:lvasgn, funny_russian_sym, s(:int, 42)),
+          s(:send, nil, :puts, s(:lvar, funny_russian_sym))),
         %Q{# coding:koi8-r
            \xd0\xd2\xcf\xd7\xc5\xd2\xcb\xc1 = 42
            puts \xd0\xd2\xcf\xd7\xc5\xd2\xcb\xc1}.
@@ -5335,5 +5336,22 @@ class TestParser < Minitest::Test
     assert_parses(
       s(:regexp, s(:str, "#)"), s(:regopt, :x)),
       %Q{/#)/x})
+  end
+
+  def test_bug_non_utf8_symbol_literal
+    # "\xC7" is actually invalid in US-ASCII, but Ruby allows the conversion of
+    # this invalid string to a symbol, regardless if you do so using
+    # `String#to_sym` or if you have :"\xC7" appear as a literal in a US-ASCII
+    # encoded source file.
+    #
+    # If it was UTF-8, we would get an EncodingError.
+
+    bad_symbol = "\xC7".force_encoding(Encoding::US_ASCII).to_sym
+    assert_parses(
+      s(:send, nil, :puts, s(:sym, bad_symbol)),
+      %q{# encoding: us-ascii
+         puts :"\\xC7"},
+      %q{},
+      ALL_VERSIONS - %w(1.8))
   end
 end


### PR DESCRIPTION
Previously, even if you had an encoding comment like:

    # encoding: us-ascii

...The string/symbol literals created by the lexer would be UTF-8 encoded.