### PR TITLE
Update rubygems version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
  allow_failures:
   - rvm: ruby-head
   - rvm: rbx-2
-  - rvm: 1.9.3
 before_install:
  - gem update bundler
  - bundle --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 before_install:
  - gem update bundler
  - bundle --version
- - gem update --system 2.1.11
+ - gem update --system 2.6.6
  - gem --version
 script:
  - bundle exec rake test_cov


### PR DESCRIPTION
I've extracted this from #313 which was experiencing failures for all MRI ruby versions due to the old rubygems version. This change should fix the problem and also make it possible to move 1.9.3 out of `allowed_failures`.