### PR TITLE
Add the required Ruby version to gemspec

### DIFF
--- a/parser.gemspec
+++ b/parser.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^test/})
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.0.0'
+
   spec.add_dependency             'ast',       '~> 2.3'
 
   spec.add_development_dependency 'bundler',   '~> 1.16'


### PR DESCRIPTION
`required_ruby_version` is missing from the gemspec.
