### PR TITLE
Parser::Current: update for Ruby 2.2.8

### DIFF
--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -46,7 +46,7 @@ module Parser
     CurrentRuby = Ruby21
 
   when /^2\.2\./
-    current_version = '2.2.7'
+    current_version = '2.2.8'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby22', current_version
     end


### PR DESCRIPTION
Ruby 2.2.8 has been released.
https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-2-8-released/

As far as I saw, there seems to be no change in syntax to `parse.y` etc.
https://github.com/ruby/ruby/compare/v2_2_7...v2_2_8