### PR TITLE
Testing UTF-32LE

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -82,10 +82,10 @@ class Parser::Lexer
   # %
 
   ESCAPES = {
-    'a' => "\a", 'b'  => "\b", 'e'  => "\e", 'f' => "\f",
-    'n' => "\n", 'r'  => "\r", 's'  => "\s", 't' => "\t",
-    'v' => "\v", '\\' => "\\"
-  }
+    ?a.ord => "\a", ?b.ord  => "\b", ?e.ord => "\e", ?f.ord => "\f",
+    ?n.ord => "\n", ?r.ord  => "\r", ?s.ord => "\s", ?t.ord => "\t",
+    ?v.ord => "\v", ?\\.ord => "\\"
+  }.freeze
 
   REGEXP_META_CHARACTERS = Regexp.union(*"\\$()*+.<>?[]^{|}".chars).freeze
 
@@ -689,8 +689,8 @@ class Parser::Lexer
   }
 
   action unescape_char {
-    char = @source[p - 1].chr
-    @escape = ESCAPES.fetch(char, char)
+    codepoint = @source_pts[p - 1]
+    @escape = ESCAPES[codepoint] || encode_escape(codepoint)
   }
 
   action invalid_complex_escape {

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -1630,7 +1630,7 @@ class Parser::Lexer
       # /=/ (disambiguation with /=)
       '/' c_any
       => {
-        type = delimiter = @source[@ts].chr
+        type = delimiter = tok[0].chr
         fhold; fgoto *push_literal(type, delimiter, @ts);
       };
 
@@ -1644,7 +1644,7 @@ class Parser::Lexer
       # %w(we are the people)
       '%' [A-Za-z]+ c_any
       => {
-        type, delimiter = @source[@ts...(@te - 1)], @source[@te - 1].chr
+        type, delimiter = tok[0..-2], tok[-1].chr
         fgoto *push_literal(type, delimiter, @ts);
       };
 
@@ -1690,7 +1690,7 @@ class Parser::Lexer
       # :"bar", :'baz'
       ':' ['"] # '
       => {
-        type, delimiter = tok, @source[@te - 1].chr
+        type, delimiter = tok, tok[-1].chr
         fgoto *push_literal(type, delimiter, @ts);
       };
 
@@ -2087,7 +2087,7 @@ class Parser::Lexer
       # `echo foo`, "bar", 'baz'
       '`' | ['"] # '
       => {
-        type, delimiter = tok, @source[@te - 1].chr
+        type, delimiter = tok, tok[-1].chr
         fgoto *push_literal(type, delimiter, @ts, nil, false, false, true);
       };
 


### PR DESCRIPTION
In one of my other PRs, @whitequark suggested that the parser tests should be run with the `force_utf32` flag set on the lexer. This amends the test suite to do just that; actually, it runs the parser tests both with and without `force_utf32`.

This immediately revealed that some of my optimizations to avoid string allocations were not sound, as @whitequark earlier said. The ones which break the test suite have been backed out.

Additionally, another bug was revealed: parsing escapes can break the lexer when `force_utf32` is on. The reason is that hash lookup in `ESCAPES` doesn't work when the source has been transcoded to UTF-32LE, because the keys of `ESCAPES` are not in that encoding. Then `ESCAPES.fetch(char, char)` returns the escaped char (which could be `"n"` or anything else), and it is appended to the current literal buffer, which fails with an incompatible encoding error.

Please have a look and see if you think the fix is sound.

(A bug was just reported against RC the other day which looks like this exact same bug... https://github.com/bbatsov/rubocop/issues/2751)