### PR TITLE
does not capture unused value.

### DIFF
--- a/lib/parser/source/comment/associator.rb
+++ b/lib/parser/source/comment/associator.rb
@@ -184,7 +184,7 @@ module Parser
         advance_comment
       end
 
-      MAGIC_COMMENT_RE = /^#\s*(-\*-|)\s*(frozen_string_literal|warn_indent|warn_past_scope):.*\1$/
+      MAGIC_COMMENT_RE = /^#\s*(-\*-|)\s*(?:frozen_string_literal|warn_indent|warn_past_scope):.*\1$/
 
       def advance_through_directives
         # Skip shebang.


### PR DESCRIPTION
MAGIC_COMMENT_RE is introduced by #387 

it captured 2 variable, but it does not used 2nd variable.
