### PR TITLE
Fixed cmdarg manipulation in command_args rule.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -89,7 +89,7 @@ class Parser::Lexer
 
   REGEXP_META_CHARACTERS = Regexp.union(*"\\$()*+.<>?[]^{|}".chars).freeze
 
-  attr_reader   :source_buffer
+  attr_reader   :source_buffer, :last_token
 
   attr_accessor :diagnostics
   attr_accessor :static_env
@@ -175,6 +175,9 @@ class Parser::Lexer
 
     # State before =begin / =end block comment
     @cs_before_block_comment = self.class.lex_en_line_begin
+
+    # Last emitted token
+    @last_token = nil
   end
 
   def source_buffer=(source_buffer)
@@ -325,6 +328,7 @@ class Parser::Lexer
     token = [ type, [ value, range(s, e) ] ]
 
     @token_queue.push(token)
+    @last_token = token
 
     @tokens.push(token) if @tokens
 

--- a/lib/parser/ruby25.y
+++ b/lib/parser/ruby25.y
@@ -860,7 +860,28 @@ rule
                     }
 
     command_args:   {
-                      @lexer.cmdarg.push(true)
+                      # When branch gets invoked by RACC's lookahead
+                      # and command args start with '[' or '('
+                      # we need to put `true` to the cmdarg stack
+                      # **before** `false` pushed by lexer
+                      #   m [], n
+                      #     ^
+                      # Right here we have cmdarg [...0] because
+                      # lexer pushed it on '['
+                      # We need to modify cmdarg stack to [...10]
+                      #
+                      # For all other cases (like `m n` or `m n, []`) we simply put 1 to the stack
+                      # and later lexer pushes corresponding bits on top of it.
+                      last_token = @lexer.last_token[0]
+                      lookahead = last_token == :tLBRACK || last_token == :tLPAREN_ARG
+
+                      if lookahead
+                        top = @lexer.cmdarg.pop
+                        @lexer.cmdarg.push(true)
+                        @lexer.cmdarg.push(top)
+                      else
+                        @lexer.cmdarg.push(true)
+                      end
                     }
                   call_args
                     {
@@ -1833,7 +1854,7 @@ regexp_contents: # nothing
                     }
                     compstmt tSTRING_DEND
                     {
-                      @lexer.cond.lexpop
+                      @lexer.cond.pop
                       @lexer.cmdarg.pop
 
                       result = @builder.begin(val[0], val[2], val[3])

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6713,4 +6713,15 @@ class TestParser < Minitest::Test
       %q{m /foo/x {}},
       SINCE_2_4)
   end
+
+  def test_bug_447
+    assert_parses(
+      s(:block,
+        s(:send, nil, :m,
+          s(:array)),
+        s(:args), nil),
+      %q{m [] do end},
+      %q{},
+      ALL_VERSIONS)
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/whitequark/parser/issues/447
Closes https://github.com/whitequark/parser/issues/433

From what I understand `command_args` rule always gets invoked in the lookahead, so inside this rule `last_token` always contains the first token of `command_args`. Bison has a `yychar` variable that is always equal to the last lookahead token (for this case `last_token` can handle it). Is there a similar thing in racc?