### PR TITLE
Add `#expand` and `#contract` methods to `Parser::Source::Range`

### DIFF
--- a/lib/parser/source/range.rb
+++ b/lib/parser/source/range.rb
@@ -179,8 +179,8 @@ module Parser
       #
       def join(other)
         Range.new(@source_buffer,
-            [@begin_pos, other.begin_pos].min,
-            [@end_pos,   other.end_pos].max)
+          [@begin_pos, other.begin_pos].min,
+          [@end_pos,   other.end_pos].max)
       end
 
       ##

--- a/lib/parser/source/range.rb
+++ b/lib/parser/source/range.rb
@@ -174,6 +174,20 @@ module Parser
       end
 
       ##
+      # @param [integer] by
+      # @return [Range] a range expanded in both directions by `by`.
+      def expand(by = 1)
+        Range.new(@source_buffer, @begin_pos - by, @end_pos + by)
+      end
+
+      ##
+      # @param [integer] by
+      # @return [Range] a range contracted in both directions by `by`.
+      def contract(by = 1)
+        Range.new(@source_buffer, @begin_pos + by, @end_pos - by)
+      end
+
+      ##
       # @param [Range] other
       # @return [Range] smallest possible range spanning both this range and `other`.
       #

--- a/test/test_source_range.rb
+++ b/test/test_source_range.rb
@@ -135,4 +135,31 @@ class TestSourceRange < Minitest::Test
       sr.resize(-1)
     end
   end
+
+  def test_expand
+    sr1 = Parser::Source::Range.new(@buf, 2, 3)
+    sr2 = Parser::Source::Range.new(@buf, 1, 4)
+    assert_equal sr2, sr1.expand
+
+    sr1 = Parser::Source::Range.new(@buf, 2, 3)
+    sr2 = Parser::Source::Range.new(@buf, 0, 5)
+    assert_equal sr2, sr1.expand(2)
+  end
+
+  def test_contract
+    sr1 = Parser::Source::Range.new(@buf, 0, 4)
+    sr2 = Parser::Source::Range.new(@buf, 1, 3)
+    assert_equal sr2, sr1.contract
+
+    sr1 = Parser::Source::Range.new(@buf, 0, 4)
+    sr2 = Parser::Source::Range.new(@buf, 2, 2)
+    assert_equal sr2, sr1.contract(2)
+  end
+
+  def test_bad_contract
+    sr = Parser::Source::Range.new(@buf, 0, 1)
+    assert_raises ArgumentError do
+      sr.contract
+    end
+  end
 end

--- a/test/test_source_range.rb
+++ b/test/test_source_range.rb
@@ -122,4 +122,17 @@ class TestSourceRange < Minitest::Test
     sr = Parser::Source::Range.new(@buf, 8, 9)
     assert_equal '(string):2:2', sr.to_s
   end
+
+  def test_resize
+    sr1 = Parser::Source::Range.new(@buf, 0, 1)
+    sr2 = Parser::Source::Range.new(@buf, 0, 3)
+    assert_equal sr2, sr1.resize(3)
+  end
+
+  def test_bad_resize
+    sr = Parser::Source::Range.new(@buf, 0, 1)
+    assert_raises ArgumentError do
+      sr.resize(-1)
+    end
+  end
 end


### PR DESCRIPTION
I fully understand the implications of extending the public API with new methods, but I thought I'd offer this for your consideration anyway. The need for these methods have arisen now and then as I've been working on [RuboCop](https://github.com/bbatsov/rubocop), where a new range sometimes needs to be constructed by expanding or contracting an existing one (often in order to include or exclude brackets.)

Because the need to fully qualify the constant, these methods offer ample opportunity for code reduction, and can clean out some of the direct references to `Parser` in higher level constructs (i.e. cops.) Consider:

```
# Before
Parser::Source::Range(node.source_range.source_buffer, node.begin_pos + 1, node.end_pos - 1)

# After
node.source_range.contract
```

This pull request also contains a small amount of opportunistic clean up; adding a unit test for `#resize`, and fixing a minor indentation mistake in `#join`. Feel free to pick and choose among the commits, should you want some of them, but not all.

🙇 
