### PR TITLE
Reject brace after literal arg.

### DIFF
--- a/lib/parser/ruby24.y
+++ b/lib/parser/ruby24.y
@@ -850,12 +850,11 @@ rule
                     }
 
     command_args:   {
-                      result = @lexer.cmdarg.dup
                       @lexer.cmdarg.push(true)
                     }
                   call_args
                     {
-                      @lexer.cmdarg = val[0]
+                      @lexer.cmdarg.pop
 
                       result = val[1]
                     }
@@ -1462,13 +1461,11 @@ opt_block_args_tail:
                     }
                   f_larglist
                     {
-                      result = @lexer.cmdarg.dup
-                      @lexer.cmdarg.clear
+                      @lexer.cmdarg.push(false)
                     }
                   lambda_body
                     {
-                      @lexer.cmdarg = val[2]
-                      @lexer.cmdarg.lexpop
+                      @lexer.cmdarg.pop
 
                       result = [ val[1], val[3] ]
 
@@ -1616,17 +1613,11 @@ opt_block_args_tail:
       brace_body:   {
                       @static_env.extend_dynamic
                     }
-                    {
-                      result = @lexer.cmdarg.dup
-                      @lexer.cmdarg.clear
-                    }
                     opt_block_param compstmt
                     {
-                      result = [ val[2], val[3] ]
+                      result = [ val[1], val[2] ]
 
                       @static_env.unextend
-                      @lexer.cmdarg = val[1]
-                      @lexer.cmdarg.pop
                     }
 
          do_body:   {
@@ -1846,7 +1837,7 @@ regexp_contents: # nothing
                     compstmt tSTRING_DEND
                     {
                       @lexer.cond.lexpop
-                      @lexer.cmdarg.lexpop
+                      @lexer.cmdarg.pop
 
                       result = @builder.begin(val[0], val[2], val[3])
                     }
@@ -1868,13 +1859,13 @@ regexp_contents: # nothing
 
           symbol: tSYMBOL
                     {
-                      @lexer.state = :expr_endarg
+                      @lexer.state = :expr_end
                       result = @builder.symbol(val[0])
                     }
 
             dsym: tSYMBEG xstring_contents tSTRING_END
                     {
-                      @lexer.state = :expr_endarg
+                      @lexer.state = :expr_end
                       result = @builder.symbol_compose(val[0], val[1], val[2])
                     }
 
@@ -1894,22 +1885,22 @@ regexp_contents: # nothing
 
   simple_numeric: tINTEGER
                     {
-                      @lexer.state = :expr_endarg
+                      @lexer.state = :expr_end
                       result = @builder.integer(val[0])
                     }
                 | tFLOAT
                     {
-                      @lexer.state = :expr_endarg
+                      @lexer.state = :expr_end
                       result = @builder.float(val[0])
                     }
                 | tRATIONAL
                     {
-                      @lexer.state = :expr_endarg
+                      @lexer.state = :expr_end
                       result = @builder.rational(val[0])
                     }
                 | tIMAGINARY
                     {
-                      @lexer.state = :expr_endarg
+                      @lexer.state = :expr_end
                       result = @builder.complex(val[0])
                     }
 

--- a/lib/parser/ruby25.y
+++ b/lib/parser/ruby25.y
@@ -846,12 +846,11 @@ rule
                     }
 
     command_args:   {
-                      result = @lexer.cmdarg.dup
                       @lexer.cmdarg.push(true)
                     }
                   call_args
                     {
-                      @lexer.cmdarg = val[0]
+                      @lexer.cmdarg.pop
 
                       result = val[1]
                     }
@@ -1465,13 +1464,11 @@ opt_block_args_tail:
                     }
                   f_larglist
                     {
-                      result = @lexer.cmdarg.dup
-                      @lexer.cmdarg.clear
+                      @lexer.cmdarg.push(false)
                     }
                   lambda_body
                     {
-                      @lexer.cmdarg = val[2]
-                      @lexer.cmdarg.lexpop
+                      @lexer.cmdarg.pop
 
                       result = [ val[1], val[3] ]
 
@@ -1619,17 +1616,11 @@ opt_block_args_tail:
       brace_body:   {
                       @static_env.extend_dynamic
                     }
-                    {
-                      result = @lexer.cmdarg.dup
-                      @lexer.cmdarg.clear
-                    }
                     opt_block_param compstmt
                     {
-                      result = [ val[2], val[3] ]
+                      result = [ val[1], val[2] ]
 
                       @static_env.unextend
-                      @lexer.cmdarg = val[1]
-                      @lexer.cmdarg.pop
                     }
 
          do_body:   {
@@ -1849,7 +1840,7 @@ regexp_contents: # nothing
                     compstmt tSTRING_DEND
                     {
                       @lexer.cond.lexpop
-                      @lexer.cmdarg.lexpop
+                      @lexer.cmdarg.pop
 
                       result = @builder.begin(val[0], val[2], val[3])
                     }
@@ -1871,13 +1862,13 @@ regexp_contents: # nothing
 
           symbol: tSYMBOL
                     {
-                      @lexer.state = :expr_endarg
+                      @lexer.state = :expr_end
                       result = @builder.symbol(val[0])
                     }
 
             dsym: tSYMBEG xstring_contents tSTRING_END
                     {
-                      @lexer.state = :expr_endarg
+                      @lexer.state = :expr_end
                       result = @builder.symbol_compose(val[0], val[1], val[2])
                     }
 
@@ -1897,22 +1888,22 @@ regexp_contents: # nothing
 
   simple_numeric: tINTEGER
                     {
-                      @lexer.state = :expr_endarg
+                      @lexer.state = :expr_end
                       result = @builder.integer(val[0])
                     }
                 | tFLOAT
                     {
-                      @lexer.state = :expr_endarg
+                      @lexer.state = :expr_end
                       result = @builder.float(val[0])
                     }
                 | tRATIONAL
                     {
-                      @lexer.state = :expr_endarg
+                      @lexer.state = :expr_end
                       result = @builder.rational(val[0])
                     }
                 | tIMAGINARY
                     {
-                      @lexer.state = :expr_endarg
+                      @lexer.state = :expr_end
                       result = @builder.complex(val[0])
                     }
 

--- a/test/parse_helper.rb
+++ b/test/parse_helper.rb
@@ -179,6 +179,42 @@ module ParseHelper
     end
   end
 
+  # Use like this:
+  # ~~~
+  # assert_diagnoses_many(
+  #   [
+  #     [:warning, :ambiguous_literal],
+  #     [:error, :unexpected_token, { :token => :tLCURLY }]
+  #   ],
+  #   %q{m /foo/ {}},
+  #   SINCE_2_4)
+  # ~~~
+  def assert_diagnoses_many(diagnostics, code, versions=ALL_VERSIONS)
+    with_versions(versions) do |version, parser|
+      source_file = Parser::Source::Buffer.new('(assert_diagnoses_many)')
+      source_file.source = code
+
+      begin
+        parser = parser.parse(source_file)
+      rescue Parser::SyntaxError
+        # do nothing; the diagnostic was reported
+      end
+
+      assert_equal diagnostics.count, @diagnostics.count
+
+      diagnostics.zip(@diagnostics) do |expected_diagnostic, actual_diagnostic|
+        level, reason, arguments = expected_diagnostic
+        arguments ||= {}
+        message     = Parser::MESSAGES[reason] % arguments
+
+        assert_equal level, actual_diagnostic.level
+        assert_equal reason, actual_diagnostic.reason
+        assert_equal arguments, actual_diagnostic.arguments
+        assert_equal message, actual_diagnostic.message
+      end
+    end
+  end
+
   def refute_diagnoses(code, versions=ALL_VERSIONS)
     with_versions(versions) do |version, parser|
       source_file = Parser::Source::Buffer.new('(refute_diagnoses)')

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6482,4 +6482,104 @@ class TestParser < Minitest::Test
       refute_diagnoses(code, SINCE_1_9)
     end
   end
+
+  def test_ruby_bug_13547
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tLCURLY' }],
+      %q{m "x" {}},
+      %q{      ^ location},
+      SINCE_2_4)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tLCURLY' }],
+      %q{m "#{'x'}" {}},
+      %q{           ^ location},
+      SINCE_2_4)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tLCURLY' }],
+      %q{m 1 {}},
+      %q{    ^ location},
+      SINCE_2_4)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tLCURLY' }],
+      %q{m 1.0 {}},
+      %q{      ^ location},
+      SINCE_2_4)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tLCURLY' }],
+      %q{m 1r {}},
+      %q{     ^ location},
+      SINCE_2_4)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tLCURLY' }],
+      %q{m 1i {}},
+      %q{     ^ location},
+      SINCE_2_4)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tLCURLY' }],
+      %q{m :m {}},
+      %q{     ^ location},
+      SINCE_2_4)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tLCURLY' }],
+      %q{m :"#{m}" {}},
+      %q{          ^ location},
+      SINCE_2_4)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tLCURLY' }],
+      %q{m %[] {}},
+      %q{      ^ location},
+      SINCE_2_4)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tLCURLY' }],
+      %q{m 0..1 {}},
+      %q{       ^ location},
+      SINCE_2_4)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tLCURLY' }],
+      %q{m 0...1 {}},
+      %q{        ^ location},
+      SINCE_2_4)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tLCURLY' }],
+      %q{m [] {}},
+      %q{     ^ location},
+      SINCE_2_4)
+
+    assert_parses(
+      s(:block,
+        s(:send,
+          s(:send, nil, :meth), :[]),
+        s(:args), nil),
+      %q{meth[] {}},
+      %q{},
+      SINCE_2_4
+    )
+
+    assert_diagnoses_many(
+      [
+        [:warning, :ambiguous_literal],
+        [:error, :unexpected_token, { :token => 'tLCURLY' }]
+      ],
+      %q{m /foo/ {}},
+      SINCE_2_4)
+
+    assert_diagnoses_many(
+      [
+        [:warning, :ambiguous_literal],
+        [:error, :unexpected_token, { :token => 'tLCURLY' }]
+      ],
+      %q{m /foo/x {}},
+      SINCE_2_4)
+  end
 end


### PR DESCRIPTION
Hopefully closes https://github.com/whitequark/parser/issues/359

@whitequark A couple of questions:
1. Do you see any other cases that need to be tested?
2. This behavior is common for all ruby versions (tests pass when I change `SINCE_2_4` to `ALL_VERSIONS`) and I don't see any similar tests for older versions of parser. Should I put `ALL_VERSIONS` to these tests?