### PR TITLE
- Builders::Default: fix location for __ENCODING__

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -416,7 +416,7 @@ module Parser
 
       when :__ENCODING__
         n(:const, [ n(:const, [ nil, :Encoding], nil), :UTF_8 ],
-          node.loc.dup)
+          constant_map(nil, nil, ["Encoding", node.loc.expression]))
 
       when :ident
         name, = *node

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -919,7 +919,8 @@ class TestParser < Minitest::Test
     assert_parses(
       s(:const, s(:const, nil, :Encoding), :UTF_8),
       %q{__ENCODING__},
-      %q{~~~~~~~~~~~~ expression},
+      %q{~~~~~~~~~~~~ name
+        |~~~~~~~~~~~~ expression},
       SINCE_1_9)
   end
 


### PR DESCRIPTION
A constant `Logger::INFO` gets parsed as a node with location of class
`Parser::Source::Map::Constant`. Since "\_\_ENCODING\_\_" gets parsed as a
constant node, it seems consistent to use the same Map::Constant class.