### PR TITLE
Merging of replace actions in Source::Rewriter produces correct replaced range

### DIFF
--- a/lib/parser/source/rewriter.rb
+++ b/lib/parser/source/rewriter.rb
@@ -376,7 +376,7 @@ module Parser
         actions = existing.push(action).sort_by do |a|
           [a.range.begin_pos, a.range.end_pos]
         end
-        range = actions.first.range.join(actions.last.range)
+        range = actions.first.range.join(actions.max_by { |a| a.range.end_pos }.range)
 
         Rewriter::Action.new(range, merge_replacements(actions))
       end

--- a/test/test_source_rewriter.rb
+++ b/test/test_source_rewriter.rb
@@ -364,6 +364,17 @@ class TestSourceRewriter < Minitest::Test
     end
   end
 
+  def test_replaced_ranges_merge_when_furthest_right_range_is_not_furthest_left
+    # regression test; previously, when actions were merged, the resulting
+    # replaced range could be too small sometimes
+    assert_equal 'foo_***_***',
+      @rewriter.
+        replace(range(3, 1), '_').
+        replace(range(7, 1), '_').
+        replace(range(4, 7), '***_***').
+        process
+  end
+
   def test_clobber
     diagnostics = []
     @rewriter.diagnostics.consumer = lambda do |diag|


### PR DESCRIPTION
Just found a bug in my `Rewriter` code while working on RuboCop...

Sorry @whitequark!