### PR TITLE
Improve performance parsing non-ASCII input.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -211,8 +211,14 @@ class Parser::Lexer
         # symbols, then storing the source in UTF-8 would be faster.
         #
         # Patches accepted.
-        @source = @source.encode(Encoding::UTF_32LE)
-        @need_encode = true
+        begin
+          @source = @source.encode(Encoding::UTF_32LE)
+          @need_encode = true
+        rescue EncodingError
+          # We may receive invalid UTF-8, which we will be able to
+          # re-encode. Just carry on in UTF-8, which will happily skip
+          # over invalid byte sequences and leave them as-is.
+        end
       end
 
       if @source_pts[0] == 0xfeff

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -198,7 +198,7 @@ class Parser::Lexer
       end
 
       if @has_encode &&
-        (@source_pts.size > 1_000_000 || @force_utf32) &&
+        (!@source.ascii_only? || @force_utf32) &&
         @encoding != Encoding::UTF_32LE
         # A heuristic: if the buffer is larger than 1M, then
         # store it in UTF-32 and convert the tokens as they're

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -2730,6 +2730,13 @@ class TestLexer < Minitest::Test
         assert_equal Encoding::UTF_8, str.encoding
       end
     end
+
+    def test_non_ascii_strings_are_reencoded_internally
+      setup_lexer(19)
+      assert_scanned(utf('"café"'),
+                         :tSTRING, utf("café"), [0, 6])
+      assert_equal Encoding::UTF_32LE, @lex.instance_variable_get(:@source).encoding
+    end
   end
 
   #


### PR DESCRIPTION
If the input contains high-bit codepoints, always transcode to UTF-32,
to ensure O(1) string slicing. This prevents quadratic behavior, because
string indexing and slicing is O(n) on UTF-8-encoded strings. (An
internal Ruby optimization preserves constant-time access if the string
is UTF-8-encoded but happes to only contain ASCII characters.

fixes #268