### PR TITLE
Fixed encoding comment handling.

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -29,7 +29,7 @@ module Parser
       # @api private
       #
       ENCODING_RE =
-        /\A\#\s*(en)?coding\s*[:=]\s*
+        /[\s#](en)?coding\s*[:=]\s*
           (
             # Special-case: there's a UTF8-MAC encoding.
             (utf8-mac)
@@ -62,6 +62,8 @@ module Parser
         else
           encoding_line = first_line
         end
+
+        return nil if encoding_line[0] != '#'
 
         if (result = ENCODING_RE.match(encoding_line))
           Encoding.find(result[3] || result[4] || result[6])

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -87,4 +87,12 @@ class TestEncoding < Minitest::Test
     assert_equal Encoding::KOI8_R, recognize('#encoding:koi8-r')
     assert_equal Encoding::KOI8_R, recognize('#coding:koi8-r')
   end
+
+  def test_underscore_and_star_characters
+    assert_equal Encoding::KOI8_R, recognize('# -*- encoding: koi8-r -*-')
+  end
+
+  def test_garbage_around_encoding_comment
+    assert_equal Encoding::KOI8_R, recognize('# 1$# -*- &)* encoding: koi8-r 1$# -*- &)*')
+  end
 end


### PR DESCRIPTION
Ruby ❤️ 

``` sh
$ cat test.rb
# whatever -*-* !@##TYU23456 whatever encoding: koi8-r whatever -*- whatever
puts "".encoding

$ ruby test.rb
KOI8-R
```

I've checked other tests on MRI, the only difference is BOM meta-chars handling. MRI doesn't care about them. @whitequark Should we drop if from the parser as well?