### PR TITLE
Fix mlhs for block arguments with trailing commas

### DIFF
--- a/lib/parser/macruby.y
+++ b/lib/parser/macruby.y
@@ -1350,6 +1350,9 @@ rule
                                   concat(val[3])
                     }
                 | f_arg tCOMMA
+                  {
+                    result = [@builder.multi_lhs(nil, val[0], nil)]
+                  }
                 | f_arg tCOMMA                       f_rest_arg tCOMMA f_arg opt_f_block_arg
                     {
                       result = val[0].

--- a/lib/parser/ruby18.y
+++ b/lib/parser/ruby18.y
@@ -1259,6 +1259,9 @@ rule
 
        block_var: block_par
                 | block_par tCOMMA
+                  {
+                    result = [@builder.multi_lhs(nil, val[0], nil)]
+                  }
                 | block_par tCOMMA tAMPER lhs
                     {
                       result =  val[0].

--- a/lib/parser/ruby19.y
+++ b/lib/parser/ruby19.y
@@ -1330,6 +1330,9 @@ rule
                                   concat(val[3])
                     }
                 | f_arg tCOMMA
+                  {
+                    result = [@builder.multi_lhs(nil, val[0], nil)]
+                  }
                 | f_arg tCOMMA                       f_rest_arg tCOMMA f_arg opt_f_block_arg
                     {
                       result = val[0].

--- a/lib/parser/ruby20.y
+++ b/lib/parser/ruby20.y
@@ -1385,6 +1385,9 @@ opt_block_args_tail:
                                   concat(val[3])
                     }
                 | f_arg tCOMMA
+                  {
+                    result = [@builder.multi_lhs(nil, val[0], nil)]
+                  }
                 | f_arg tCOMMA                       f_rest_arg tCOMMA f_arg opt_block_args_tail
                     {
                       result = val[0].

--- a/lib/parser/ruby21.y
+++ b/lib/parser/ruby21.y
@@ -1365,6 +1365,9 @@ opt_block_args_tail:
                                   concat(val[3])
                     }
                 | f_arg tCOMMA
+                  {
+                    result = [@builder.multi_lhs(nil, val[0], nil)]
+                  }
                 | f_arg tCOMMA                       f_rest_arg tCOMMA f_arg opt_block_args_tail
                     {
                       result = val[0].

--- a/lib/parser/ruby22.y
+++ b/lib/parser/ruby22.y
@@ -1364,6 +1364,9 @@ opt_block_args_tail:
                                   concat(val[3])
                     }
                 | f_arg tCOMMA
+                  {
+                    result = [@builder.multi_lhs(nil, val[0], nil)]
+                  }
                 | f_arg tCOMMA                       f_rest_arg tCOMMA f_arg opt_block_args_tail
                     {
                       result = val[0].

--- a/lib/parser/ruby23.y
+++ b/lib/parser/ruby23.y
@@ -1364,6 +1364,9 @@ opt_block_args_tail:
                                   concat(val[3])
                     }
                 | f_arg tCOMMA
+                  {
+                    result = [@builder.multi_lhs(nil, val[0], nil)]
+                  }
                 | f_arg tCOMMA                       f_rest_arg tCOMMA f_arg opt_block_args_tail
                     {
                       result = val[0].

--- a/lib/parser/ruby24.y
+++ b/lib/parser/ruby24.y
@@ -1364,6 +1364,9 @@ opt_block_args_tail:
                                   concat(val[3])
                     }
                 | f_arg tCOMMA
+                  {
+                    result = [@builder.multi_lhs(nil, val[0], nil)]
+                  }
                 | f_arg tCOMMA                       f_rest_arg tCOMMA f_arg opt_block_args_tail
                     {
                       result = val[0].

--- a/lib/parser/rubymotion.y
+++ b/lib/parser/rubymotion.y
@@ -1323,6 +1323,9 @@ rule
                                   concat(val[3])
                     }
                 | f_arg tCOMMA
+                  {
+                    result = [@builder.multi_lhs(nil, val[0], nil)]
+                  }
                 | f_arg tCOMMA                       f_rest_arg tCOMMA f_arg opt_f_block_arg
                     {
                       result = val[0].

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -2350,8 +2350,9 @@ class TestParser < Minitest::Test
       %w(1.8))
 
     assert_parses_blockargs(
-      s(:args, s(:arg, :a)),
-      %q{|a,|})
+      s(:args, s(:mlhs, s(:arg, :a))),
+      %q{|a,|}
+    )
 
     assert_parses_blockargs(
       s(:args, s(:arg, :a), s(:blockarg, :b)),


### PR DESCRIPTION
Fixes #312 and backports the parser change to all rubies including 1.8, ruby motion, and macruby. I installed 1.8 and verified that this syntax should be backported that far. I was also able to verify this syntax for macruby but I'm not sure how to install rubymotion.