### PR TITLE
Allows file paths to be used as well as file names for Ruby Rewrite.

### DIFF
--- a/lib/parser/runner/ruby_rewrite.rb
+++ b/lib/parser/runner/ruby_rewrite.rb
@@ -32,7 +32,10 @@ module Parser
     def load_and_discover(file)
       load file
 
-      const_name = file.
+      file_name = File.basename(file)
+      file_name[0] = file_name[0].capitalize
+
+      const_name = file_name.
         sub(/\.rb$/, '').
         gsub(/(^|_)([a-z])/) do |m|
           "#{$2.upcase}"


### PR DESCRIPTION
Previously Ruby Rewrite would only work when a file name was passed in. The addition of these changes now allows for file paths without affecting the old functionality.