### PR TITLE
ruby25.y: Allow class and method definition in the while condition.

### DIFF
--- a/lib/parser/ruby25.y
+++ b/lib/parser/ruby25.y
@@ -1100,6 +1100,7 @@ rule
                     {
                       @static_env.extend_static
                       @lexer.push_cmdarg
+                      @lexer.push_cond
                       @context.push(:class)
                     }
                     bodystmt kEND
@@ -1114,6 +1115,7 @@ rule
                                                   val[4], val[5])
 
                       @lexer.pop_cmdarg
+                      @lexer.pop_cond
                       @static_env.unextend
                       @context.pop
                     }
@@ -1121,6 +1123,7 @@ rule
                     {
                       @static_env.extend_static
                       @lexer.push_cmdarg
+                      @lexer.push_cond
                       @context.push(:sclass)
                     }
                     bodystmt kEND
@@ -1129,6 +1132,7 @@ rule
                                                    val[5], val[6])
 
                       @lexer.pop_cmdarg
+                      @lexer.pop_cond
                       @static_env.unextend
                       @context.pop
                     }
@@ -1153,6 +1157,7 @@ rule
                     {
                       @static_env.extend_static
                       @lexer.push_cmdarg
+                      @lexer.push_cond
                       @context.push(:def)
                     }
                     f_arglist bodystmt kEND
@@ -1161,6 +1166,7 @@ rule
                                   val[3], val[4], val[5])
 
                       @lexer.pop_cmdarg
+                      @lexer.pop_cond
                       @static_env.unextend
                       @context.pop
                     }
@@ -1172,6 +1178,7 @@ rule
                     {
                       @static_env.extend_static
                       @lexer.push_cmdarg
+                      @lexer.push_cond
                       @context.push(:defs)
                     }
                     f_arglist bodystmt kEND
@@ -1180,6 +1187,7 @@ rule
                                   val[4], val[6], val[7], val[8])
 
                       @lexer.pop_cmdarg
+                      @lexer.pop_cond
                       @static_env.unextend
                       @context.pop
                     }

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6483,4 +6483,110 @@ class TestParser < Minitest::Test
       refute_diagnoses(code, SINCE_1_9)
     end
   end
+
+  def test_method_definition_in_while_cond
+    assert_parses(
+      s(:while,
+        s(:def, :foo,
+          s(:args),
+          s(:block,
+            s(:send, nil, :tap),
+            s(:args), nil)),
+        s(:break)),
+      %q{while def foo; tap do end; end; break; end},
+      %q{},
+      SINCE_2_5)
+
+    assert_parses(
+      s(:while,
+        s(:defs,
+          s(:self), :foo,
+          s(:args),
+          s(:block,
+            s(:send, nil, :tap),
+            s(:args), nil)),
+        s(:break)),
+      %q{while def self.foo; tap do end; end; break; end},
+      %q{},
+      SINCE_2_5)
+
+    assert_parses(
+      s(:while,
+        s(:def, :foo,
+          s(:args,
+            s(:optarg, :a,
+              s(:block,
+                s(:send, nil, :tap),
+                s(:args), nil))), nil),
+        s(:break)),
+      %q{while def foo a = tap do end; end; break; end},
+      %q{},
+      SINCE_2_5)
+
+    assert_parses(
+      s(:while,
+        s(:defs,
+          s(:self), :foo,
+          s(:args,
+            s(:optarg, :a,
+              s(:block,
+                s(:send, nil, :tap),
+                s(:args), nil))), nil),
+        s(:break)),
+      %q{while def self.foo a = tap do end; end; break; end},
+      %q{},
+      SINCE_2_5)
+  end
+
+  def test_class_definition_in_while_cond
+    assert_parses(
+      s(:while,
+        s(:class,
+          s(:const, nil, :Foo), nil,
+          s(:block,
+            s(:send, nil, :tap),
+            s(:args), nil)),
+        s(:break)),
+      %q{while class Foo; tap do end; end; break; end},
+      %q{},
+      SINCE_2_5)
+
+    assert_parses(
+      s(:while,
+        s(:class,
+          s(:const, nil, :Foo), nil,
+          s(:lvasgn, :a,
+            s(:block,
+              s(:send, nil, :tap),
+              s(:args), nil))),
+        s(:break)),
+      %q{while class Foo a = tap do end; end; break; end},
+      %q{},
+      SINCE_2_5)
+
+    assert_parses(
+      s(:while,
+        s(:sclass,
+          s(:self),
+          s(:block,
+            s(:send, nil, :tap),
+            s(:args), nil)),
+        s(:break)),
+      %q{while class << self; tap do end; end; break; end},
+      %q{},
+      SINCE_2_5)
+
+    assert_parses(
+      s(:while,
+        s(:sclass,
+          s(:self),
+          s(:lvasgn, :a,
+            s(:block,
+              s(:send, nil, :tap),
+              s(:args), nil))),
+        s(:break)),
+      %q{while class << self; a = tap do end; end; break; end},
+      %q{},
+      SINCE_2_5)
+  end
 end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/430.
ruby/ruby@0dfec65 and ruby/ruby@5aa3523.
MRI doesn't have test cases for singleton method definition and singleton class handling in the while condition but in fact it handles it well (there are changes in corresponding sections in MRI's `parse.y`):
``` sh
$ dev-ruby -vce 'while def self.foo; tap do end; end; break; end;'
ruby 2.6.0dev (2018-01-10 trunk 61758) [x86_64-darwin17]
Syntax OK
$ dev-ruby -vce 'while class << self; tap do end; end; break; end'
ruby 2.6.0dev (2018-01-10 trunk 61758) [x86_64-darwin17]
Syntax OK
```