### PR TITLE
Fixed parsing of encoding comment when the file contains only shebang.

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -63,7 +63,7 @@ module Parser
           encoding_line = first_line
         end
 
-        return nil if encoding_line[0] != '#'
+        return nil if encoding_line.nil? || encoding_line[0] != '#'
 
         if (result = ENCODING_RE.match(encoding_line))
           Encoding.find(result[3] || result[4] || result[6])

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -27,6 +27,7 @@ class TestEncoding < Minitest::Test
 
   def test_shebang
     assert_equal Encoding::KOI8_R, recognize("#!/bin/foo\n# coding:koi8-r\nfoobar")
+    assert_nil recognize("#!/bin/foo\n")
   end
 
   def test_case


### PR DESCRIPTION
My regression introduced in https://github.com/whitequark/parser/pull/444