### PR TITLE
Replicate cmdargs handling from MRI.

### DIFF
--- a/lib/parser/ruby24.y
+++ b/lib/parser/ruby24.y
@@ -955,20 +955,13 @@ rule
 
                       result = @builder.begin_keyword(val[0], val[2], val[3])
                     }
-                | tLPAREN_ARG
-                    {
-                      result = @lexer.cmdarg.dup
-                      @lexer.cmdarg.clear
-                    }
-                    stmt
+                | tLPAREN_ARG stmt
                     {
                       @lexer.state = :expr_endarg
                     }
                     rparen
                     {
-                      @lexer.cmdarg = val[1]
-
-                      result = @builder.begin(val[0], val[2], val[4])
+                      result = @builder.begin(val[0], val[1], val[3])
                     }
                 | tLPAREN_ARG
                     {

--- a/lib/parser/ruby25.y
+++ b/lib/parser/ruby25.y
@@ -965,20 +965,13 @@ rule
 
                       result = @builder.begin_keyword(val[0], val[2], val[3])
                     }
-                | tLPAREN_ARG
-                    {
-                      result = @lexer.cmdarg.dup
-                      @lexer.cmdarg.clear
-                    }
-                    stmt
+                | tLPAREN_ARG stmt
                     {
                       @lexer.state = :expr_endarg
                     }
                     rparen
                     {
-                      @lexer.cmdarg = val[1]
-
-                      result = @builder.begin(val[0], val[2], val[4])
+                      result = @builder.begin(val[0], val[1], val[3])
                     }
                 | tLPAREN_ARG
                     {

--- a/test/parse_helper.rb
+++ b/test/parse_helper.rb
@@ -122,6 +122,9 @@ module ParseHelper
 
       assert_source_range(begin_pos, end_pos, range, version, line.inspect)
     end
+
+    assert_equal parser.instance_eval { @lexer }.cmdarg.instance_eval { @stack }, 0,
+      "(#{version}) expected cmdarg to be empty after parsing"
   end
 
   # Use like this:

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6781,4 +6781,20 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_1_9)
   end
+
+  def test_bug_452
+    assert_parses(
+      s(:begin,
+        s(:send, nil, :td,
+          s(:send,
+            s(:begin,
+              s(:int, 1500)), :toString)),
+        s(:block,
+          s(:send,
+            s(:send, nil, :td), :num),
+          s(:args), nil)),
+      %q{td (1_500).toString(); td.num do; end},
+      %q{},
+      ALL_VERSIONS)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@1727c83.
All other changes from this commit were initially ported from the `parser` (haha), so there's no need to backport them.

Closes https://github.com/whitequark/parser/issues/452

