### PR TITLE
Relax restriction spaces inside "\u{...}".

### DIFF
--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -1229,6 +1229,46 @@ class TestLexer < Minitest::Test
     refute_scanned '?\\u{123'
   end
 
+  def test_question_eh_escape_space_around_unicode_point__19
+    setup_lexer 19
+    refute_scanned '"\\u{1 }"'
+
+    setup_lexer 19
+    refute_scanned '"\\u{ 1}"'
+
+    setup_lexer 19
+    refute_scanned '"\\u{ 1 }"'
+
+    setup_lexer 19
+    refute_scanned '"\\u{1 2 }"'
+
+    setup_lexer 19
+    refute_scanned '"\\u{ 1 2}"'
+
+    setup_lexer 19
+    refute_scanned '"\\u{1  2}"'
+  end
+
+  def test_question_eh_escape_space_around_unicode_point__24
+    setup_lexer 24
+    assert_scanned '"\\u{ 1}"', :tSTRING, "\u0001", [0, 8]
+
+    setup_lexer 24
+    assert_scanned '"\\u{1 }"', :tSTRING, "\u0001", [0, 8]
+
+    setup_lexer 24
+    assert_scanned '"\\u{ 1 }"', :tSTRING, "\u0001", [0, 9]
+
+    setup_lexer 24
+    assert_scanned '"\\u{1 2 }"', :tSTRING, "\u0001\u0002", [0, 10]
+
+    setup_lexer 24
+    assert_scanned '"\\u{ 1 2}"', :tSTRING, "\u0001\u0002", [0, 10]
+
+    setup_lexer 24
+    assert_scanned '"\\u{1  2}"', :tSTRING, "\u0001\u0002", [0, 10]
+  end
+
   def test_integer_hex
     assert_scanned "0x2a", :tINTEGER, 42, [0, 4]
   end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/330.

This is my first contribution to lexer, so I need some help:
1. ~~There's 1 failing spec - `"\u{}"` should produce an error, there's an explicit machine (line 738) that handles it, but for some reason ragel doesn't enter it (I'm still reading ragel guide, so I guess I simply don't understand something). This rule is on top of all `u{` rules, and it matches a string content completely. Ragel emits an unescaped string.~~
2. Is there some style guide for ragel syntax? I've tried to write rules using existing code style, is it ok?
3. Also I have a feeling that probably it makes sense to extract parts related to whitespace handling to separate machines (something like `optional_surrounding_spaces_in_unicode_codepoints` / `spaces_in_unicode_codepoints`, as those rules are different).