### PR TITLE
Don't add dozens of encoding comments to each generated file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,12 +34,14 @@ GENERATED_FILES = %w(lib/parser/lexer.rb
 
 CLEAN.include(GENERATED_FILES)
 
+ENCODING_COMMENT = "# -*- encoding:utf-8; warn-indent:false; frozen_string_literal: true  -*-\n"
+
 desc 'Generate the Ragel lexer and Racc parser.'
 task :generate => GENERATED_FILES do
   Rake::Task[:ragel_check].invoke
   GENERATED_FILES.each do |filename|
     content = File.read(filename)
-    content = "# -*- encoding:utf-8; warn-indent:false; frozen_string_literal: true  -*-\n" + content
+    content = ENCODING_COMMENT + content unless content.start_with?(ENCODING_COMMENT)
 
     File.open(filename, 'w') do |io|
       io.write content


### PR DESCRIPTION
The 'generate' Rake task runs every time the tests are run, YARD documentation is
generated, and so on. Even if all the generated files are already there, it adds another
encoding comment to them each time. If you repeatedly run the tests while working on the
Parser codebase, these generated files accumulate more and more encoding comments at the
top.

Put an end to this silliness by only adding the encoding comment if it is not already there.