### PR TITLE
Enforcing frozen string literals with pragma comment.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in parser.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
-# encoding:utf-8
+# encoding: utf-8
+# frozen_string_literal: true
 
 require 'bundler/gem_tasks'
 require 'rake/testtask'

--- a/bin/ruby-parse
+++ b/bin/ruby-parse
@@ -1,4 +1,5 @@
-#!/usr/bin/env ruby
+#! /usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 require 'parser/runner/ruby_parse'

--- a/bin/ruby-rewrite
+++ b/bin/ruby-rewrite
@@ -1,4 +1,5 @@
-#!/usr/bin/env ruby
+#! /usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 require 'parser/runner/ruby_rewrite'

--- a/lib/gauntlet_parser.rb
+++ b/lib/gauntlet_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gauntlet'
 require 'parser/all'
 require 'shellwords'

--- a/lib/parser.rb
+++ b/lib/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if RUBY_VERSION =~ /^1\.[89]\./
   require 'parser/version'
   raise LoadError, <<-UNSUPPORTED_VERSION_MSG

--- a/lib/parser/all.rb
+++ b/lib/parser/all.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'parser/ruby18'
 require 'parser/ruby19'
 require 'parser/ruby20'

--- a/lib/parser/ast/node.rb
+++ b/lib/parser/ast/node.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module AST
 

--- a/lib/parser/ast/processor.rb
+++ b/lib/parser/ast/processor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module AST
 

--- a/lib/parser/base.rb
+++ b/lib/parser/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
 
   ##

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
 
   ##

--- a/lib/parser/clobbering_error.rb
+++ b/lib/parser/clobbering_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   ##
   # {Parser::ClobberingError} is raised when {Parser::Source::Rewriter}

--- a/lib/parser/context.rb
+++ b/lib/parser/context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   # Context of parsing that is represented by a stack of scopes.
   #

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   class << self
     def warn_syntax_deviation(feature, version)

--- a/lib/parser/deprecation.rb
+++ b/lib/parser/deprecation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   ##
   # @api private

--- a/lib/parser/diagnostic.rb
+++ b/lib/parser/diagnostic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
 
   ##

--- a/lib/parser/diagnostic/engine.rb
+++ b/lib/parser/diagnostic/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
 
   ##

--- a/lib/parser/lexer/dedenter.rb
+++ b/lib/parser/lexer/dedenter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
 
   class Lexer::Dedenter

--- a/lib/parser/lexer/explanation.rb
+++ b/lib/parser/lexer/explanation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
 
   module Lexer::Explanation

--- a/lib/parser/lexer/literal.rb
+++ b/lib/parser/lexer/literal.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 module Parser
 

--- a/lib/parser/lexer/literal.rb
+++ b/lib/parser/lexer/literal.rb
@@ -234,7 +234,7 @@ module Parser
     end
 
     def clear_buffer
-      @buffer = ''
+      @buffer = ''.dup
 
       # Prime the buffer with lexer encoding; otherwise,
       # concatenation will produce varying results.

--- a/lib/parser/lexer/stack_state.rb
+++ b/lib/parser/lexer/stack_state.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
 
   class Lexer::StackState

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   ##
   # Diagnostic messages (errors, warnings and notices) that can be generated.

--- a/lib/parser/meta.rb
+++ b/lib/parser/meta.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   # Parser metadata
   module Meta

--- a/lib/parser/rewriter.rb
+++ b/lib/parser/rewriter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
 
   ##

--- a/lib/parser/runner.rb
+++ b/lib/parser/runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark'
 require 'find'
 require 'optparse'

--- a/lib/parser/runner/ruby_parse.rb
+++ b/lib/parser/runner/ruby_parse.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'parser/runner'
 require 'parser/lexer/explanation'
 

--- a/lib/parser/runner/ruby_rewrite.rb
+++ b/lib/parser/runner/ruby_rewrite.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'parser/runner'
 require 'tempfile'
 

--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# frozen_string_literal: true
 
 module Parser
   module Source

--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -244,7 +244,7 @@ module Parser
       def source_lines
         @lines ||= begin
           lines = @source.lines.to_a
