### PR TITLE
ruby24: Generate proper AST for multi-asgn in condition

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1097,6 +1097,8 @@ module Parser
       when :masgn
         if @parser.version <= 23
           diagnostic :error, :masgn_as_condition, nil, cond.loc.expression
+        else
+          cond
         end
 
       when :begin

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -4255,7 +4255,12 @@ class TestParser < Minitest::Test
   def test_if_masgn__24
     assert_parses(
       s(:if,
-        s(:begin, nil), nil, nil),
+        s(:begin,
+          s(:masgn,
+            s(:mlhs,
+              s(:lvasgn, :a),
+              s(:lvasgn, :b)),
+          s(:lvar, :foo))), nil, nil),
       %q{if (a, b = foo); end},
       %q{},
       SINCE_2_4)


### PR DESCRIPTION
Commit c1310f6 introduces a new behavior that got merged for the Ruby
2.4 release: multi-asgn is now allowed in a conditional context.

Besides the changes to the language grammar, the commit also updates the
AST builder (builder/default.rb @ check_condition) to stop it from
emiting a diagnostic error in 2.4.

This change, however, is not correct: the condition check for Ruby 2.4
does not emit an error anymore, but it does not return the AST nodes it
was checking either. Without an explicit return, the `:masgn` branch of
the function yields a `nil`, swallowing up the expressions inside the
condition of the `if` statement.

The fix is trivial: return the value we were checking. The corresponding
test has been updated to reflect the change -- the previous AST output
was missing all the contents of the `if` statement.

---

Hi @whitequark! First PR right here. I'm pretty sure the AST we were generating here was bogus. Let me know if something about the fix doesn't make sense. Cheers!

cc @charliesome 