### PR TITLE
Source::Rewriter handles clobbering correctly for insertions

### DIFF
--- a/test/test_source_rewriter.rb
+++ b/test/test_source_rewriter.rb
@@ -56,16 +56,262 @@ class TestSourceRewriter < Minitest::Test
                     process
   end
 
-  def test_multiple_insertions_at_same_location
-    assert_equal '<([foo] bar) baz>',
-                 @rewriter.
-                   insert_before(range(0, 11), '<').
-                   insert_after( range(0, 11), '>').
-                   insert_before(range(0, 7), '(').
-                   insert_after( range(0, 7), ')').
-                   insert_before(range(0, 3), '[').
-                   insert_after( range(0, 3), ']').
-                   process
+  #
+  # Merging/clobbering of overlapping edits
+  #
+
+  def test_insertion_just_before_replace
+    assert_equal 'foostrawberry jam---bar baz',
+      @rewriter.
+        replace(range(3, 1), '---').
+        insert_before(range(3, 1), 'strawberry jam').
+        process
+  end
+
+  def test_insertion_just_after_replace
+    assert_equal 'foo---strawberry jam baz',
+      @rewriter.
+        replace(range(3, 4), '---').
+        insert_after(range(3, 4), 'strawberry jam').
+        process
+  end
+
+  def test_insertion_just_before_remove
+    assert_equal 'foostrawberry jambar baz',
+      @rewriter.
+        remove(range(3, 1)).
+        insert_before(range(3, 1), 'strawberry jam').
+        process
+  end
+
+  def test_insertion_just_after_remove
+    assert_equal 'foostrawberry jam baz',
+      @rewriter.
+        remove(range(3, 4)).
+        insert_after(range(3, 4), 'strawberry jam').
+        process
+  end
+
+  def test_insertion_just_before_replace_at_buffer_start
+    assert_equal 'strawberry jam--- bar baz',
+      @rewriter.
+        replace(range(0, 3), '---').
+        insert_before(range(0, 1), 'strawberry jam').
+        process
+  end
+
+  def test_insertion_just_after_replace_at_buffer_end
+    assert_equal 'foo bar ---strawberry jam',
+      @rewriter.
+        replace(range(8, 3), '---').
+        insert_after(range(9, 2), 'strawberry jam').
+        process
+  end
+
+  def test_insertion_just_before_remove_at_buffer_start
+    assert_equal 'strawberry bar baz',
+      @rewriter.
+        remove(range(0, 3)).
+        insert_before(range(0, 1), 'strawberry').
+        process
+  end
+
+  def test_insertion_just_after_remove_at_buffer_end
+    assert_equal 'foo bar strawberry',
+      @rewriter.
+        remove(range(8, 3)).
+        insert_after(range(10, 1), 'strawberry').
+        process
+  end
+
+  def test_multiple_insertions_at_same_location_clobber
+    silence_diagnostics
+
+    assert_raises Parser::ClobberingError do
+      @rewriter.
+        insert_before(range(0, 11), '<').
+        insert_after( range(0, 11), '>').
+        insert_before(range(0, 7), '(')
+    end
+  end
+
+  def test_insertion_within_replace_clobber
+    silence_diagnostics
+
+    assert_raises Parser::ClobberingError do
+      @rewriter.
+        replace(range(3, 2), '<').
+        insert_after(range(3, 1), '>')
+    end
+  end
+
+  def test_insertion_within_remove_clobber
+    silence_diagnostics
+
+    assert_raises Parser::ClobberingError do
+      @rewriter.
+        remove(range(3, 2)).
+        insert_after(range(3, 1), '>')
+    end
+  end
+
+  def test_replace_overlapping_insertion_clobber
+    silence_diagnostics
+
+    assert_raises Parser::ClobberingError do
+      @rewriter.
+        insert_after(range(3, 1), '>').
+        replace(range(3, 2), '<')
+    end
+  end
+
+  def test_remove_overlapping_insertion_clobber
+    silence_diagnostics
+
+    assert_raises Parser::ClobberingError do
+      @rewriter.
+        insert_after(range(3, 1), '>').
+        remove(range(3, 2))
+    end
+  end
+
+  def test_insertion_on_merged_insertion_clobber
+    # 2 insertions at the same point clobber each other, even if the 1st one
+    # was merged with an adjacent edit, and even if the same text is being
+    # inserted
+
+    silence_diagnostics
+
+    assert_raises Parser::ClobberingError do
+      @rewriter.
+        insert_before(range(3, 1), '>').
+        remove(range(3, 2)).
+        insert_after(range(2, 1), '>')
+    end
+  end
+
+  def test_insertion_merge_with_overlapping_replace
+    assert_equal 'fo abc bar baz',
+      @rewriter.
+        insert_before(range(3, 1), 'abc').
+        replace(range(2, 2), ' abc ').
+        process
+  end
+
+  def test_replace_merge_with_overlapped_insertion
+    assert_equal 'fo abc bar baz',
+      @rewriter.
+        replace(range(2, 2), ' abc ').
+        insert_before(range(3, 1), 'abc').
+        process
+  end
+
+  def test_replace_same_begin_larger_than_replaced_range_matching
+    assert_equal 'foo supercalifragilistic baz',
+      @rewriter.
+        replace(range(4, 3), 'super').
+        replace(range(4, 3), 'supercalifragilistic').
+        process
+  end
+
+  def test_replace_same_begin_larger_than_replaced_range_non_matching
+    silence_diagnostics
+
+    assert_raises Parser::ClobberingError do
+      @rewriter.
+        replace(range(4, 3), 'super!').
+        replace(range(4, 3), 'supercalifragilistic')
+    end
+  end
+
+  def test_overlapping_replace_left_smaller_than_replaced_matching
+    assert_equal 'superbaz',
+      @rewriter.
+        replace(range(0, 7), 'super').
+        replace(range(2, 6), 'per').
+        process
+  end
+
+  def test_overlapping_replace_left_smaller_than_replaced_non_matching
+    silence_diagnostics
+
+    assert_raises Parser::ClobberingError do
+      @rewriter.
+        replace(range(0, 7), 'super').
+        replace(range(2, 8), 'perk')
+    end
+  end
+
+  def test_overlapping_replace_left_larger_right_smaller_matching
+    assert_equal 'foods baz',
+      @rewriter.
+        replace(range(1, 3), 'oods ').
+        replace(range(3, 6), 'ds b').
+        process
+  end
+
+  def test_overlapping_replace_left_larger_right_larger_matching
+    assert_equal 'foods abcdefghijklm',
+      @rewriter.
+        replace(range(1, 3), 'oods ').
+        replace(range(3, 8), 'ds abcdefghijklm').
+        process
+  end
+
+  def test_overlapping_replace_left_larger_right_smaller_non_matching
+    silence_diagnostics
+
+    assert_raises Parser::ClobberingError do
+      @rewriter.
+        replace(range(1, 3), 'oods ').
+        replace(range(3, 6), 'ds')
+    end
+  end
+
+  def test_overlapping_replace_left_larger_right_larger_non_matching
+    silence_diagnostics
+
+    assert_raises Parser::ClobberingError do
+      @rewriter.
+        replace(range(1, 3), 'oods b').
+        replace(range(3, 8), 'ds abcdefghijklm')
+    end
+  end
+
+  def test_subsuming_replace_both_smaller_matching
+    assert_equal 'food baz',
+      @rewriter.
+        replace(range(0, 7), 'food').
+        replace(range(3, 3), 'd').
+        process
+  end
+
+  def test_subsuming_replace_both_smaller_non_matching
+    silence_diagnostics
+
+    assert_raises Parser::ClobberingError do
+      @rewriter.
+        replace(range(0, 7), 'foo').
+        replace(range(3, 3), 'd')
+    end
+  end
+
+  def test_subsuming_replace_both_larger_matching
+    assert_equal 'foo barr baz',
+      @rewriter.
+        replace(range(0, 7), 'foo barr').
+        replace(range(3, 3), ' bar').
+        process
+  end
+
+  def test_subsuming_replace_both_larger_non_matching
+    silence_diagnostics
+
+    assert_raises Parser::ClobberingError do
+      @rewriter.
+        replace(range(0, 7), 'foo barr').
+        replace(range(3, 3), ' bar ')
+    end
   end
 
   def test_clobber
