### PR TITLE
Skip magic comments

### DIFF
--- a/lib/parser/source/comment/associator.rb
+++ b/lib/parser/source/comment/associator.rb
@@ -184,9 +184,16 @@ module Parser
         advance_comment
       end
 
+      MAGIC_COMMENT_RE = /^#\s*(-\*-|)\s*(frozen_string_literal|warn_indent|warn_past_scope):.*\1$/
+
       def advance_through_directives
         # Skip shebang.
         if @current_comment && @current_comment.text =~ /^#!/
+          advance_comment
+        end
+
+        # Skip magic comments.
+        if @current_comment && @current_comment.text =~ MAGIC_COMMENT_RE
           advance_comment
         end
 

--- a/test/test_source_comment_associator.rb
+++ b/test/test_source_comment_associator.rb
@@ -213,6 +213,96 @@ end
     assert_equal 0, associations.size
   end
 
+  def test_associate_frozen_string_literal
+    ast, associations = associate(<<-END)
+# frozen_string_literal: true
+class Foo
+end
+    END
+
+    assert_equal 0, associations.size
+  end
+
+  def test_associate_frozen_string_literal_dash_star_dash
+    ast, associations = associate(<<-END)
+# -*- frozen_string_literal: true -*-
+class Foo
+end
+    END
+
+    assert_equal 0, associations.size
+  end
+
+  def test_associate_frozen_string_literal_no_space_after_colon
+    ast, associations = associate(<<-END)
+# frozen_string_literal:true
+class Foo
+end
+    END
+
+    assert_equal 0, associations.size
+  end
+
+  def test_associate_warn_indent
+    ast, associations = associate(<<-END)
+# warn_indent: true
+class Foo
+end
+    END
+
+    assert_equal 0, associations.size
+  end
+
+  def test_associate_warn_indent_dash_star_dash
+    ast, associations = associate(<<-END)
+# -*- warn_indent: true -*-
+class Foo
+end
+    END
+
+    assert_equal 0, associations.size
+  end
+
+  def test_associate_warn_past_scope
+    ast, associations = associate(<<-END)
+# warn_past_scope: true
+class Foo
+end
+    END
+
+    assert_equal 0, associations.size
+  end
+
+  def test_associate_warn_past_scope_dash_star_dash
+    ast, associations = associate(<<-END)
+# -*- warn_past_scope: true -*-
+class Foo
+end
+    END
+
+    assert_equal 0, associations.size
+  end
+
+  def test_associate_multiple
+    ast, associations = associate(<<-END)
+# frozen_string_literal: true; warn_indent: true
+class Foo
+end
+    END
+
+    assert_equal 0, associations.size
+  end
+
+  def test_associate_multiple_dash_star_dash
+    ast, associations = associate(<<-END)
+# -*- frozen_string_literal: true; warn_indent: true -*-
+class Foo
+end
+    END
+
+    assert_equal 0, associations.size
+  end
+
   def test_associate_no_comments
     ast, associations = associate(<<-END)
 class Foo


### PR DESCRIPTION
This makes the comment associator ignore the following magic comments:

* `frozen_string_literal`
* `warn_indent`
* `warn_past_scope`

Fixes #386.

Questions:

* `MAGIC_COMMENT_RE` and `Buffer::ENCODING_RE` are very similar. I’d prefer for them to be combined somehow, but I can’t think of a good way to do it. Might it make sense to move `MAGIC_COMMENT_RE` into `Buffer`, at least?

* `warn_past_scope` is only activated when `WARN_PAST_SCOPE` is set when compiling Ruby (it isn’t by default). Given that, does it still make sense to support it?