### PR TITLE
Fix broken build on MRI 2.3

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -1668,7 +1668,7 @@ class Parser::Lexer
 
         indent      = !$1.empty? || !$2.empty?
         dedent_body = !$2.empty?
-        type        =  $3.empty? ? '<<"'.freeze : ('<<' << $3)
+        type        =  $3.empty? ? '<<"'.freeze : ('<<'.freeze + $3)
         delimiter   =  $4
 
         if dedent_body && version?(18, 19, 20, 21, 22)


### PR DESCRIPTION
Sorry and thanks for pointing out my mistake!

bb0f0e6 modified the lexer in one place to build a string using `String#<<` on
a string literal. Since lexer.rb includes a `frozen_string_literal: true`
comment, this would fail on MRI 2.3.