### PR TITLE
Fix disjoint? for empty & different ranges. Add tests.

### DIFF
--- a/lib/parser/source/range.rb
+++ b/lib/parser/source/range.rb
@@ -223,8 +223,11 @@ module Parser
       # @return [Boolean]
       #
       def disjoint?(other)
-        (@begin_pos >= other.end_pos || other.begin_pos >= @end_pos) &&
-          (!empty? || !other.empty?)
+        if empty? && other.empty?
+          @begin_pos != other.begin_pos
+        else
+          @begin_pos >= other.end_pos || other.begin_pos >= @end_pos
+        end
       end
 
       ##

--- a/test/test_source_range.rb
+++ b/test/test_source_range.rb
@@ -6,6 +6,7 @@ class TestSourceRange < Minitest::Test
     @buf.source = "foobar\nbaz"
     @sr1_3 = Parser::Source::Range.new(@buf, 1, 3)
     @sr2_2 = Parser::Source::Range.new(@buf, 2, 2)
+    @sr3_3 = Parser::Source::Range.new(@buf, 3, 3)
     @sr2_6 = Parser::Source::Range.new(@buf, 2, 6)
     @sr5_8 = Parser::Source::Range.new(@buf, 5, 8)
   end
@@ -74,6 +75,7 @@ class TestSourceRange < Minitest::Test
   def test_disjoint
     check_relationship(:disjoint?, @sr1_3, @sr5_8)
     check_relationship(:disjoint?, @sr2_2, @sr2_6)
+    check_relationship(:disjoint?, @sr2_2, @sr3_3)
   end
 
   def test_crossing

--- a/test/test_source_range.rb
+++ b/test/test_source_range.rb
@@ -9,6 +9,8 @@ class TestSourceRange < Minitest::Test
     @sr3_3 = Parser::Source::Range.new(@buf, 3, 3)
     @sr2_6 = Parser::Source::Range.new(@buf, 2, 6)
     @sr5_8 = Parser::Source::Range.new(@buf, 5, 8)
+    @sr5_7 = Parser::Source::Range.new(@buf, 5, 7)
+    @sr6_7 = Parser::Source::Range.new(@buf, 6, 7)
   end
 
   def test_initialize
@@ -76,6 +78,7 @@ class TestSourceRange < Minitest::Test
     check_relationship(:disjoint?, @sr1_3, @sr5_8)
     check_relationship(:disjoint?, @sr2_2, @sr2_6)
     check_relationship(:disjoint?, @sr2_2, @sr3_3)
+    check_relationship(:disjoint?, @sr2_6, @sr6_7)
   end
 
   def test_crossing
@@ -84,7 +87,8 @@ class TestSourceRange < Minitest::Test
 
   def test_containment
     check_relationship(:contained?, @sr2_2, @sr1_3, :contains?)
-    check_relationship(:contained?, @sr5_8.with(end_pos: 7), @sr5_8, :contains?)
+    check_relationship(:contained?, @sr5_7, @sr5_8, :contains?)
+    check_relationship(:contained?, @sr6_7, @sr5_8, :contains?)
   end
 
   def test_empty


### PR DESCRIPTION
I'm not proud to admit I screwed up the corner case for empty ranges & `disjoint?`. I was actually missing a few tests too, which this completes.