### PR TITLE
Cache line/column numbers for fast lookup in Source::Buffer

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -106,6 +106,10 @@ module Parser
 
         @lines       = nil
         @line_begins = nil
+
+        # Cache for fast lookup
+        @line_for_position = {}
+        @col_for_position  = {}
       end
 
       ##
@@ -186,6 +190,34 @@ module Parser
         line_no, line_begin = line_for(position)
 
         [ @first_line + line_no, position - line_begin ]
+      end
+
+      ##
+      # Convert a character index into the source to a line number.
+      #
+      # @param  [Integer] position
+      # @return [Integer] line
+      # @api private
+      #
+      def line_for_position(position)
+        @line_for_position[position] ||= begin
+          line_no, _ = line_for(position)
+          @first_line + line_no
+        end
+      end
+
+      ##
+      # Convert a character index into the source to a column number.
+      #
+      # @param  [Integer] position
+      # @return [Integer] column
+      # @api private
+      #
+      def column_for_position(position)
+        @col_for_position[position] ||= begin
+          _, line_begin = line_for(position)
+          position - line_begin
+        end
       end
 
       ##

--- a/lib/parser/source/range.rb
+++ b/lib/parser/source/range.rb
@@ -77,9 +77,7 @@ module Parser
       # @return [Integer] line number of the beginning of this range.
       #
       def line
-        line, _ = @source_buffer.decompose_position(@begin_pos)
-
-        line
+        @source_buffer.line_for_position(@begin_pos)
       end
 
       alias_method :first_line, :line
@@ -88,27 +86,21 @@ module Parser
       # @return [Integer] zero-based column number of the beginning of this range.
       #
       def column
-        _, column = @source_buffer.decompose_position(@begin_pos)
-
-        column
+        @source_buffer.column_for_position(@begin_pos)
       end
 
       ##
       # @return [Integer] line number of the end of this range.
       #
       def last_line
-        line, _ = @source_buffer.decompose_position(@end_pos)
-
-        line
+        @source_buffer.line_for_position(@end_pos)
       end
 
       ##
       # @return [Integer] zero-based column number of the end of this range.
       #
       def last_column
-        _, column = @source_buffer.decompose_position(@end_pos)
-
-        column
+        @source_buffer.column_for_position(@end_pos)
       end
 
       ##


### PR DESCRIPTION
This halves the time which RuboCop spends in `Range#line`.

...Which will probably not be enough, eventually. But for now, it's good. That's why I annotated the added methods as `@api private` -- we may come up with something better later.

(It turns out that tracking the line numbers in the lexer is even more difficult than I thought. The handling of newlines would have to be completely reworked, and I have better things to work on.)

Closes #260.