### PR TITLE
Allow rescue/else/ensure inside do/end blocks. [Feature #12906]

### DIFF
--- a/lib/parser/ruby25.y
+++ b/lib/parser/ruby25.y
@@ -1603,7 +1603,7 @@ opt_block_args_tail:
                       result = @lexer.cmdarg.dup
                       @lexer.cmdarg.clear
                     }
-                    opt_block_param compstmt
+                    opt_block_param bodystmt
                     {
                       result = [ val[2], val[3] ]
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -4992,6 +4992,23 @@ class TestParser < Minitest::Test
       SINCE_1_9)
   end
 
+  def test_rescue_without_begin_end
+    assert_parses(
+      s(:block,
+        s(:send, nil, :meth),
+        s(:args),
+        s(:rescue,
+          s(:lvar, :foo),
+          s(:resbody, nil, nil,
+            s(:lvar, :bar)),
+          nil)),
+      %q{meth do; foo; rescue; bar; end},
+      %q{              ~~~~~~ keyword (rescue.resbody)
+        |              ~~~~~~~~~~~ expression (rescue.resbody)
+        |         ~~~~~~~~~~~~~~~~ expression (rescue)},
+      SINCE_2_5)
+  end
+
   def test_resbody_list
     assert_parses(
       s(:kwbegin,


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/337