### PR TITLE
+ Add Range#with. Use it where convenient

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1207,13 +1207,9 @@ module Parser
     def delimited_string_map(string_t)
       str_range = loc(string_t)
 
-      begin_l = Source::Range.new(str_range.source_buffer,
-                                  str_range.begin_pos,
-                                  str_range.begin_pos + 1)
+      begin_l = str_range.with(end_pos: str_range.begin_pos + 1)
 
-      end_l   = Source::Range.new(str_range.source_buffer,
-                                  str_range.end_pos - 1,
-                                  str_range.end_pos)
+      end_l   = str_range.with(begin_pos: str_range.end_pos - 1)
 
       Source::Map::Collection.new(begin_l, end_l,
                                   loc(string_t))
@@ -1222,9 +1218,7 @@ module Parser
     def prefix_string_map(symbol)
       str_range = loc(symbol)
 
-      begin_l = Source::Range.new(str_range.source_buffer,
-                                  str_range.begin_pos,
-                                  str_range.begin_pos + 1)
+      begin_l = str_range.with(end_pos: str_range.begin_pos + 1)
 
       Source::Map::Collection.new(begin_l, nil,
                                   loc(symbol))
@@ -1238,13 +1232,9 @@ module Parser
     def pair_keyword_map(key_t, value_e)
       key_range = loc(key_t)
 
-      key_l   = Source::Range.new(key_range.source_buffer,
-                                  key_range.begin_pos,
-                                  key_range.end_pos - 1)
+      key_l   = key_range.with(end_pos: key_range.end_pos - 1)
 
-      colon_l = Source::Range.new(key_range.source_buffer,
-                                  key_range.end_pos - 1,
-                                  key_range.end_pos)
+      colon_l = key_range.with(begin_pos: key_range.end_pos - 1)
 
       [ # key map
         Source::Map::Collection.new(nil, nil,
@@ -1257,13 +1247,10 @@ module Parser
     def pair_quoted_map(begin_t, end_t, value_e)
       end_l = loc(end_t)
 
-      quote_l = Source::Range.new(end_l.source_buffer,
-                                  end_l.end_pos - 2,
-                                  end_l.end_pos - 1)
+      quote_l = end_l.with(begin_pos: end_l.end_pos - 2,
+                           end_pos: end_l.end_pos - 1)
 
-      colon_l = Source::Range.new(end_l.source_buffer,
-                                  end_l.end_pos - 1,
-                                  end_l.end_pos)
+      colon_l = end_l.with(begin_pos: end_l.end_pos - 1)
 
       [ # modified end token
         [ value(end_t), quote_l ],
@@ -1351,9 +1338,7 @@ module Parser
 
     def kwarg_map(name_t, value_e=nil)
       label_range = loc(name_t)
-      name_range  = Source::Range.new(label_range.source_buffer,
-                                      label_range.begin_pos,
-                                      label_range.end_pos - 1)
+      name_range  = label_range.with(end_pos: label_range.end_pos - 1)
 
       if value_e
         expr_l = loc(name_t).join(value_e.loc.expression)

--- a/lib/parser/diagnostic.rb
+++ b/lib/parser/diagnostic.rb
@@ -152,9 +152,7 @@ module Parser
     #
     def last_line_only(range)
       if range.line != range.last_line
-        Source::Range.new(range.source_buffer,
-                          range.begin_pos + (range.source =~ /[^\n]*\z/),
-                          range.end_pos)
+        range.with(begin_pos: range.begin_pos + (range.source =~ /[^\n]*\z/))
       else
         range
       end

--- a/lib/parser/source/range.rb
+++ b/lib/parser/source/range.rb
@@ -49,7 +49,7 @@ module Parser
       #   of this range.
       #
       def begin
-        Range.new(@source_buffer, @begin_pos, @begin_pos)
+        with(end_pos: @begin_pos)
       end
 
       ##
@@ -57,7 +57,7 @@ module Parser
       #   of this range.
       #
       def end
-        Range.new(@source_buffer, @end_pos, @end_pos)
+        with(begin_pos: @end_pos)
       end
 
       ##
@@ -166,11 +166,19 @@ module Parser
       end
 
       ##
+      # @param [Hash] Endpoint(s) to change, any combination of :begin_pos or :end_pos
+      # @return [Range] the same range as this range but with the given end point(s) changed
+      #
+      def with(pos)
+        Range.new(@source_buffer,pos.fetch(:begin_pos, @begin_pos), pos.fetch(:end_pos, @end_pos))
+      end
+
+      ##
       # @param [Integer] new_size
       # @return [Range] a range beginning at the same point as this range and length `new_size`.
       #
       def resize(new_size)
-        Range.new(@source_buffer, @begin_pos, @begin_pos + new_size)
+        with(end_pos: @begin_pos + new_size)
       end
 
       ##

--- a/test/test_source_range.rb
+++ b/test/test_source_range.rb
@@ -122,4 +122,15 @@ class TestSourceRange < Minitest::Test
     sr = Parser::Source::Range.new(@buf, 8, 9)
     assert_equal '(string):2:2', sr.to_s
   end
+
+  def test_with
+    sr1 = Parser::Source::Range.new(@buf, 1, 3)
+    sr2 = sr1.with(begin_pos: 2)
+    sr3 = sr1.with(end_pos: 4)
+
+    assert_equal 2, sr2.begin_pos
+    assert_equal 3, sr2.end_pos
+    assert_equal 1, sr3.begin_pos
+    assert_equal 4, sr3.end_pos
+  end
 end


### PR DESCRIPTION
Whenever I work with ranges, I find that I'm always creating ranges from other ranges, tweaking either end points, sometimes both.

I'm proposing `Range#with` to easily update either or both end points.

This not only saves keystrokes, it makes it easier to read and see what is being changed.

I've used it 8 times in `parser` itself.

I'm counting about 20 uses in Rubocop (not counting the specs), plus eliminating [`slice_source`](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/format_string_token.rb#L126-L132) which it makes redundant.

PS: I was waiting for Ruby 1.9 support to die, but this version can do until then.