### PR TITLE
Fix Out of range error reporting

### DIFF
--- a/lib/parser/source/tree_rewriter.rb
+++ b/lib/parser/source/tree_rewriter.rb
@@ -273,7 +273,7 @@ module Parser
 
       def check_range_validity(range)
         if range.begin_pos < 0 || range.end_pos > @source_buffer.source.size
-          raise IndexError, "The range #{action.range} is outside the bounds of the source"
+          raise IndexError, "The range #{range} is outside the bounds of the source"
         end
         range
       end

--- a/test/test_source_tree_rewriter.rb
+++ b/test/test_source_tree_rewriter.rb
@@ -174,4 +174,9 @@ DIAGNOSTIC
 (rewriter):1:       ^~~~~  ~~~~
 DIAGNOSTIC
   end
+
+  def test_out_of_range_ranges
+    rewriter = Parser::Source::TreeRewriter.new(@buf)
+    assert_raises(IndexError) { rewriter.insert_before(range(0, 100), 'hola') }
+  end
 end


### PR DESCRIPTION
The error message was wrong and generated an error.

Very sorry about this.