### PR TITLE
Fix performance regression for a string that contains a very long line

### DIFF
--- a/lib/parser/lexer/literal.rb
+++ b/lib/parser/lexer/literal.rb
@@ -187,7 +187,7 @@ module Parser
       @buffer_s ||= ts
       @buffer_e = te
 
-      @buffer += string
+      @buffer << string
     end
 
     def flush_string

--- a/lib/parser/lexer/literal.rb
+++ b/lib/parser/lexer/literal.rb
@@ -183,20 +183,11 @@ module Parser
       (@interp_braces == 0)
     end
 
-    if RUBY_ENGINE == 'opal'
-      def extend_string(string, ts, te)
-        @buffer_s ||= ts
-        @buffer_e = te
+    def extend_string(string, ts, te)
+      @buffer_s ||= ts
+      @buffer_e = te
 
-        @buffer += string
-      end
-    else
-      def extend_string(string, ts, te)
-        @buffer_s ||= ts
-        @buffer_e = te
-
-        @buffer << string
-      end
+      @buffer += string
     end
 
     def flush_string

--- a/lib/parser/lexer/literal.rb
+++ b/lib/parser/lexer/literal.rb
@@ -183,11 +183,20 @@ module Parser
       (@interp_braces == 0)
     end
 
-    def extend_string(string, ts, te)
-      @buffer_s ||= ts
-      @buffer_e = te
+    if RUBY_ENGINE == 'opal'
+      def extend_string(string, ts, te)
+        @buffer_s ||= ts
+        @buffer_e = te
 
-      @buffer += string
+        @buffer += string
+      end
+    else
+      def extend_string(string, ts, te)
+        @buffer_s ||= ts
+        @buffer_e = te
+
+        @buffer << string
+      end
     end
 
     def flush_string


### PR DESCRIPTION
`+=` is replaced with `<<` in `extend_string` method in #293.
This replacing did not introduce performance regressions about small string. However, it has introduced a performance regression about a string that contains very long line.

This seems to be a problem in an actual application. An issue was opened
in RuboCop repository about this problem. https://github.com/bbatsov/rubocop/issues/4701

`<<` is replaced with `+=` also in `initialize` method by #293. However this `<<` doesn't introduce regressions because it is a concatenation of small strings.

Benchmark
-----

```
File.open 'test.rb', 'w' do |f|
  f.write '"'
  f.write 'a' * 100000
  f.write '"'
end
```

Master:

```bash
$ bin/ruby-parse -B test.rb
Parsed 1 files (100002 characters) in 0.73 seconds (136.989 kchars/s).
Running on ruby 2.4.1.
```

Patch:

```bash
$ bin/ruby-parse -B test.rb
Parsed 1 files (100002 characters) in 0.16 seconds (625.012 kchars/s).
Running on ruby 2.4.1.
```