### PR TITLE
Rake task to make CHANGELOG.md: Avoid wrong release v2.4.0.0 (2016-01-16) [sic]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,9 +132,6 @@ Bugs fixed:
  * Add :csend to Parser::Meta::NODE_TYPES (Markus Schirp)
  * lexer/dedenter: "\<\<x\n  y\\n  z\nx": don't dedent after escaped newline. (whitequark)
 
-v2.4.0.0 (2016-01-16)
----------------------
-
 v2.3.0.1 (2016-01-14)
 ---------------------
 


### PR DESCRIPTION
~This PR **drops** the heading for **a non-existent release** v2.4.0.0 (in _2016_) from the change log.~

  - ~it had wrongly been `v2.3.3.1 (2016-01-16)` but then wrongly replaced with `v2.4.0.0 (2016-01-16)`~
  - ~this edit removes the heading, so that the releases listed in this document mirrors the released Git tags~

**Update**: What needs to be done is to avoid this mis-rendering by the Rake task which produces the change log.