### PR TITLE
Travis: skip extra gem update --system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,8 @@ matrix:
   - rvm: ruby-head
   - rvm: rbx-2
 before_install:
- - gem update bundler
+ - gem install bundler
  - bundle --version
- - gem update --system 2.6.6
  - gem --version
 script:
  - bundle exec rake test_cov


### PR DESCRIPTION
This PR tries to make the CI a little more efficient.

  - rvm nowadays update rubygems on its own, at install of a Ruby
  - `gem install bundler` will install latest (_and_ if the version of Ruby does not ship with a Bundler, such as perhaps jruby-head, for example, the update command may fail)