### PR TITLE
Fix Parser::Lexer::StackState#lexpop to match MRI behavior.

### DIFF
--- a/lib/parser/lexer/stack_state.rb
+++ b/lib/parser/lexer/stack_state.rb
@@ -25,7 +25,8 @@ module Parser
     end
 
     def lexpop
-      push(pop || pop)
+      @stack = ((@stack >> 1) | (@stack & 1))
+      @stack[0] == 1
     end
 
     def active?


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/398.

By the way, not sure what should be returned from `lexpop`. That's basically a void procedure and the code that invokes it never uses its return value. But there are some tests that actually use it for assertions, so I've changed the method to pass them. @whitequark Please, let me know if it's wrong and must be changed.