### PR TITLE
Change relative order of insert_after_multi and insert_before_multi

### DIFF
--- a/lib/parser/source/rewriter.rb
+++ b/lib/parser/source/rewriter.rb
@@ -71,16 +71,40 @@ module Parser
         append Rewriter::Action.new(range.begin, content)
       end
 
+      INSERT_GROUP_SEPARATOR = 0x1fff_ffff # Any big enough integer will do. This one fits in a Fixnum
+
       ##
       # Inserts new code before the given source range by allowing other
       # insertions at the same position.
-      # Note that an insertion with latter invocation comes _before_ earlier
-      # insertion at the same position in the rewritten source.
+      # Note that multiple insertions at the same position are done in groups:
+      #  - insert_after_multi (with non empty ranges ending at insertion point)
+      #  - insert_before_multi at insertion point (i.e. empty range)
+      #  - insert_after_multi at insertion point (i.e. empty range)
+      #  - insert_before_multi (with non empty ranges beginning at insertion point)
       #
-      # @example Inserting '[('
+      #  Within each group of `insert_before_multi`, the insertions are done
+      #  in the _reverse_ order they were given, while each group of `insert_after_multi` is
+      #  processed in the _same_ order they were given.
+      #
+      # @example Inserting '[(' before and ')]' after a range:
       #   rewriter.
       #     insert_before_multi(range, '(').
+      #     insert_after_multi(range, ')').
       #     insert_before_multi(range, '[').
+      #     insert_after_multi(range, ']').
+      #     process
+      #
+      # @example Inserting '>{}<'
+      #   insertion_point = range.end
+      #   # Assume that range and other_range non empty ranges such that
+      #   insertion_point == other_range.begin # => true
+      #   # The following will insert '>{}<' for any order of the calls to `insert...`:
+      #
+      #   rewriter.
+      #     insert_after_multi(range, '>').
+      #     insert_before_multi(insertion_point, '{').
+      #     insert_after_multi(insertion_point, '}').
+      #     insert_before_multi(other_range, '<').
       #     process
       #
       # @param [Range] range
@@ -90,7 +114,8 @@ module Parser
       #
       def insert_before_multi(range, content)
         @insert_before_multi_order -= 1
-        append Rewriter::Action.new(range.begin, content, true, @insert_before_multi_order)
+        group_delta = range.empty? ? 0 : INSERT_GROUP_SEPARATOR
+        append Rewriter::Action.new(range.begin, content, true, @insert_before_multi_order + group_delta)
       end
 
       ##
@@ -108,14 +133,7 @@ module Parser
       ##
       # Inserts new code after the given source range by allowing other
       # insertions at the same position.
-      # Note that an insertion with latter invocation comes _after_ earlier
-      # insertion at the same position in the rewritten source.
-      #
-      # @example Inserting ')]'
-      #   rewriter.
-      #     insert_after_multi(range, ')').
-      #     insert_after_multi(range, ']').
-      #     process
+      # See `insert_before_multi` for examples and details on the order.
       #
       # @param [Range] range
       # @param [String] content
@@ -124,7 +142,8 @@ module Parser
       #
       def insert_after_multi(range, content)
         @insert_after_multi_order += 1
-        append Rewriter::Action.new(range.end, content, true, @insert_after_multi_order)
+        group_delta = range.empty? ? 0 : INSERT_GROUP_SEPARATOR
+        append Rewriter::Action.new(range.end, content, true, @insert_after_multi_order - group_delta)
       end
 
       ##

--- a/test/test_source_rewriter.rb
+++ b/test/test_source_rewriter.rb
@@ -145,6 +145,36 @@ class TestSourceRewriter < Minitest::Test
         process
   end
 
+  def test_intentional_multiple_insertions_at_same_location_with_after_then_before
+    assert_equal 'foo ba>1>2{b{aa}b}2<1<r baz',
+      @rewriter.
+        insert_after_multi(range(5, 1), '>1').
+        insert_after_multi(range(6, 0), 'a}').
+        insert_before_multi(range(6, 0), '{a').
+        insert_before_multi(range(6, 1), '1<').
+        insert_after_multi(range(5, 1), '>2').
+        insert_after_multi(range(6, 0), 'b}').
+        insert_before_multi(range(6, 0), '{b').
+        insert_before_multi(range(6, 1), '2<').
+        process
+  end
+
+  def test_intentional_multiple_insertions_at_same_location_with_before_then_after
+    # Same test as above, with same result, but with first and second half of
+    # commands given in reverse order.
+    assert_equal 'foo ba>1>2{b{aa}b}2<1<r baz',
+      @rewriter.
+        insert_before_multi(range(6, 1), '1<').
+        insert_before_multi(range(6, 0), '{a').
+        insert_after_multi(range(6, 0), 'a}').
+        insert_after_multi(range(5, 1), '>1').
+        insert_before_multi(range(6, 1), '2<').
+        insert_before_multi(range(6, 0), '{b').
+        insert_after_multi(range(6, 0), 'b}').
+        insert_after_multi(range(5, 1), '>2').
+        process
+  end
+
   def test_insertion_within_replace_clobber
     silence_diagnostics
 


### PR DESCRIPTION
While the order of multiple calls to either `insert_after_multi` or `insert_before_multi` is well tested and documented, the relative order of `insert_after_multi` and `insert_before_multi` done at the same point isn't.

My use case is I wanted to rewrite:
```
foo.bar
```
into:
```
<span class="...">foo</span><span>.</span><span ...>bar</span>
```

To do so, I inserted my opening tags before each range, and my closing tags after. This gives me the wrong result! I'd have to insert my opening tags using `insert_after` and my closing tags using `insert_before`!

This PR fixes it by prioritizing `insert_after` over `insert_before`. This is a potentially breaking change, but neither the doc nor the tests condone the current behavior. 

Implementation isn't super pretty, but I favored it over changing `Change#<=>` to account for signs because this relative order is not `Change`'s responsibility but the `Rewriter`'s.