### PR TITLE
Emit :&& as tSYMBEG + tANDOP, :|| as tSYMBEG + tOROP.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -1740,6 +1740,13 @@ class Parser::Lexer
       # SYMBOL LITERALS
       #
 
+      # :&&, :||
+      ':' ('&&' | '||') => {
+        fhold; fhold;
+        emit(:tSYMBEG, tok(@ts, @ts + 1), @ts, @ts + 1)
+        fgoto expr_fname;
+      };
+
       # :"bar", :'baz'
       ':' ['"] # '
       => {

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -3451,4 +3451,16 @@ class TestLexer < Minitest::Test
                    :tSTRING_END,      "\"",  [15, 16])
   end
 
+  def test_bug_423
+    @lex.state = :expr_beg
+    assert_scanned(':&&',
+                   :tSYMBEG, ':',  [0, 1],
+                   :tANDOP,  '&&', [1, 3])
+
+    @lex.state = :expr_beg
+    assert_scanned(':||',
+                   :tSYMBEG, ':',  [0, 1],
+                   :tOROP,   '||', [1, 3])
+  end
+
 end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/423