### PR TITLE
Utilities

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1232,7 +1232,7 @@ module Parser
     def pair_keyword_map(key_t, value_e)
       key_range = loc(key_t)
 
-      key_l   = key_range.with(end_pos: key_range.end_pos - 1)
+      key_l   = key_range.adjust(end_pos: -1)
 
       colon_l = key_range.with(begin_pos: key_range.end_pos - 1)
 
@@ -1338,7 +1338,7 @@ module Parser
 
     def kwarg_map(name_t, value_e=nil)
       label_range = loc(name_t)
-      name_range  = label_range.with(end_pos: label_range.end_pos - 1)
+      name_range  = label_range.adjust(end_pos: -1)
 
       if value_e
         expr_l = loc(name_t).join(value_e.loc.expression)

--- a/lib/parser/diagnostic.rb
+++ b/lib/parser/diagnostic.rb
@@ -152,7 +152,7 @@ module Parser
     #
     def last_line_only(range)
       if range.line != range.last_line
-        range.with(begin_pos: range.begin_pos + (range.source =~ /[^\n]*\z/))
+        range.adjust(begin_pos: range.source =~ /[^\n]*\z/)
       else
         range
       end

--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -289,6 +289,13 @@ module Parser
       end
 
       ##
+      # @return [Range] A range covering the whole source
+      #
+      def source_range
+        @source_range ||= Range.new(self, 0, source.size)
+      end
+
+      ##
       # Number of last line in the buffer
       #
       # @return [Integer]

--- a/lib/parser/source/range.rb
+++ b/lib/parser/source/range.rb
@@ -168,9 +168,19 @@ module Parser
       ##
       # @param [Hash] Endpoint(s) to change, any combination of :begin_pos or :end_pos
       # @return [Range] the same range as this range but with the given end point(s) changed
+      # to the given value(s).
       #
       def with(pos)
         Range.new(@source_buffer,pos.fetch(:begin_pos, @begin_pos), pos.fetch(:end_pos, @end_pos))
+      end
+
+      ##
+      # @param [Hash] Endpoint(s) to change, any combination of :begin_pos or :end_pos
+      # @return [Range] the same range as this range but with the given end point(s) adjusted
+      # by the given amount(s)
+      #
+      def adjust(begin_pos: 0, end_pos: 0)
+        Range.new(@source_buffer, @begin_pos + begin_pos, @end_pos + end_pos)
       end
 
       ##

--- a/test/test_source_buffer.rb
+++ b/test/test_source_buffer.rb
@@ -117,6 +117,18 @@ class TestSourceBuffer < Minitest::Test
     end
   end
 
+  def test_source_range
+    @buffer = Parser::Source::Buffer.new('(string)', 5)
+
+    assert_raises RuntimeError do
+      @buffer.source_range
+    end
+
+    @buffer.source = "abc\ndef\nghi\n"
+
+    assert_equal Parser::Source::Range.new(@buffer, 0, @buffer.source.size), @buffer.source_range
+  end
+
   def test_last_line
     @buffer.source = "1\nfoo\nbar"
     assert_equal 3, @buffer.last_line


### PR DESCRIPTION
Adds `Range#adjust` to get a new range from offsets.
Adds `Buffer#source_range`, a trivial method to get a source range from a Buffer.

I could split in two PRs if need be

(Prelude to TreeRewriter. Not needed per say, just thought they were "natural" features that could be useful to others)