### PR TITLE
Fix cmdarg handling around string interpolation.

### DIFF
--- a/lib/parser/ruby24.y
+++ b/lib/parser/ruby24.y
@@ -1845,13 +1845,13 @@ regexp_contents: # nothing
                     }
                 | tSTRING_DBEG
                     {
-                      @lexer.cond.push(false)
-                      @lexer.cmdarg.push(false)
+                      @lexer.push_cmdarg
+                      @lexer.push_cond
                     }
                     compstmt tSTRING_DEND
                     {
-                      @lexer.cond.pop
-                      @lexer.cmdarg.pop
+                      @lexer.pop_cmdarg
+                      @lexer.pop_cond
 
                       result = @builder.begin(val[0], val[2], val[3])
                     }

--- a/lib/parser/ruby25.y
+++ b/lib/parser/ruby25.y
@@ -1842,13 +1842,13 @@ regexp_contents: # nothing
                     }
                 | tSTRING_DBEG
                     {
-                      @lexer.cond.push(false)
-                      @lexer.cmdarg.push(false)
+                      @lexer.push_cmdarg
+                      @lexer.push_cond
                     }
                     compstmt tSTRING_DEND
                     {
-                      @lexer.cond.pop
-                      @lexer.cmdarg.pop
+                      @lexer.pop_cmdarg
+                      @lexer.pop_cond
 
                       result = @builder.begin(val[0], val[2], val[3])
                     }

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6814,4 +6814,21 @@ class TestParser < Minitest::Test
       %q{},
       ALL_VERSIONS)
   end
+
+  def test_bug_466
+    assert_parses(
+      s(:block,
+        s(:send, nil, :foo,
+          s(:dstr,
+            s(:begin,
+              s(:send,
+                s(:begin,
+                  s(:send,
+                    s(:int, 1), :+,
+                    s(:int, 1))), :to_i)))),
+        s(:args), nil),
+      %q{foo "#{(1+1).to_i}" do; end},
+      %q{},
+      ALL_VERSIONS)
+  end
 end


### PR DESCRIPTION
Fixes #466.
By the way, now I think that there's a bug in MRI, `cmdarg.push(0)/pop` and `push/pop_cmdarg` are semantically equivalent if there's no garbage in the stack. Anyway, that's what MRI does in the [corresponding rule](https://github.com/ruby/ruby/blob/trunk/parse.y#L3579-L3606)