-          lines << '' if @source.end_with?("\n".freeze)
+          lines << ''.dup if @source.end_with?("\n".freeze)
 
           lines.each do |line|
             line.chomp!("\n".freeze)

--- a/lib/parser/source/comment.rb
+++ b/lib/parser/source/comment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/comment/associator.rb
+++ b/lib/parser/source/comment/associator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/map.rb
+++ b/lib/parser/source/map.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/map/collection.rb
+++ b/lib/parser/source/map/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/map/condition.rb
+++ b/lib/parser/source/map/condition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/map/constant.rb
+++ b/lib/parser/source/map/constant.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/map/definition.rb
+++ b/lib/parser/source/map/definition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/map/for.rb
+++ b/lib/parser/source/map/for.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/map/heredoc.rb
+++ b/lib/parser/source/map/heredoc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/map/keyword.rb
+++ b/lib/parser/source/map/keyword.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/map/objc_kwarg.rb
+++ b/lib/parser/source/map/objc_kwarg.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/map/operator.rb
+++ b/lib/parser/source/map/operator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/map/rescue_body.rb
+++ b/lib/parser/source/map/rescue_body.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/map/send.rb
+++ b/lib/parser/source/map/send.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/map/ternary.rb
+++ b/lib/parser/source/map/ternary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/map/variable.rb
+++ b/lib/parser/source/map/variable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/range.rb
+++ b/lib/parser/source/range.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/rewriter.rb
+++ b/lib/parser/source/rewriter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/rewriter.rb
+++ b/lib/parser/source/rewriter.rb
@@ -423,7 +423,7 @@ module Parser
       end
 
       def merge_replacements(actions)
-        result    = ''
+        result    = ''.dup
         prev_act  = nil
 
         actions.each do |act|

--- a/lib/parser/source/rewriter/action.rb
+++ b/lib/parser/source/rewriter/action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/tree_rewriter.rb
+++ b/lib/parser/source/tree_rewriter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
 

--- a/lib/parser/source/tree_rewriter/action.rb
+++ b/lib/parser/source/tree_rewriter/action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   module Source
     ##

--- a/lib/parser/static_environment.rb
+++ b/lib/parser/static_environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
 
   class StaticEnvironment

--- a/lib/parser/syntax_error.rb
+++ b/lib/parser/syntax_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   ##
   # {Parser::SyntaxError} is raised whenever parser detects a syntax error,

--- a/lib/parser/tree_rewriter.rb
+++ b/lib/parser/tree_rewriter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
 
   ##

--- a/lib/parser/version.rb
+++ b/lib/parser/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parser
   VERSION = '2.4.0.2'
 end

--- a/parser.gemspec
+++ b/parser.gemspec
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require File.expand_path('../lib/parser/version', __FILE__)
 

--- a/test/bug_163/fixtures/input.rb
+++ b/test/bug_163/fixtures/input.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if(true)
   puts "Hello, world!"
 end

--- a/test/bug_163/fixtures/output.rb
+++ b/test/bug_163/fixtures/output.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if true
   puts "Hello, world!"
 end

--- a/test/bug_163/rewriter.rb
+++ b/test/bug_163/rewriter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rewriter < Parser::Rewriter
   def on_if(node)
     # Crude, totally-not-usable-in-the-real-world code to remove optional

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tempfile'
 require 'minitest/test'
 

--- a/test/parse_helper.rb
+++ b/test/parse_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ParseHelper
   include AST::Sexp
 

--- a/test/racc_coverage_helper.rb
+++ b/test/racc_coverage_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'racc/grammarfileparser'
 
 # Unfortunately, Ruby's Coverage module ignores module_eval statements,

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 require 'parser/current'
 

--- a/test/test_current.rb
+++ b/test/test_current.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 require 'parser/current'
 

--- a/test/test_diagnostic.rb
+++ b/test/test_diagnostic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 class TestDiagnostic < Minitest::Test

--- a/test/test_diagnostic.rb
+++ b/test/test_diagnostic.rb
@@ -20,7 +20,7 @@ class TestDiagnostic < Minitest::Test
   end
 
   def test_freezes
