### PR TITLE
ruby25: Allow `-> do rescue; end`.

### DIFF
--- a/lib/parser/ruby25.y
+++ b/lib/parser/ruby25.y
@@ -1500,7 +1500,7 @@ opt_block_args_tail:
                     {
                       @context.push(:lambda)
                     }
-                  compstmt kEND
+                  bodystmt kEND
                     {
                       result = [ val[0], val[2], val[3] ]
                       @context.pop

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6483,4 +6483,28 @@ class TestParser < Minitest::Test
       refute_diagnoses(code, SINCE_1_9)
     end
   end
+
+  def test_rescue_in_lambda_block
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'kRESCUE'}],
+      %q{-> do rescue; end},
+      %q{      ~~~~~~ location},
+      SINCE_1_9 - SINCE_2_5)
+
+    assert_parses(
+      s(:block,
+        s(:lambda),
+        s(:args),
+        s(:rescue, nil,
+          s(:resbody, nil, nil, nil), nil)),
+      %q{-> do rescue; end},
+      %q{      ~~~~~~ keyword (rescue.resbody)},
+      SINCE_2_5)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'kRESCUE'}],
+      %q{-> { rescue; }},
+      %q{     ~~~~~~ location},
+      SINCE_1_9)
+  end
 end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/429
ruby/ruby@9d9d87f.