### PR TITLE
Parser::Current: update for Ruby 2.1.10 and 2.2.7

### DIFF
--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -37,7 +37,7 @@ module Parser
     CurrentRuby = Ruby20
 
   when /^2\.1\./
-    current_version = '2.1.8'
+    current_version = '2.1.10'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby21', current_version
     end

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -46,7 +46,7 @@ module Parser
     CurrentRuby = Ruby21
 
   when /^2\.2\./
-    current_version = '2.2.6'
+    current_version = '2.2.7'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby22', current_version
     end


### PR DESCRIPTION
Follow up of https://github.com/whitequark/parser/pull/362#issuecomment-325368370.

Currently, it seems there are no open issues for Ruby 2.1 and 2.2. This PR updates them.