### PR TITLE
Fix parse error when hash contains do blocks

### DIFF
--- a/lib/parser/ruby24.y
+++ b/lib/parser/ruby24.y
@@ -1613,7 +1613,6 @@ opt_block_args_tail:
 
                       @static_env.unextend
                       @lexer.cmdarg = val[1]
-                      @lexer.cmdarg.pop
                     }
 
        case_body: kWHEN args then compstmt cases

--- a/lib/parser/ruby25.y
+++ b/lib/parser/ruby25.y
@@ -1609,7 +1609,6 @@ opt_block_args_tail:
 
                       @static_env.unextend
                       @lexer.cmdarg = val[1]
-                      @lexer.cmdarg.pop
                     }
 
        case_body: kWHEN args then compstmt cases

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6185,4 +6185,97 @@ class TestParser < Minitest::Test
       s(:regexp, s(:str, "#)"), s(:regopt, :x)),
       %Q{/#)/x})
   end
+
+  def test_bug_do_block_in_hash_brace
+    assert_parses(
+      s(:send, nil, :p,
+        s(:sym, :foo),
+        s(:hash,
+          s(:pair,
+            s(:sym, :a),
+            s(:block,
+              s(:send, nil, :proc),
+              s(:args), nil)),
+          s(:pair,
+            s(:sym, :b),
+            s(:block,
+              s(:send, nil, :proc),
+              s(:args), nil)))),
+      %q{p :foo, {a: proc do end, b: proc do end}},
+      %q{},
+      SINCE_2_3)
+
+    assert_parses(
+      s(:send, nil, :p,
+        s(:sym, :foo),
+        s(:hash,
+          s(:pair,
+            s(:sym, :a),
+            s(:block,
+              s(:send, nil, :proc),
+              s(:args), nil)),
+          s(:pair,
+            s(:sym, :b),
+            s(:block,
+              s(:send, nil, :proc),
+              s(:args), nil)))),
+      %q{p :foo, {:a => proc do end, b: proc do end}},
+      %q{},
+      SINCE_2_3)
+
+    assert_parses(
+      s(:send, nil, :p,
+        s(:sym, :foo),
+        s(:hash,
+          s(:pair,
+            s(:sym, :a),
+            s(:block,
+              s(:send, nil, :proc),
+              s(:args), nil)),
+          s(:pair,
+            s(:sym, :b),
+            s(:block,
+              s(:send, nil, :proc),
+              s(:args), nil)))),
+      %q{p :foo, {"a": proc do end, b: proc do end}},
+      %q{},
+      SINCE_2_3)
+
+    assert_parses(
+      s(:send, nil, :p,
+        s(:sym, :foo),
+        s(:hash,
+          s(:pair,
+            s(:block,
+              s(:send, nil, :proc),
+              s(:args), nil),
+            s(:block,
+              s(:send, nil, :proc),
+              s(:args), nil)),
+          s(:pair,
+            s(:sym, :b),
+            s(:block,
+              s(:send, nil, :proc),
+              s(:args), nil)))),
+      %q{p :foo, {proc do end => proc do end, b: proc do end}},
+      %q{},
+      SINCE_2_3)
+
+    assert_parses(
+      s(:send, nil, :p,
+        s(:sym, :foo),
+        s(:hash,
+          s(:kwsplat,
+            s(:block,
+              s(:send, nil, :proc),
+              s(:args), nil)),
+          s(:pair,
+            s(:sym, :b),
+            s(:block,
+              s(:send, nil, :proc),
+              s(:args), nil)))),
+      %q{p :foo, {** proc do end, b: proc do end}},
+      %q{},
+      SINCE_2_3)
+  end
 end


### PR DESCRIPTION
Ports commit b4aa884f06ee5c40f88e90f312ea6b31c120f308 from
github.com/ruby/ruby:

* parse.y (do_body): preserve cmdarg stack around do/end block.
  [ruby-core:78837] [Bug #13073]