@@ -111,6 +357,7 @@ class TestSourceRewriter < Minitest::Test
     assert rescued
   end
 
+
   def test_overlapping_delete
     assert_equal 'faz',
                  @rewriter.
@@ -145,6 +392,18 @@ class TestSourceRewriter < Minitest::Test
                    replace(range(1, 10), 'reebie').
                    replace(range(5, 2), 'ie').
                    process
+  end
+
+  def test_equivalent_delete_insert_replace
+    # A deletion + insertion just before or after the deleted range is
+    # identical in every way to a replacement! So logically, they shouldn't
+    # conflict.
+    assert_equal 'tin bar baz',
+      @rewriter.
+        remove(range(0, 3)).  # ' bar baz'
+        insert_before(range(0, 1), 'tin'). # 'tin bar baz'
+        replace(range(0, 3), 'tin').
+        process
   end
 
   def test_transaction_returns_self


### PR DESCRIPTION
Previously, insertions ("replacements" of a zero-length range) would never
clobber or be clobbered by anything, even if they landed right in the middle
of a replaced or deleted range of text. As can easily be seen, this makes a
mess and should give rise to a clobbering error.

The tricky thing is that an insertion can legitimately appear at the very
beginning or very end of a replaced or deleted range. If it is in the middle,
though, that is definitely wrong and should cause an error. (Unless it appears
in the middle of a replaced range, and the replacement is longer than the
replaced text by the length of the insertion or more, and the replacement has
the same effect as the insertion.)

Additionally, two insertions at the very same point should also clobber each
other. Why? Well, how do we know which inserted text should come before the
other? We don't. And if the inserted texts are identical, how do we know if
the intention was to add one or two copies of that text? Again, we don't. It's
safer to just flag this as clobbering.

Additionally, there were some cases where the previous code would merge edits
which should really have raised a clobbering error. It is now more robust all
around, and close to 30 new unit tests have been added to verify its behavior.