### PR TITLE
Make Buffer#line_begins fly

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -253,14 +253,11 @@ module Parser
 
       def line_begins
         unless @line_begins
-          @line_begins, index = [ [ 0, 0 ] ], 1
+          @line_begins, index = [ [ 0, 0 ] ], 0
 
-          @source.each_char do |char|
-            if char == NEW_LINE
-              @line_begins.unshift [ @line_begins.length, index ]
-            end
-
+          while index = @source.index("\n".freeze, index)
             index += 1
+            @line_begins.unshift [ @line_begins.length, index ]
           end
         end
 


### PR DESCRIPTION
The existing code uses `String#each_char`, which allocates a new string object for **each** character in the source file. (This is the #2 source of object allocations in RuboCop.) It also uses a lot of (slow) Ruby method calls.

Switching to `String#index` increases the performance of `Source::Buffer#line_begins` by a factor of more than 20.