### PR TITLE
Use `check_condition` for `not` node

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -878,7 +878,7 @@ module Parser
 
     def not_op(not_t, begin_t=nil, receiver=nil, end_t=nil)
       if @parser.version == 18
-        n(:not, [ receiver ],
+        n(:not, [ check_condition(receiver) ],
           unary_op_map(not_t, receiver))
       else
         if receiver.nil?
@@ -888,7 +888,7 @@ module Parser
             nil_node, :'!'
           ], send_unary_op_map(not_t, nil_node))
         else
-          n(:send, [ receiver, :'!' ],
+          n(:send, [ check_condition(receiver), :'!' ],
             send_map(nil, nil, not_t, begin_t, [receiver], end_t))
         end
       end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -2868,7 +2868,7 @@ class TestParser < Minitest::Test
       %q{fun(1, bar: 2, 3, nil)},
       %q{            ~~~~~~~~~ expression (hash.pair.objc_varargs)},
       %w(mac))
-    end
+  end
 
   # To receiver
 


### PR DESCRIPTION
Problem
===



MRI's parser treats the body of `not` as a condition.


For example:

```bash
# In ruby 2.3, it is syntax error.
$ ruby -ce '!(a, b = x)'
-e:1 multiple assignment in conditional

# Ruby 2.4 can parse the code.
$ ruby -ce '!(a,b=x)'
Syntax OK

# match_current_line
$ ruby -e '$_ = "a"; p(!(/a/)); p(!(/b/))'
false
true

# flip flop
$ ruby -e 'x = 0; p !((x==1)..(x==2))'
true
$ ruby -e 'x = 1; p !((x==1)..(x==2))'
false
```

But parser gem does not treat body of `not` as a condition.

For example:

```ruby
# It should be error, but parser can parse the code.
$ ruby-parse --23 -e '!(a, b = x)'
(send
  (begin
    (masgn
      (mlhs
        (lvasgn :a)
        (lvasgn :b))
      (send nil :x))) :!)

# it should be parsed to `match-current-line`, but it is parsed as `regexp`.
$ ruby-parse -e '!/a/'
(send
  (regexp
    (str "a")
    (regopt)) :!)

# it should be parsed to `iflipflop`, but it is parsed as `irange`.
$ ruby-parse -e '!(a..b)'
(send
  (begin
    (irange
      (send nil :a)
      (send nil :b))) :!)
```


Solution
------


Apply `check_condition` method for `not_op`.


By this change, all above problems are resolved.