### PR TITLE
Travis: Use JRuby 9.1.13.0, add 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,14 @@ rvm:
  - 2.0.0
  - 2.2.5
  - 2.3.1
+ - 2.4.0
  - ruby-head
- - jruby-18mode
- - jruby-19mode
+ - jruby-9.1.13.0
  - rbx-2
 matrix:
  allow_failures:
   - rvm: ruby-head
   - rvm: rbx-2
-  - rvm: jruby-18mode
-  - rvm: jruby-19mode
 before_install:
  - gem install bundler
  - bundle --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
  allow_failures:
   - rvm: ruby-head
   - rvm: rbx-2
+  - rvm: jruby-18mode
+  - rvm: jruby-19mode
 before_install:
  - gem install bundler
  - bundle --version

--- a/test/racc_coverage_helper.rb
+++ b/test/racc_coverage_helper.rb
@@ -15,7 +15,7 @@ module RaccCoverage
       @coverage[parser] = extract_interesting_lines(parser, base_path)
     end
 
-    @trace = TracePoint.trace(:line) do |trace|
+    @trace = TracePoint.new(:line) do |trace|
       lineno = trace.lineno - 1
 
       if (line_coverage = @coverage[trace.path])
@@ -24,6 +24,7 @@ module RaccCoverage
         end
       end
     end
+    @trace.enable
   end
 
   def self.stop


### PR DESCRIPTION
~Racc has issues building in jruby-18mode, jruby-19mode~

~To allow the CI to remain useful until those issues can be... resolved, this PR places those platforms in `allow_failures`.~

**Update**: Renamed PR to match content. 