### PR TITLE
Ensure caching hashes for line/column_for_position are initialized

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -200,6 +200,7 @@ module Parser
       # @api private
       #
       def line_for_position(position)
+        @line_for_position ||= {}
         @line_for_position[position] ||= begin
           line_no, _ = line_for(position)
           @first_line + line_no
@@ -214,6 +215,7 @@ module Parser
       # @api private
       #
       def column_for_position(position)
+        @col_for_position ||= {}
         @col_for_position[position] ||= begin
           _, line_begin = line_for(position)
           position - line_begin


### PR DESCRIPTION
It seems that buffer.line_for_position and column_for_position can be called when the caching hashes have not been initialized. 

We can see this behavior happening when parsing this file - https://github.com/theforeman/foreman/blob/develop/app/models/compute_resources/foreman/model/vmware.rb#L28

To reproduce, clone this repository - https://github.com/theforeman/foreman/pull/3164 and ensure Parser is running 2.3.0.3. You should see the following backtrace, the failure happens because line_for_position and column_for_position are nil then.

```
undefined method `[]' for nil:NilClass
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/parser-2.3.0.3/lib/parser/source/buffer.rb:203:in `line_for_position'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/parser-2.3.0.3/lib/parser/source/range.rb:80:in `line'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/parser-2.3.0.3/lib/parser/source/map.rb:98:in `line'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/lib/rubocop/cop/lint/unneeded_disable.rb:25:in `block (3 levels) in check'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/lib/rubocop/cop/lint/unneeded_disable.rb:25:in `each'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/lib/rubocop/cop/lint/unneeded_disable.rb:25:in `find'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/lib/rubocop/cop/lint/unneeded_disable.rb:25:in `block (2 levels) in check'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/lib/rubocop/cop/lint/unneeded_disable.rb:24:in `each'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/lib/rubocop/cop/lint/unneeded_disable.rb:24:in `block in check'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/lib/rubocop/cop/lint/unneeded_disable.rb:22:in `each'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/lib/rubocop/cop/lint/unneeded_disable.rb:22:in `check'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/lib/rubocop/formatter/formatter_set.rb:48:in `file_finished'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/lib/rubocop/runner.rb:98:in `process_file'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/lib/rubocop/runner.rb:58:in `block in inspect_files'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/lib/rubocop/runner.rb:56:in `each'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/lib/rubocop/runner.rb:56:in `inspect_files'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/lib/rubocop/runner.rb:34:in `run'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/lib/rubocop/cli.rb:26:in `run'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/bin/rubocop:13:in `block in <top (required)>'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/2.2.0/benchmark.rb:303:in `realtime'
/home/daniel/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.35.1/bin/rubocop:12:in `<top (required)>'
/home/daniel/.rbenv/versions/2.2.3/bin/rubocop:23:in `load'
/home/daniel/.rbenv/versions/2.2.3/bin/rubocop:23:in `<main>'
```

This is my first contribution to this repo, so if I'm missing tests, or anything else, I'd appreciate some help with that :smile: !