### PR TITLE
Treat shadowarg as local variable inside the block.

### DIFF
--- a/lib/parser/macruby.y
+++ b/lib/parser/macruby.y
@@ -1443,6 +1443,7 @@ rule
 
             bvar: tIDENTIFIER
                     {
+                      @static_env.declare val[0][0]
                       result = @builder.shadowarg(val[0])
                     }
                 | f_bad_arg

--- a/lib/parser/ruby19.y
+++ b/lib/parser/ruby19.y
@@ -1423,6 +1423,7 @@ rule
 
             bvar: tIDENTIFIER
                     {
+                      @static_env.declare val[0][0]
                       result = @builder.shadowarg(val[0])
                     }
                 | f_bad_arg

--- a/lib/parser/ruby20.y
+++ b/lib/parser/ruby20.y
@@ -1475,6 +1475,7 @@ opt_block_args_tail:
 
             bvar: tIDENTIFIER
                     {
+                      @static_env.declare val[0][0]
                       result = @builder.shadowarg(val[0])
                     }
                 | f_bad_arg

--- a/lib/parser/ruby21.y
+++ b/lib/parser/ruby21.y
@@ -1455,6 +1455,7 @@ opt_block_args_tail:
 
             bvar: tIDENTIFIER
                     {
+                      @static_env.declare val[0][0]
                       result = @builder.shadowarg(val[0])
                     }
                 | f_bad_arg

--- a/lib/parser/ruby22.y
+++ b/lib/parser/ruby22.y
@@ -1454,6 +1454,7 @@ opt_block_args_tail:
 
             bvar: tIDENTIFIER
                     {
+                      @static_env.declare val[0][0]
                       result = @builder.shadowarg(val[0])
                     }
                 | f_bad_arg

--- a/lib/parser/ruby23.y
+++ b/lib/parser/ruby23.y
@@ -1454,6 +1454,7 @@ opt_block_args_tail:
 
             bvar: tIDENTIFIER
                     {
+                      @static_env.declare val[0][0]
                       result = @builder.shadowarg(val[0])
                     }
                 | f_bad_arg

--- a/lib/parser/ruby24.y
+++ b/lib/parser/ruby24.y
@@ -1454,6 +1454,7 @@ opt_block_args_tail:
 
             bvar: tIDENTIFIER
                     {
+                      @static_env.declare val[0][0]
                       result = @builder.shadowarg(val[0])
                     }
                 | f_bad_arg

--- a/lib/parser/rubymotion.y
+++ b/lib/parser/rubymotion.y
@@ -1416,6 +1416,7 @@ rule
 
             bvar: tIDENTIFIER
                     {
+                      @static_env.declare val[0][0]
                       result = @builder.shadowarg(val[0])
                     }
                 | f_bad_arg

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -2026,6 +2026,15 @@ class TestParser < Minitest::Test
       %q{def f(var: defined?(var)) var end},
       %q{},
       ALL_VERSIONS - %w(1.8 1.9 mac ios 2.0))
+
+    assert_parses(
+      s(:block,
+        s(:send, nil, :lambda),
+        s(:args, s(:shadowarg, :a)),
+        s(:lvar, :a)),
+      %q{lambda{|;a|a}},
+      %q{},
+      ALL_VERSIONS - %w(1.8))
   end
 
   def assert_parses_args(ast, code, versions=ALL_VERSIONS)


### PR DESCRIPTION
``` sh
ruby-parse -e "lambda{|;a|a}"
```
Before:
```
(block
  (send nil :lambda)
  (args
    (shadowarg :a))
  (send nil :a))
```
After:
```
(block
  (send nil :lambda)
  (args
    (shadowarg :a))
  (lvar :a))
```