### PR TITLE
Fixed magic encoding comment parsing when encoding comment is on the first line but not in the beginning.

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -29,7 +29,7 @@ module Parser
       # @api private
       #
       ENCODING_RE =
-        /\#.*coding\s*[:=]\s*
+        /\A\#\s*(en)?coding\s*[:=]\s*
           (
             # Special-case: there's a UTF8-MAC encoding.
             (utf8-mac)
@@ -64,7 +64,7 @@ module Parser
         end
 
         if (result = ENCODING_RE.match(encoding_line))
-          Encoding.find(result[2] || result[3] || result[5])
+          Encoding.find(result[3] || result[4] || result[6])
         else
           nil
         end

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -74,4 +74,17 @@ class TestEncoding < Minitest::Test
       Parser::Ruby19.parse("# encoding:feynman-diagram\n1")
     end
   end
+
+  def test_ending_comment
+    assert_nil recognize('foo # coding: koi8-r')
+  end
+
+  def test_wrong_prefix
+    assert_nil recognize('# decoding: koi8-r')
+  end
+
+  def test_no_spaces
+    assert_equal Encoding::KOI8_R, recognize('#encoding:koi8-r')
+    assert_equal Encoding::KOI8_R, recognize('#coding:koi8-r')
+  end
 end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/443