### PR TITLE
Allow newlines in heredoc identifiers.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -1669,18 +1669,29 @@ class Parser::Lexer
       # <<-END | <<-'END' | <<-"END" | <<-`END` |
       # <<~END | <<~'END' | <<~"END" | <<~`END`
       '<<' [~\-]?
-        ( '"' ( c_line - '"' )* '"'
-        | "'" ( c_line - "'" )* "'"
-        | "`" ( c_line - "`" )* "`"
+        ( '"' ( any - '"' )* '"'
+        | "'" ( any - "'" )* "'"
+        | "`" ( any - "`" )* "`"
         | bareword ) % { heredoc_e      = p }
         c_line* c_nl % { new_herebody_s = p }
       => {
-        tok(@ts, heredoc_e) =~ /^<<(-?)(~?)(["'`]?)(.*)\3$/
+        tok(@ts, heredoc_e) =~ /^<<(-?)(~?)(["'`]?)(.*)\3$/m
 
         indent      = !$1.empty? || !$2.empty?
         dedent_body = !$2.empty?
         type        =  $3.empty? ? '<<"'.freeze : ('<<'.freeze + $3)
         delimiter   =  $4
+
+        if @version >= 24
+          if delimiter.count("\n") > 0
+            if delimiter.end_with?("\n")
+              diagnostic :warning, :heredoc_id_ends_with_nl, nil, range(@ts, @ts + 1)
+              delimiter = delimiter.rstrip
+            else
+              diagnostic :fatal, :heredoc_id_has_newline, nil, range(@ts, @ts + 1)
+            end
+          end
+        end
 
         if dedent_body && version?(18, 19, 20, 21, 22)
           emit(:tLSHFT, '<<'.freeze, @ts, @ts + 2)

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -26,6 +26,8 @@ module Parser
     :bare_backslash          => 'bare backslash only allowed before newline',
     :unexpected              => "unexpected `%{character}'",
     :embedded_document       => 'embedded document meets end of file (and they embark on a romantic journey)',
+    :heredoc_id_has_newline  => 'here document identifier across newlines, never match',
+    :heredoc_id_ends_with_nl => 'here document identifier ends with a newline',
 
     # Lexer warnings
     :invalid_escape_use      => 'invalid character syntax; use ?%{escape}',

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -974,6 +974,34 @@ class TestLexer < Minitest::Test
                    :tNL,             nil,          [8, 9])
   end
 
+  def test_heredoc_with_identifier_ending_newline__19
+    setup_lexer 19
+    refute_scanned "<<\"EOS\n\"\n123\nEOS\n"
+  end
+
+  def test_heredoc_with_identifier_ending_newline__24
+    setup_lexer 24
+
+    assert_scanned("a = <<\"EOS\n\"\nABCDEF\nEOS\n",
+                   :tIDENTIFIER,     "a",          [0, 1],
+                   :tEQL,            "=",          [2, 3],
+                   :tSTRING_BEG,     "<<\"",       [4, 12],
+                   :tSTRING_CONTENT, "ABCDEF\n",   [13, 20],
+                   :tSTRING_END,     "EOS",        [20, 23],
+                   :tNL,             nil,          [12, 13])
+  end
+
+  def test_heredoc_with_identifier_containing_newline_inside__19
+    setup_lexer 19
+    refute_scanned "<<\"EOS\nEOS\"\n123\nEOS\n"
+  end
+
+  def test_heredoc_with_identifier_containing_newline_inside__24
+    setup_lexer 24
+
+    refute_scanned "<<\"EOS\nEOS\"\n123\nEOS\n"
+  end
+
   def test_identifier
     assert_scanned("identifier",
                    :tIDENTIFIER, "identifier", [0, 10])


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/334