### PR TITLE
Fix cmdarg handling for parsers < 24.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -2219,7 +2219,13 @@ class Parser::Lexer
       e_rbrace | e_rparen | ']'
       => {
         emit_table(PUNCTUATION)
-        @cond.lexpop; @cmdarg.pop
+
+        @cond.lexpop
+        if @version < 24
+          @cmdarg.lexpop
+        else
+          @cmdarg.pop
+        end
 
         if tok == '}'.freeze
           fnext expr_endarg;

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6766,6 +6766,16 @@ class TestParser < Minitest::Test
       %q{m [] do end},
       %q{},
       ALL_VERSIONS)
+
+    assert_parses(
+      s(:block,
+        s(:send, nil, :m,
+          s(:array),
+          s(:int, 1)),
+        s(:args), nil),
+      %q{m [], 1 do end},
+      %q{},
+      ALL_VERSIONS)
   end
 
   def test_bug_435


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/447