### PR TITLE
Remove a duplicated test

### DIFF
--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -569,16 +569,6 @@ class TestLexer < Minitest::Test
                    :kEND,        "end", [8, 11])
   end
 
-  def test_do_cond
-    @lex.cond.push(true)
-
-    assert_scanned("x do 42 end",
-                   :tIDENTIFIER, "x",   [0, 1],
-                   :kDO_COND,    "do",  [2, 4],
-                   :tINTEGER,    42,    [5, 7],
-                   :kEND,        "end", [8, 11])
-  end
-
   def test_do_block
     @lex.state = :expr_endarg
 


### PR DESCRIPTION
`test_do_cond` and `test_identifier_eh` is redefined.

With `RUBYOPT=-w`, `rake` command displays the following warnings.

```
/home/pocke/ghq/github.com/whitequark/parser/test/test_lexer.rb:591: warning: method redefined; discarding old test_do_cond
/home/pocke/ghq/github.com/whitequark/parser/test/test_lexer.rb:572: warning: previous definition of test_do_cond was here
/home/pocke/ghq/github.com/whitequark/parser/test/test_lexer.rb:981: warning: method redefined; discarding old test_identifier_eh
/home/pocke/ghq/github.com/whitequark/parser/test/test_lexer.rb:964: warning: previous definition of test_identifier_eh was here
```

This change only suppresses one of the warnings that is for `test_do_cond`.

`test_do_cond` is defined twice with same meaning code.
So, we can remove one of these safely.

But this change does not suppres the warning that is for `test_identifier_eh`.
Because the overridden test does not pass.

```ruby
def test_identifier_eh # This test case is overrided!
  assert_scanned("identifier?",
                 :tFID,        "identifier?", [0, 11])

  assert_scanned("identifier?=",
                 :tIDENTIFIER, "identifier", [0, 10],
                 :tNEQ,        "?=",         [10, 12])
end

def test_identifier_eh
  assert_scanned("identifier?", :tFID, "identifier?", [0, 11])
end
```

If we remove the second `test_identifier_eh`, the first `test_identifier_eh` is failed.

```bash
$ rake
Run options: --seed 40

................................................................................................................................................................................................................................................................................................................................................................................................................F...........................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 1.992764s, 431.5613 runs/s, 37392.7777 assertions/s.

  1) Failure:
TestLexer#test_identifier_eh [/home/pocke/ghq/github.com/whitequark/parser/test/test_lexer.rb:958]:
identifier?=.
Expected [:tINTEGER, 61] to be eql? [:tNEQ, "?="].

860 runs, 74515 assertions, 1 failures, 0 errors, 0 skips
```

The first(overridden) `test_identifier_eh` is added in d599084eaf89cdaf95dbed474dc8cbaa8885fabb.