### PR TITLE
Move last_token capturing from Lexer#emit to Parser#next_token.

### DIFF
--- a/lib/parser/base.rb
+++ b/lib/parser/base.rb
@@ -131,6 +131,9 @@ module Parser
       @builder.parser = self
       @context = Context.new
 
+      # Last emitted token
+      @last_token = nil
+
       if self.class::Racc_debug_parser && ENV['RACC_DEBUG']
         @yydebug = true
       end
@@ -222,7 +225,9 @@ module Parser
     private
 
     def next_token
-      @lexer.advance
+      token = @lexer.advance
+      @last_token = token
+      token
     end
 
     def check_kwarg_name(name_t)

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -89,7 +89,7 @@ class Parser::Lexer
 
   REGEXP_META_CHARACTERS = Regexp.union(*"\\$()*+.<>?[]^{|}".chars).freeze
 
-  attr_reader   :source_buffer, :last_token
+  attr_reader   :source_buffer
 
   attr_accessor :diagnostics
   attr_accessor :static_env
@@ -175,9 +175,6 @@ class Parser::Lexer
 
     # State before =begin / =end block comment
     @cs_before_block_comment = self.class.lex_en_line_begin
-
-    # Last emitted token
-    @last_token = nil
   end
 
   def source_buffer=(source_buffer)
@@ -328,7 +325,6 @@ class Parser::Lexer
     token = [ type, [ value, range(s, e) ] ]
 
     @token_queue.push(token)
-    @last_token = token
 
     @tokens.push(token) if @tokens
 

--- a/lib/parser/ruby24.y
+++ b/lib/parser/ruby24.y
@@ -862,7 +862,7 @@ rule
                       #
                       # For all other cases (like `m n` or `m n, []`) we simply put 1 to the stack
                       # and later lexer pushes corresponding bits on top of it.
-                      last_token = @lexer.last_token[0]
+                      last_token = @last_token[0]
                       lookahead = last_token == :tLBRACK || last_token == :tLPAREN_ARG
 
                       if lookahead

--- a/lib/parser/ruby25.y
+++ b/lib/parser/ruby25.y
@@ -872,7 +872,7 @@ rule
                       #
                       # For all other cases (like `m n` or `m n, []`) we simply put 1 to the stack
                       # and later lexer pushes corresponding bits on top of it.
-                      last_token = @lexer.last_token[0]
+                      last_token = @last_token[0]
                       lookahead = last_token == :tLBRACK || last_token == :tLPAREN_ARG
 
                       if lookahead

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6831,4 +6831,15 @@ class TestParser < Minitest::Test
       %q{},
       ALL_VERSIONS)
   end
+
+  def test_bug_473
+    assert_parses(
+      s(:send, nil, :m,
+        s(:dstr,
+          s(:begin,
+            s(:array)))),
+      %q{m "#{[]}"},
+      %q{},
+      ALL_VERSIONS)
+  end
 end


### PR DESCRIPTION
Closes #473, see https://github.com/whitequark/parser/issues/473#issuecomment-374588226 for more information.

@whitequark The test actually verifies that `@cmdarg` is 0 after parsing (`assert_parses` does it in the end of its definition), please, let me know if it should be changed to the code from the reported issue to make an assertion explicit.