### PR TITLE
update .travis.yml to running test with ruby 2.4.3 and ruby 2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ rvm:
  - 2.0.0
  - 2.2.9
  - 2.3.6
- - 2.4.0
+ - 2.4.3
+ - 2.5.0
  - ruby-head
- - jruby-9.1.14.0
+ - jruby-9.1.15.0
  - rbx-2
 matrix:
  allow_failures:


### PR DESCRIPTION
ruby 2.5.0 was released. https://www.ruby-lang.org/en/news/2017/12/25/ruby-2-5-0-released/

update 2.4.x to edge version https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-4-3-released/

update jruby version http://jruby.org/2017/12/07/jruby-9-1-15-0.html
