### PR TITLE
Correct misnamed `TestSourceMap` class

### DIFF
--- a/test/test_source_map.rb
+++ b/test/test_source_map.rb
@@ -1,7 +1,7 @@
 require 'helper'
 require 'parse_helper'
 
-class TestSourceComment < Minitest::Test
+class TestSourceMap < Minitest::Test
   include ParseHelper
 
   def test_to_hash


### PR DESCRIPTION
Found a misnamed test class when I was looking around. This change fixes that.