### PR TITLE
Fix warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: ruby
 rvm:
  - 1.9.2

--- a/lib/parser/source/rewriter.rb
+++ b/lib/parser/source/rewriter.rb
@@ -42,6 +42,10 @@ module Parser
 
         @insert_before_multi_order = 0
         @insert_after_multi_order = 0
+
+        @pending_queue = nil
+        @pending_clobber = nil
+        @pending_insertions = nil
       end
 
       ##

--- a/test/parse_helper.rb
+++ b/test/parse_helper.rb
@@ -98,6 +98,11 @@ module ParseHelper
       raise
     end
 
+    if ast.nil?
+      assert_nil parsed_ast, "(#{version}) AST equality"
+      return
+    end
+
     assert_equal ast, parsed_ast,
                  "(#{version}) AST equality"
 

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -23,7 +23,7 @@ class TestBase < Minitest::Test
 
   def test_loc_dup
     ast = Parser::CurrentRuby.parse('1')
-    assert_equal nil, ast.loc.dup.node
+    assert_nil ast.loc.dup.node
     Parser::AST::Node.new(:root, [], :location => ast.loc)
   end
 end

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -13,7 +13,7 @@ class TestEncoding < Minitest::Test
     require 'parser/all'
 
     def test_default
-      assert_equal nil, recognize('foobar')
+      assert_nil recognize('foobar')
     end
 
     def test_bom
@@ -38,16 +38,16 @@ class TestEncoding < Minitest::Test
     end
 
     def test_empty
-      assert_equal nil, recognize('')
+      assert_nil recognize('')
     end
 
     def test_no_comment
-      assert_equal nil, recognize(%{require 'cane/encoding_aware_iterator'})
+      assert_nil recognize(%{require 'cane/encoding_aware_iterator'})
     end
 
     def test_adjacent
-      assert_equal nil, recognize('# codingkoi8-r')
-      assert_equal nil, recognize('# coding koi8-r')
+      assert_nil recognize('# codingkoi8-r')
+      assert_nil recognize('# coding koi8-r')
     end
 
     def test_utf8_mac
@@ -60,7 +60,7 @@ class TestEncoding < Minitest::Test
       assert_equal Encoding::UTF_8, recognize('# coding: utf-8-mac')
 
       assert_raises(ArgumentError) do
-        assert_equal nil,           recognize('# coding: utf-8-dicks')
+        assert_nil recognize('# coding: utf-8-dicks')
       end
     end
 

--- a/test/test_parse_helper.rb
+++ b/test/test_parse_helper.rb
@@ -65,13 +65,13 @@ class TestParseHelper < Minitest::Test
     assert_equal ast, traverse_ast(ast, %w())
 
     assert_equal s(:int, 1), traverse_ast(ast, %w(int))
-    assert_equal nil, traverse_ast(ast, %w(str))
-
     assert_equal s(:str, 'foo'), traverse_ast(ast, %w(dstr str))
     assert_equal s(:int, 2), traverse_ast(ast, %w(dstr int))
     assert_equal s(:int, 2), traverse_ast(ast, %w(dstr int/1))
     assert_equal s(:int, 3), traverse_ast(ast, %w(dstr int/2))
-    assert_equal nil, traverse_ast(ast, %w(dstr int/3))
+
+    assert_nil traverse_ast(ast, %w(str))
+    assert_nil traverse_ast(ast, %w(dstr int/3))
   end
 
   def test_assert_parses

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -5234,7 +5234,7 @@ class TestParser < Minitest::Test
 
       ast, comments, tokens = parser.tokenize(source_file, true)
 
-      assert_equal nil, ast
+      assert_nil ast
 
       assert_equal [
                      Parser::Source::Comment.new(range.call(4, 9))


### PR DESCRIPTION
1. Fixed warnings in `Parser::Source::Rewriter`.
2. Fixed warnings coming from minitest (`assert nil, value` -> `assert_nil value`, see https://github.com/seattlerb/minitest/issues/666)
3. Changed CI config, it can fix an issue with installing 1.9.2 on Travis.