### PR TITLE
use String#start_with? instread of Regexp match

### DIFF
--- a/lib/parser/source/comment/associator.rb
+++ b/lib/parser/source/comment/associator.rb
@@ -188,7 +188,7 @@ module Parser
 
       def advance_through_directives
         # Skip shebang.
-        if @current_comment && @current_comment.text =~ /^#!/
+        if @current_comment && @current_comment.text.start_with?('#!')
           advance_comment
         end
 


### PR DESCRIPTION
String#start_with? is faster than Regex match If it does not need Regexp match.