-    string     = 'foo'
+    string     = 'foo'.dup
     highlights = [@range2]
 
     diag = Parser::Diagnostic.new(:error, :escape_eof, @range1, highlights)

--- a/test/test_diagnostic_engine.rb
+++ b/test/test_diagnostic_engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 class TestDiagnosticEngine < Minitest::Test

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -1,4 +1,5 @@
 # encoding: binary
+# frozen_string_literal: true
 
 require 'helper'
 

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# frozen_string_literal: true
 
 require 'helper'
 require 'complex'

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -23,7 +23,7 @@ class TestLexer < Minitest::Test
   #
 
   def utf(str)
-    str.force_encoding(Encoding::UTF_8)
+    str.dup.force_encoding(Encoding::UTF_8)
   end
 
   #

--- a/test/test_lexer_stack_state.rb
+++ b/test/test_lexer_stack_state.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 class TestLexerStackState < Minitest::Test

--- a/test/test_parse_helper.rb
+++ b/test/test_parse_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 require 'parse_helper'
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -5228,7 +5228,7 @@ class TestParser < Minitest::Test
   def test_bom
     assert_parses(
       s(:int, 1),
-      %Q{\xef\xbb\xbf1}.force_encoding(Encoding::BINARY),
+      %Q{\xef\xbb\xbf1}.dup.force_encoding(Encoding::BINARY),
       %q{},
       %w(1.9 2.0 2.1))
   end
@@ -5240,7 +5240,7 @@ class TestParser < Minitest::Test
         s(:send, nil, :puts, s(:lvar, :"проверка"))),
       %Q{# coding:koi8-r
          \xd0\xd2\xcf\xd7\xc5\xd2\xcb\xc1 = 42
-         puts \xd0\xd2\xcf\xd7\xc5\xd2\xcb\xc1}.
+         puts \xd0\xd2\xcf\xd7\xc5\xd2\xcb\xc1}.dup.
         force_encoding(Encoding::BINARY),
       %q{},
       %w(1.9 2.0 2.1))
@@ -5253,7 +5253,7 @@ class TestParser < Minitest::Test
           s(:str, "\\xa8"),
           s(:regopt, :n)),
         s(:str, "")),
-      %q{/\xa8/n =~ ""}.force_encoding(Encoding::UTF_8),
+      %q{/\xa8/n =~ ""}.dup.force_encoding(Encoding::UTF_8),
       %{},
       SINCE_1_9)
   end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -1,4 +1,5 @@
-# encoding:utf-8
+# encoding: utf-8
+# frozen_string_literal: true
 
 require 'helper'
 require 'parse_helper'

--- a/test/test_runner_rewrite.rb
+++ b/test/test_runner_rewrite.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'fileutils'
 require 'shellwords'

--- a/test/test_source_buffer.rb
+++ b/test/test_source_buffer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 class TestSourceBuffer < Minitest::Test

--- a/test/test_source_comment.rb
+++ b/test/test_source_comment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 class TestSourceComment < Minitest::Test

--- a/test/test_source_comment_associator.rb
+++ b/test/test_source_comment_associator.rb
@@ -1,8 +1,4 @@
-#! /usr/bin/env ruby
-# coding: utf-8
 # frozen_string_literal: true
-# warn_indent: true
-# warn_past_scope: true
 
 require 'helper'
 require 'parser/ruby18'
@@ -33,6 +29,8 @@ class TestSourceCommentAssociator < Minitest::Test
 
   def test_associate
     ast, associations = associate(<<-END)
+#!/usr/bin/env ruby
+# coding: utf-8
 # class preceeding
 # another class preceeding
 class Foo # class keyword line
@@ -112,6 +110,8 @@ end
 
   def test_associate_locations
     ast, associations = associate_locations(<<-END)
+#!/usr/bin/env ruby
+# coding: utf-8
 # class preceeding
 # another class preceeding
 class Foo # class keyword line
@@ -217,6 +217,7 @@ end
 
   def test_associate_frozen_string_literal
     ast, associations = associate(<<-END)
