### PR TITLE
- Fix parsing words are delimited by backslash. e.g.) `%w\a b\`

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -385,13 +385,19 @@ class Parser::Lexer
     new_literal = Literal.new(self, *args)
     @literal_stack.push(new_literal)
 
-    if new_literal.words?
+    if new_literal.words? && new_literal.backslash_delimited?
+      if new_literal.interpolate?
+        self.class.lex_en_interp_backslash_delimited_words
+      else
+        self.class.lex_en_plain_backslash_delimited_words
+      end
+    elsif new_literal.words? && !new_literal.backslash_delimited?
       if new_literal.interpolate?
         self.class.lex_en_interp_words
       else
         self.class.lex_en_plain_words
       end
-    elsif new_literal.backslash_delimited?
+    elsif !new_literal.words? && new_literal.backslash_delimited?
       if new_literal.interpolate?
         self.class.lex_en_interp_backslash_delimited
       else
@@ -1062,6 +1068,20 @@ class Parser::Lexer
   *|;
 
   plain_backslash_delimited := |*
+      c_eol       => extend_string_eol;
+      c_any       => extend_string;
+  *|;
+
+  interp_backslash_delimited_words := |*
+      interp_code => extend_interp_code;
+      interp_var  => extend_interp_var;
+      c_space+    => extend_string_space;
+      c_eol       => extend_string_eol;
+      c_any       => extend_string;
+  *|;
+
+  plain_backslash_delimited_words := |*
+      c_space+    => extend_string_space;
       c_eol       => extend_string_eol;
       c_any       => extend_string;
   *|;

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -2188,6 +2188,55 @@ class TestLexer < Minitest::Test
                    :tSTRING_END,     "\\",  [3, 4])
   end
 
+  def test_string_pct_w_backslash
+    assert_scanned("%w\\s1 s2 \\",
+                   :tQWORDS_BEG,     "%w\\", [0, 3],
+                   :tSTRING_CONTENT, "s1",  [3, 5],
+                   :tSPACE,          nil,   [5, 6],
+                   :tSTRING_CONTENT, "s2",  [6, 8],
+                   :tSPACE,          nil,   [8, 9],
+                   :tSTRING_END,     "\\",   [9, 10])
+  end
+
+  def test_string_pct_w_backslash_nl
+    assert_scanned("%w\\s1 s2 \\\n",
+                   :tQWORDS_BEG,     "%w\\", [0, 3],
+                   :tSTRING_CONTENT, "s1",   [3, 5],
+                   :tSPACE,          nil,    [5, 6],
+                   :tSTRING_CONTENT, "s2",   [6, 8],
+                   :tSPACE,          nil,    [8, 9],
+                   :tSTRING_END,     "\\",   [9, 10],
+                   :tNL,             nil,    [10, 11])
+  end
+
+  def test_string_pct_w_backslash_interp_nl
+    assert_scanned("%W\\blah #x a \#@a b \#$b c \#{3} # \\",
+                   :tWORDS_BEG,     "%W\\",  [0, 3],
+                   :tSTRING_CONTENT, "blah", [3, 7],
+                   :tSPACE,          nil,    [7, 8],
+                   :tSTRING_CONTENT, "#x",   [8, 10],
+                   :tSPACE,          nil,    [10, 11],
+                   :tSTRING_CONTENT, "a",    [11, 12],
+                   :tSPACE,          nil,    [12, 13],
+                   :tSTRING_DVAR,    nil,    [13, 14],
+                   :tIVAR,           "@a",   [14, 16],
+                   :tSPACE,          nil,    [16, 17],
+                   :tSTRING_CONTENT, "b",    [17, 18],
+                   :tSPACE,          nil,    [18, 19],
+                   :tSTRING_DVAR,    nil,    [19, 20],
+                   :tGVAR,           "$b",   [20, 22],
+                   :tSPACE,          nil,    [22, 23],
+                   :tSTRING_CONTENT, "c",    [23, 24],
+                   :tSPACE,          nil,    [24, 25],
+                   :tSTRING_DBEG,    '#{',   [25, 27],
+                   :tINTEGER,        3,      [27, 28],
+                   :tRCURLY,         "}",    [28, 29],
+                   :tSPACE,          nil,    [29, 30],
+                   :tSTRING_CONTENT, "#",    [30, 31],
+                   :tSPACE,          nil,    [31, 32],
+                   :tSTRING_END,     "\\",   [32, 33])
+  end
+
   def test_string_pct_backslash_with_bad_escape
     # No escapes are allowed in a backslash-delimited string
     refute_scanned("%\\a\\n\\",


### PR DESCRIPTION
Problem
======

parser crashes when parsing words are delimited by backslash.

e.g.

```sh
$ ruby-parse --version
ruby-parse based on parser version 2.3.1.2
$ ruby -v
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]

$ echo -E -n '%w\a b\' > without_nl.rb
$ ruby -c without_nl.rb
Syntax OK
$ ruby-parse without_nl.rb  # This works
(array
  (str "a")
  (str "b"))

$ echo -E  '%w\a b\' > with_nl.rb
$ ruby -c with_nl.rb 
Syntax OK
$ with_nl.rb:1:1: fatal: unterminated string meets end of file
with_nl.rb:1: %w\a b\
with_nl.rb:1: ^      
```