### PR TITLE
ruby-parse displays escape sequences only in tty

### DIFF
--- a/lib/parser/color.rb
+++ b/lib/parser/color.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Parser
+  module Color
+    def self.color(str, code, bold: false)
+      return str unless STDOUT.tty?
+      code = Array(code)
+      code.unshift(1) if bold
+      "\e[#{code.join(';')}m#{str}\e[0m"
+    end
+
+    def self.red(str, bold: false)
+      color(str, 31, bold: bold)
+    end
+
+    def self.green(str, bold: false)
+      color(str, 32, bold: bold)
+    end
+
+    def self.yellow(str, bold: false)
+      color(str, 33, bold: bold)
+    end
+
+    def self.magenta(str, bold: false)
+      color(str, 35, bold: bold)
+    end
+
+    def self.underline(str)
+      color(str, 4)
+    end
+  end
+end

--- a/lib/parser/lexer/explanation.rb
+++ b/lib/parser/lexer/explanation.rb
@@ -21,14 +21,14 @@ module Parser
       more = "(in-kwarg)" if @in_kwarg
 
       puts decorate(range,
-                    "\e[0;32m#{type} #{val.inspect}\e[0m",
-                    "#{state.to_s.ljust(12)} #{@cond} #{@cmdarg} #{more}\e[0m")
+                    Color.green("#{type} #{val.inspect}"),
+                    "#{state.to_s.ljust(12)} #{@cond} #{@cmdarg} #{more}")
 
       [ type, [val, range] ]
     end
 
     def state=(new_state)
-      puts "  \e[1;33m>>> STATE SET <<<\e[0m " +
+      puts "  #{Color.yellow(">>> STATE SET <<<", bold: true)} " +
            "#{new_state.to_s.ljust(12)} #{@cond} #{@cmdarg}".rjust(66)
 
       self.state_before_explanation = new_state
@@ -40,12 +40,12 @@ module Parser
       from, to = range.begin.column, range.end.column
 
       line = range.source_line + '   '
-      line[from...to] = "\e[4m#{line[from...to]}\e[0m"
+      line[from...to] = Color.underline(line[from...to])
 
       tail_len   = to - from - 1
       tail       = '~' * (tail_len >= 0 ? tail_len : 0)
-      decoration =  "#{" " * from}\e[1;31m^#{tail}\e[0m #{token} ".
-                        ljust(70) + info
+      decoration =  "#{" " * from}#{Color.red("^#{tail}", bold: true)} #{token} ".
+                        ljust(68) + info
 
       [ line, decoration ]
     end

--- a/lib/parser/runner/ruby_parse.rb
+++ b/lib/parser/runner/ruby_parse.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'parser/runner'
+require 'parser/color'
 require 'parser/lexer/explanation'
 require 'json'
 
@@ -20,15 +21,15 @@ module Parser
           print_line = lambda do
             unless hilight_line.empty?
               puts hilight_line.
-                gsub(/[a-z_]+/) { |m| "\e[1;33m#{m}\e[0m" }.
-                gsub(/[~.]+/)   { |m| "\e[1;35m#{m}\e[0m" }
+                gsub(/[a-z_]+/) { |m| Color.yellow(m, bold: true) }.
+                gsub(/[~.]+/)   { |m| Color.magenta(m, bold: true) }
               hilight_line = ''
             end
           end
 
           print_source = lambda do |range|
             source_line = range.source_line
-            puts "\e[32m#{source_line}\e[0m"
+            puts Color.green(source_line)
             source_line
           end
 


### PR DESCRIPTION
Fix #474 
