### PR TITLE
Add `require 'date'` into Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rake/clean'
+require 'date'
 
 task :default => [:test]
 


### PR DESCRIPTION
Bundler does not require `date` after 1.14.4.
https://github.com/bundler/bundler/issues/5470

So `rake changelog` task does not work with new bundler. This change will fix this problem.