### PR TITLE
Generalize the unicode performance fixes.

### DIFF
--- a/lib/parser/lexer/literal.rb
+++ b/lib/parser/lexer/literal.rb
@@ -242,7 +242,7 @@ module Parser
       # Prime the buffer with lexer encoding; otherwise,
       # concatenation will produce varying results.
       if defined?(Encoding)
-        @buffer.force_encoding(@lexer.encoding)
+        @buffer.force_encoding(@lexer.source_buffer.source.encoding)
       end
 
       @buffer_s = nil

--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -107,6 +107,9 @@ module Parser
         @lines       = nil
         @line_begins = nil
 
+        # UTF-32-reencoded source for O(1) slicing
+        @slice_source = nil
+
         # Cache for fast lookup
         @line_for_position = {}
         @col_for_position  = {}
@@ -178,6 +181,21 @@ module Parser
         end
 
         @source = input.gsub("\r\n".freeze, "\n".freeze).freeze
+
+        if defined?(Encoding) &&
+           !@source.ascii_only? &&
+           @source.encoding != Encoding::UTF_32LE &&
+           @source.encoding != Encoding::ASCII_8BIT
+          @slice_source = @source.encode(Encoding::UTF_32LE)
+        end
+      end
+
+      def slice(range)
+        if @slice_source.nil?
+          @source[range]
+        else
+          @slice_source[range].encode(@source.encoding)
+        end
       end
 
       ##

--- a/lib/parser/source/range.rb
+++ b/lib/parser/source/range.rb
@@ -126,7 +126,7 @@ module Parser
       # @return [String] all source code covered by this range.
       #
       def source
-        @source_buffer.source[self.begin_pos...self.end_pos]
+        @source_buffer.slice(self.begin_pos...self.end_pos)
       end
 
       ##

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -2730,13 +2730,6 @@ class TestLexer < Minitest::Test
         assert_equal Encoding::UTF_8, str.encoding
       end
     end
-
-    def test_non_ascii_strings_are_reencoded_internally
-      setup_lexer(19)
-      assert_scanned(utf('"café"'),
-                         :tSTRING, utf("café"), [0, 6])
-      assert_equal Encoding::UTF_32LE, @lex.instance_variable_get(:@source).encoding
-    end
   end
 
   #


### PR DESCRIPTION
@whitequark how do you feel about this, or something like this? The last
PR essentially fixed the parser performance, but rubocop was still slow
becaue of repeated slicing of source ranges. I don't have an intuition
for whether the extra cost of indirecting through @source_buffer is too
expensive -- I realize the lexer is some of the hottest code here.

---

This is an attempt to generalize the performance gains of #269 to extend
to clients of the resulting AST.

The immediate problem is that many AST consumers (rubocop is the one I'm
currently interested in) are going to invoke
`Parser::Source::Range#source` on many of the AST nodes, and that method
has the same linear-time-slicing behavior as `Parser::Lexer#tok` did.

By pushing the re-encoding inside the `Parser::Source::Buffer`
abstraction, we make it also available to `Range`, and we simplify
`Lexer` while we're at it: A bunch of encoding bookkeeping is now hidden
inside the `Buffer#slice` abstraction.