### PR TITLE
Pass --no-line-convert to Racc to prevent wrapping generated parser code with module_eval.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ test/tmp
 test/version_tmp
 tmp
 *.output
+.ruby-version
+.ruby-gemset
 lib/parser/lexer.rb
 lib/parser/ruby18.rb
 lib/parser/ruby19.rb

--- a/Rakefile
+++ b/Rakefile
@@ -148,6 +148,7 @@ rule '.rb' => '.y' do |t|
            t.source,
            "-o", t.name
          ]
+  opts << "--no-line-convert" unless ENV['RACC_DEBUG']
   opts << "--debug" if ENV['RACC_DEBUG']
 
   sh "racc", *opts


### PR DESCRIPTION
Required for https://github.com/opal/opal/pull/1465