### PR TITLE
- Accept `BEGIN` and `END` as correct method name

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -467,6 +467,7 @@ class Parser::Lexer
     'if'     => :kIF,          'unless'   => :kUNLESS,
     'while'  => :kWHILE,       'until'    => :kUNTIL,
     'rescue' => :kRESCUE,      'defined?' => :kDEFINED,
+    'BEGIN'  => :klBEGIN,      'END'      => :klEND,
   }
 
   %w(class module def undef begin end then elsif else ensure case when

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -1804,6 +1804,14 @@ class TestParser < Minitest::Test
     assert_parses(
       s(:def, :until, s(:args), nil),
       %q{def until; end})
+
+    assert_parses(
+      s(:def, :BEGIN, s(:args), nil),
+      %q{def BEGIN; end})
+
+    assert_parses(
+      s(:def, :END, s(:args), nil),
+      %q{def END; end})
   end
 
   def test_defs


### PR DESCRIPTION
`BEGIN` and `END` are correct as a method name.
But the parser does not accept them.


## MRI

```
$ ruby -vce 'def BEGIN; end; def END; end'
ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-linux]
Syntax OK

$ docker run --rm -it jonwood/ruby-1.8 ruby -vce 'def BEGIN; end; def END; end' 
ruby 1.8.7 (2013-06-27 MBARI 8/0x6770 on patchlevel 375) [x86_64-linux], MBARI 0x6770, Ruby Enterprise Edition 2012.02
Syntax OK
```

We can confirm the results in other rubies from here. https://bacon-cannon.herokuapp.com/parmlinks/d34f5b5f-1573-4504-883c-3ab52f252381

## parser gem

```
$ ruby-parse -e 'def BEGIN; end; def END; end'
(fragment:0):1:5: error: unexpected token error
(fragment:0):1: def BEGIN; end; def END; end
(fragment:0):1:     ^~~~~
```



---

I'm not sure this patch is correct way. Can you help me?

- `KEYWORDS_BEGIN` is used only two places.
  - https://github.com/whitequark/parser/blob/034c7555c4ea331a8024eb58fbdbc7a36cd25dcf/lib/parser/lexer.rl#L1302-L1305
    - it's the target of this patch.
  - https://github.com/whitequark/parser/blob/034c7555c4ea331a8024eb58fbdbc7a36cd25dcf/lib/parser/lexer.rl#L1850-L1853
    - the `keyword_modifier` does not include `BEGIN` and `END`, so I guess  this patch does not change `keyword_modifier`' s behaviour.
- `expr_fname` is also used only two places.
  - https://github.com/whitequark/parser/blob/034c7555c4ea331a8024eb58fbdbc7a36cd25dcf/lib/parser/lexer.rl#L1741-L1746
    - I guess tok is `&&` or `||` at here, so this patch does not change the behaviour.
  - https://github.com/whitequark/parser/blob/034c7555c4ea331a8024eb58fbdbc7a36cd25dcf/lib/parser/lexer.rl#L2025-L2027
    - `keyword_with_fname` are `def`, `undef` and `alias`, and `def END`, `undef END` and `alias a END` are valid, so I think this is OK.
