### PR TITLE
Fix ruby_parser comparison markup

### DIFF
--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -722,6 +722,7 @@ Format:
 ~~~
 
 Ruby_parser output for reference:
+
 ~~~
 "@foo.bar &&= 1"
 s(:op_asgn2, s(:ivar, :@foo), :bar=, :"&&", s(:int, 1))


### PR DESCRIPTION
![screen shot 2017-05-22 at 20 33 59](https://cloud.githubusercontent.com/assets/6269/26323163/156d9c1c-3f2e-11e7-8d3f-f6e78023498d.png)

Without the blank line, the markup is broken.