+# frozen_string_literal: true
 class Foo
 end
     END
@@ -236,6 +237,7 @@ end
 
   def test_associate_frozen_string_literal_no_space_after_colon
     ast, associations = associate(<<-END)
+# frozen_string_literal:true
 class Foo
 end
     END
@@ -245,6 +247,7 @@ end
 
   def test_associate_warn_indent
     ast, associations = associate(<<-END)
+# warn_indent: true
 class Foo
 end
     END
@@ -264,6 +267,7 @@ end
 
   def test_associate_warn_past_scope
     ast, associations = associate(<<-END)
+# warn_past_scope: true
 class Foo
 end
     END

--- a/test/test_source_comment_associator.rb
+++ b/test/test_source_comment_associator.rb
@@ -1,3 +1,9 @@
+#! /usr/bin/env ruby
+# coding: utf-8
+# frozen_string_literal: true
+# warn_indent: true
+# warn_past_scope: true
+
 require 'helper'
 require 'parser/ruby18'
 
@@ -27,8 +33,6 @@ class TestSourceCommentAssociator < Minitest::Test
 
   def test_associate
     ast, associations = associate(<<-END)
-#!/usr/bin/env ruby
-# coding: utf-8
 # class preceeding
 # another class preceeding
 class Foo # class keyword line
@@ -108,8 +112,6 @@ end
 
   def test_associate_locations
     ast, associations = associate_locations(<<-END)
-#!/usr/bin/env ruby
-# coding: utf-8
 # class preceeding
 # another class preceeding
 class Foo # class keyword line
@@ -215,7 +217,6 @@ end
 
   def test_associate_frozen_string_literal
     ast, associations = associate(<<-END)
-# frozen_string_literal: true
 class Foo
 end
     END
@@ -235,7 +236,6 @@ end
 
   def test_associate_frozen_string_literal_no_space_after_colon
     ast, associations = associate(<<-END)
-# frozen_string_literal:true
 class Foo
 end
     END
@@ -245,7 +245,6 @@ end
 
   def test_associate_warn_indent
     ast, associations = associate(<<-END)
-# warn_indent: true
 class Foo
 end
     END
@@ -265,7 +264,6 @@ end
 
   def test_associate_warn_past_scope
     ast, associations = associate(<<-END)
-# warn_past_scope: true
 class Foo
 end
     END

--- a/test/test_source_map.rb
+++ b/test/test_source_map.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 require 'parse_helper'
 

--- a/test/test_source_range.rb
+++ b/test/test_source_range.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 class TestSourceRange < Minitest::Test

--- a/test/test_source_rewriter.rb
+++ b/test/test_source_rewriter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 class TestSourceRewriter < Minitest::Test

--- a/test/test_source_rewriter_action.rb
+++ b/test/test_source_rewriter_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 class TestSourceRewriterAction < Minitest::Test

--- a/test/test_source_tree_rewriter.rb
+++ b/test/test_source_tree_rewriter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 class TestSourceTreeRewriter < Minitest::Test

--- a/test/test_static_environment.rb
+++ b/test/test_static_environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 class TestStaticEnvironment < Minitest::Test

--- a/test/using_tree_rewriter/fixtures/input.rb
+++ b/test/using_tree_rewriter/fixtures/input.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 6 * 7

--- a/test/using_tree_rewriter/fixtures/output.rb
+++ b/test/using_tree_rewriter/fixtures/output.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 ([6] * 7)

--- a/test/using_tree_rewriter/using_tree_rewriter.rb
+++ b/test/using_tree_rewriter/using_tree_rewriter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UsingTreeRewriter < Parser::TreeRewriter
   def on_send(node)
     wrap(node.loc.expression, '(', ')')


### PR DESCRIPTION
A slightly different take on #354 - instead of relying on dependencies to be frozen-string-literal friendly, this PR adds the pragma comment to all Ruby files, and then string literals are frozen for Ruby versions that support it.

This ensures the test suite can remain green while supporting frozen string literals, separate of whether dependencies do. If/when dependencies are all supporting frozen string literals, then perhaps the env flag (as noted in the Travis CI config in #354) can be set as well.