### PR TITLE
Disable tLPAREN_ARG state by local variable.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -1901,6 +1901,21 @@ class Parser::Lexer
       call_or_var
       => local_ident;
 
+      (call_or_var - keyword)
+        % { ident_tok = tok; ident_ts = @ts; ident_te = @te; }
+      w_space+ '('
+      => {
+        emit(:tIDENTIFIER, ident_tok, ident_ts, ident_te)
+        p = ident_te - 1
+
+        if !@static_env.nil? && @static_env.declared?(ident_tok) && @version < 25
+          fnext expr_endfn;
+        else
+          fnext expr_cmdarg;
+        end
+        fbreak;
+      };
+
       #
       # WHITESPACE
       #

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6278,4 +6278,41 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_2_3)
   end
+
+  def test_lparenarg_after_lvar__since_25
+    assert_parses(
+      s(:send, nil, :meth,
+        s(:send,
+          s(:begin,
+            s(:float, -1.3)), :abs)),
+      %q{meth (-1.3).abs},
+      %q{},
+      ALL_VERSIONS - SINCE_2_5)
+
+    assert_parses(
+      s(:send,
+        s(:send, nil, :foo,
+          s(:float, -1.3)), :abs),
+      %q{foo (-1.3).abs},
+      %q{},
+      ALL_VERSIONS - SINCE_2_5)
+
+    assert_parses(
+      s(:send, nil, :meth,
+        s(:send,
+          s(:begin,
+            s(:float, -1.3)), :abs)),
+      %q{meth (-1.3).abs},
+      %q{},
+      SINCE_2_5)
+
+    assert_parses(
+      s(:send, nil, :foo,
+        s(:send,
+          s(:begin,
+            s(:float, -1.3)), :abs)),
+      %q{foo (-1.3).abs},
+      %q{},
+      SINCE_2_5)
+  end
 end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/367
ruby/ruby@50f7d64.