### PR TITLE
Remove duplicate test case in test_source_tree_rewriter.rb

### DIFF
--- a/test/test_source_tree_rewriter.rb
+++ b/test/test_source_tree_rewriter.rb
@@ -134,15 +134,6 @@ DIAGNOSTIC
                           [:wrap, @world, '[', ']']
   end
 
-
-  def test_multiple_actions
-    assert_actions_result 'puts({:hello => [:everybody]})',
-                          [:replace, @comma_space, ' => '],
-                          [:wrap, @hello.join(@world), '{', '}'],
-                          [:replace, @world, ':everybody'],
-                          [:wrap, @world, '[', ']']
-  end
-
   def test_wraps_same_range
     assert_actions_result 'puts([(:hello)], :world)',
                            [[:wrap, @hello, '(', ')'],


### PR DESCRIPTION
`test_multiple_actions` method is defined twice. So Ruby warns.

```
$ bundle exec rake
(snip)
/path/to/test/test_source_tree_rewriter.rb:138: warning: method redefined; discarding old test_multiple_actions
/path/to/test/test_source_tree_rewriter.rb:129: warning: previous definition of test_multiple_actions was here
(snip)
```

And they has exactly the same definition. So this change removes the one of them.