### PR TITLE
Allow do after cmdarg in paren.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -424,8 +424,10 @@ class Parser::Lexer
     if old_literal.type == :tREGEXP_BEG
       # Fetch modifiers.
       self.class.lex_en_regexp_modifiers
-    else
+    elsif @version < 24
       self.class.lex_en_expr_end
+    else
+      self.class.lex_en_expr_endarg
     end
   end
 
@@ -1096,13 +1098,25 @@ class Parser::Lexer
         end
 
         emit(:tREGEXP_OPT)
-        fnext expr_end; fbreak;
+
+        if @version < 24
+          fnext expr_end;
+        else
+          fnext expr_endarg;
+        end
+
+        fbreak;
       };
 
       any
       => {
         emit(:tREGEXP_OPT, tok(@ts, @te - 1), @ts, @te - 1)
-        fhold; fgoto expr_end;
+        fhold;
+        if @version < 24
+          fgoto expr_end;
+        else
+          fgoto expr_endarg;
+        end
       };
   *|;
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -5969,6 +5969,170 @@ class TestParser < Minitest::Test
       %q{    ^^^^^^ location})
   end
 
+  def test_ruby_bug_11873
+    # strings
+    assert_parses(
+      s(:block,
+        s(:send, nil, :a,
+          s(:block,
+            s(:send, nil, :b),
+            s(:args),
+            s(:send, nil, :c, s(:send, nil, :d))),
+          s(:str, "x")),
+        s(:args),
+        nil),
+      %q{a b{c d}, "x" do end},
+      %q{},
+      SINCE_2_4)
+
+    assert_parses(
+      s(:block,
+        s(:send, nil, :a,
+          s(:send, nil, :b,
+            s(:send, nil, :c,
+              s(:send, nil, :d))),
+          s(:str, "x")),
+        s(:args),
+        nil),
+      %q{a b(c d), "x" do end},
+      %q{},
+      SINCE_2_4)
+
+    assert_parses(
+      s(:block,
+        s(:send, nil, :a,
+          s(:block,
+            s(:send, nil, :b),
+            s(:args),
+            s(:send, nil, :c,
+              s(:send, nil, :d))),
+          s(:str, "x")),
+        s(:args), nil),
+      %q{a b{c(d)}, "x" do end},
+      %q{},
+      SINCE_2_4)
+
+    assert_parses(
+      s(:block,
+        s(:send, nil, :a,
+          s(:send, nil, :b,
+            s(:send, nil, :c,
+              s(:send, nil, :d))),
+          s(:str, "x")),
+        s(:args), nil),
+      %q{a b(c(d)), "x" do end},
+      %q{},
+      SINCE_2_4)
+
+    # regexps without options
+    assert_parses(
+      s(:block,
+        s(:send, nil, :a,
+          s(:block,
+            s(:send, nil, :b),
+            s(:args),
+            s(:send, nil, :c, s(:send, nil, :d))),
+          s(:regexp, s(:str, "x"), s(:regopt))),
+        s(:args),
+        nil),
+      %q{a b{c d}, /x/ do end},
+      %q{},
+      SINCE_2_4)
+
+    assert_parses(
+      s(:block,
+        s(:send, nil, :a,
+          s(:send, nil, :b,
+            s(:send, nil, :c,
+              s(:send, nil, :d))),
+          s(:regexp, s(:str, "x"), s(:regopt))),
+        s(:args),
+        nil),
+      %q{a b(c d), /x/ do end},
+      %q{},
+      SINCE_2_4)
+
+    assert_parses(
+      s(:block,
+        s(:send, nil, :a,
+          s(:block,
+            s(:send, nil, :b),
+            s(:args),
+            s(:send, nil, :c,
+              s(:send, nil, :d))),
+          s(:regexp, s(:str, "x"), s(:regopt))),
+        s(:args), nil),
+      %q{a b{c(d)}, /x/ do end},
+      %q{},
+      SINCE_2_4)
+
+    assert_parses(
+      s(:block,
+        s(:send, nil, :a,
+          s(:send, nil, :b,
+            s(:send, nil, :c,
+              s(:send, nil, :d))),
+          s(:regexp, s(:str, "x"), s(:regopt))),
+        s(:args), nil),
+      %q{a b(c(d)), /x/ do end},
+      %q{},
+      SINCE_2_4)
+
+    # regexps with options
+    assert_parses(
+      s(:block,
+        s(:send, nil, :a,
+          s(:block,
+            s(:send, nil, :b),
+            s(:args),
+            s(:send, nil, :c, s(:send, nil, :d))),
+          s(:regexp, s(:str, "x"), s(:regopt, :m))),
+        s(:args),
+        nil),
+      %q{a b{c d}, /x/m do end},
+      %q{},
+      SINCE_2_4)
+
+    assert_parses(
+      s(:block,
+        s(:send, nil, :a,
+          s(:send, nil, :b,
+            s(:send, nil, :c,
+              s(:send, nil, :d))),
+          s(:regexp, s(:str, "x"), s(:regopt, :m))),
+        s(:args),
+        nil),
+      %q{a b(c d), /x/m do end},
+      %q{},
+      SINCE_2_4)
+
+    assert_parses(
+      s(:block,
+        s(:send, nil, :a,
+          s(:block,
+            s(:send, nil, :b),
+            s(:args),
+            s(:send, nil, :c,
+              s(:send, nil, :d))),
+          s(:regexp, s(:str, "x"), s(:regopt, :m))),
+        s(:args), nil),
+      %q{a b{c(d)}, /x/m do end},
+      %q{},
+      SINCE_2_4)
+
+    assert_parses(
+      s(:block,
+        s(:send, nil, :a,
+          s(:send, nil, :b,
+            s(:send, nil, :c,
+              s(:send, nil, :d))),
+          s(:regexp, s(:str, "x"), s(:regopt, :m))),
+        s(:args), nil),
+      %q{a b(c(d)), /x/m do end},
+      %q{},
+      SINCE_2_4)
+  end
+
   def test_parser_bug_198
     assert_parses(
       s(:array,


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/347

@whitequark Is it possible to move it to `ruby24.y/ruby25.y`? 