### PR TITLE
Bump warning message for 2.4.x branch in the parser/current.

### DIFF
--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -48,7 +48,7 @@ module Parser
     CurrentRuby = Ruby23
 
   when /^2\.4\./
-    current_version = '2.4.0'
+    current_version = '2.4.3'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby24', current_version
     end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/454