### PR TITLE
* parser/current: update 2.2 warning to 2.2.6

### DIFF
--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -46,7 +46,7 @@ module Parser
     CurrentRuby = Ruby21
 
   when /^2\.2\./
-    current_version = '2.2.5'
+    current_version = '2.2.6'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby22', current_version
     end


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2016/11/15/ruby-2-2-6-released/