### PR TITLE
Fix parsing of interpolated lambda with open args.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -1437,12 +1437,12 @@ class Parser::Lexer
       w_space* e_lbrace
       => {
         if @lambda_stack.last == @paren_nest
-          p = @ts - 1
-          fgoto expr_end;
+          @lambda_stack.pop
+          emit(:tLAMBEG, '{'.freeze, @te - 1, @te)
         else
           emit(:tLCURLY, '{'.freeze, @te - 1, @te)
-          fnext expr_value; fbreak;
         end
+        fnext expr_value; fbreak;
       };
 
       #

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6724,4 +6724,17 @@ class TestParser < Minitest::Test
       %q{},
       ALL_VERSIONS)
   end
+
+  def test_bug_435
+    assert_parses(
+      s(:dstr,
+        s(:begin,
+          s(:block,
+            s(:lambda),
+            s(:args,
+              s(:arg, :foo)), nil))),
+      %q{"#{-> foo {}}"},
+      %q{},
+      SINCE_1_9)
+  end
 end


### PR DESCRIPTION
The bug is caused by `p -=` and thus calling action attached to `e_lbrace` twice. This patch removes lookahead and emits the token instantly to guarantee that the action of `e_lbrace` gets called only once.

Basically, lambda-branch in the modified action is replaced to what corresponding action does later in
```
  expr_end := |*

    e_lbrace | 'do'
      => {
        if @lambda_stack.last == @paren_nest
          @lambda_stack.pop

          if tok == '{'.freeze
            emit(:tLAMBEG, '{'.freeze)
          else # 'do'
            emit(:kDO_LAMBDA, 'do'.freeze)
          end
        else
          if tok == '{'.freeze
            emit(:tLCURLY, '{'.freeze)
          else # 'do'
            emit_do
          end
        end

        fnext expr_value; fbreak;
      };
*|;
```

Closes https://github.com/whitequark/parser/issues/435