### PR TITLE
Parser::Current: update for latest Ruby versions

### DIFF
--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -37,7 +37,7 @@ module Parser
     CurrentRuby = Ruby20
 
   when /^2\.1\./
-    current_version = '2.1.8'
+    current_version = '2.1.10'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby21', current_version
     end

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -46,7 +46,7 @@ module Parser
     CurrentRuby = Ruby21
 
   when /^2\.2\./
-    current_version = '2.2.6'
+    current_version = '2.2.7'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby22', current_version
     end

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -64,7 +64,7 @@ module Parser
     CurrentRuby = Ruby23
 
   when /^2\.4\./
-    current_version = '2.4.0'
+    current_version = '2.4.1'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby24', current_version
     end

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -55,7 +55,7 @@ module Parser
     CurrentRuby = Ruby22
 
   when /^2\.3\./
-    current_version = '2.3.3'
+    current_version = '2.3.4'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby23', current_version
     end


### PR DESCRIPTION
### Summary

This PR suppresses these warnings. So this PR uses the latest Ruby versions for `Parser::CurrentRuby`.

```console
# Ruby 2.1.10
% rbenv shell 2.1.10 && ruby -rparser/current -e 'Parser::CurrentRuby.parse("puts :hello")'
warning: parser/current is loading parser/ruby21, which recognizes
warning: 2.1.8-compliant syntax, but you are running 2.1.10.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.

# Ruby 2.2.7
% rbenv shell 2.2.7 && ruby -rparser/current -e 'Parser::CurrentRuby.parse("puts :hello")'
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.6-compliant syntax, but you are running 2.2.7.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.

# Ruby 2.3.4
% rbenv shell 2.3.4 && ruby -rparser/current -e 'Parser::CurrentRuby.parse("puts :hello")'
warning: parser/current is loading parser/ruby23, which recognizes
warning: 2.3.3-compliant syntax, but you are running 2.3.4.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.

# Ruby 2.4.1
% rbenv shell 2.4.1 && ruby -rparser/current -e 'Parser::CurrentRuby.parse("puts :hello")'
warning: parser/current is loading parser/ruby24, which recognizes
warning: 2.4.0-compliant syntax, but you are running 2.4.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
```

### Other Information

These Ruby versions are released.

- https://www.ruby-lang.org/en/news/2016/04/01/ruby-2-1-10-released
- https://www.ruby-lang.org/en/news/2017/03/28/ruby-2-2-7-released
- https://www.ruby-lang.org/en/news/2017/03/30/ruby-2-3-4-released
- https://www.ruby-lang.org/en/news/2017/03/22/ruby-2-4-1-released
