### PR TITLE
Fix wording [ci-skip]

### DIFF
--- a/lib/parser/source/rewriter.rb
+++ b/lib/parser/source/rewriter.rb
@@ -17,7 +17,7 @@ module Parser
     # - The TreeRewriter policy closest to Rewriter's behavior is:
     #       different_replacements: :raise,
     #       swallowed_insertions: :raise,
-    #       overlapping_deletions: :accept
+    #       crossing_deletions: :accept
     #
     # @!attribute [r] source_buffer
     #  @return [Source::Buffer]

--- a/test/test_source_rewriter.rb
+++ b/test/test_source_rewriter.rb
@@ -421,7 +421,7 @@ class TestSourceRewriter < Minitest::Test
   end
 
 
-  def test_overlapping_delete
+  def test_crossing_delete
     assert_equal 'faz',
                  @rewriter.
                    remove(range(1, 4)).


### PR DESCRIPTION
Fixes a mistake I made in the documentation (similarly in the name of a test method).
Sorry.