### PR TITLE
Make sure Source::Buffer#name is a string

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -103,7 +103,7 @@ module Parser
       end
 
       def initialize(name, first_line = 1)
-        @name        = name
+        @name        = name.to_s
         @source      = nil
         @first_line  = first_line
 

--- a/test/test_source_buffer.rb
+++ b/test/test_source_buffer.rb
@@ -8,6 +8,12 @@ class TestSourceBuffer < Minitest::Test
   end
 
   def test_initialize
+    buffer = Parser::Source::Buffer.new(nil)
+    assert_equal '', buffer.name
+
+    buffer = Parser::Source::Buffer.new(Pathname('a/b'))
+    assert_equal 'a/b', buffer.name
+
     buffer = Parser::Source::Buffer.new('(string)')
     assert_equal '(string)', buffer.name
     assert_equal 1, buffer.first_line


### PR DESCRIPTION
Minor tweak to make sure the 'name' argument is a string.

This has two advantages:
* One can pass a `Pathname`
* Avoid some strange parsing issues where the name is used by parser instead of `__FILE__`, generating unexpected ASTs (I had some `[:str, nil]` nodes which took created havoc with my type checking.