### PR TITLE
Get tests passing with frozen-string-literals enabled.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
  - 2.0.0
  - 2.2.5
  - 2.3.1
+ - 2.4.1
  - ruby-head
  - jruby-18mode
  - jruby-19mode
@@ -18,5 +19,7 @@ before_install:
  - bundle --version
  - gem update --system 2.6.6
  - gem --version
+before_script:
+- if (ruby -e "exit RUBY_VERSION.to_f >= 2.4"); then export RUBYOPT="--enable-frozen-string-literal"; fi; echo $RUBYOPT
 script:
  - bundle exec rake test_cov

--- a/lib/parser/lexer/literal.rb
+++ b/lib/parser/lexer/literal.rb
@@ -237,7 +237,7 @@ module Parser
     end
 
     def clear_buffer
-      @buffer = ''
+      @buffer = ''.dup
 
       # Prime the buffer with lexer encoding; otherwise,
       # concatenation will produce varying results.

--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -246,7 +246,7 @@ module Parser
       def source_lines
         @lines ||= begin
           lines = @source.lines.to_a
-          lines << '' if @source.end_with?("\n".freeze)
+          lines << ''.dup if @source.end_with?("\n".freeze)
 
           lines.each do |line|
             line.chomp!("\n".freeze)

--- a/lib/parser/source/rewriter.rb
+++ b/lib/parser/source/rewriter.rb
@@ -388,7 +388,7 @@ module Parser
       end
 
       def merge_replacements(actions)
-        result    = ''
+        result    = ''.dup
         prev_act  = nil
 
         actions.each do |act|

--- a/test/test_diagnostic.rb
+++ b/test/test_diagnostic.rb
@@ -18,7 +18,7 @@ class TestDiagnostic < Minitest::Test
   end
 
   def test_freezes
-    string     = 'foo'
+    string     = 'foo'.dup
     highlights = [@range2]
 
     diag = Parser::Diagnostic.new(:error, :escape_eof, @range1, highlights)

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -23,7 +23,7 @@ class TestLexer < Minitest::Test
 
   def utf(str)
     if str.respond_to?(:force_encoding)
-      str.force_encoding(Encoding::UTF_8)
+      str.dup.force_encoding(Encoding::UTF_8)
     else
       str
     end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -5091,7 +5091,7 @@ class TestParser < Minitest::Test
     def test_bom
       assert_parses(
         s(:int, 1),
-        %Q{\xef\xbb\xbf1}.force_encoding(Encoding::BINARY),
+        %Q{\xef\xbb\xbf1}.dup.force_encoding(Encoding::BINARY),
         %q{},
         %w(1.9 2.0 2.1))
     end
@@ -5103,7 +5103,7 @@ class TestParser < Minitest::Test
           s(:send, nil, :puts, s(:lvar, :"проверка"))),
         %Q{# coding:koi8-r
            \xd0\xd2\xcf\xd7\xc5\xd2\xcb\xc1 = 42
-           puts \xd0\xd2\xcf\xd7\xc5\xd2\xcb\xc1}.
+           puts \xd0\xd2\xcf\xd7\xc5\xd2\xcb\xc1}.dup.
           force_encoding(Encoding::BINARY),
         %q{},
         %w(1.9 2.0 2.1))
@@ -5116,7 +5116,7 @@ class TestParser < Minitest::Test
             s(:str, "\\xa8"),
             s(:regopt, :n)),
           s(:str, "")),
-        %q{/\xa8/n =~ ""}.force_encoding(Encoding::UTF_8),
+        %q{/\xa8/n =~ ""}.dup.force_encoding(Encoding::UTF_8),
         %{},
         SINCE_1_9)
     end


### PR DESCRIPTION
These changes ensure that all string literals can be frozen (as per the optional feature in MRI 2.3 and onwards). I would recommend adding the following to your `.travis.yml` file to ensure regressions aren't introduced:

```yml
before_script:
- if (ruby -e "exit RUBY_VERSION.to_f >= 2.4"); then export RUBYOPT="--enable-frozen-string-literal"; fi; echo $RUBYOPT
```

This will add the flag when the tests are run on MRI 2.4 or newer (while the feature was introduced in 2.3, it doesn't seem to work reliably until 2.4).