### PR TITLE
Emit tSTRING_BEG and tSTRING_DBEG one by one to allow parser to properly manipulate cmdarg stack

### DIFF
--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6843,4 +6843,16 @@ class TestParser < Minitest::Test
       %q{},
       ALL_VERSIONS)
   end
+
+  def test_bug_480
+    assert_parses(
+      s(:send, nil, :m,
+        s(:dstr,
+          s(:begin),
+          s(:begin,
+            s(:begin)))),
+      %q{m "#{}#{()}"},
+      %q{},
+      ALL_VERSIONS)
+  end
 end


### PR DESCRIPTION
Also I've added missing `cmdarg_push` and `cond_push` for `{` in the string literal. MRI always does if, even if it's not important now (because of the `push_cmdarg`/`pop_cmdarg` around the string) - https://github.com/ruby/ruby/blob/trunk/parse.y#L8008-L8010

``` ruby
$ dev-ruby -ye '"#{}#{}#{}"' | grep "stack(pop)"
p->cond_stack(pop): 0 at line 8009
p->cmdarg_stack(pop): 0 at line 8010
p->cond_stack(pop): 0 at line 8009
p->cmdarg_stack(pop): 0 at line 8010
p->cond_stack(pop): 0 at line 8009
p->cmdarg_stack(pop): 0 at line 8010
```

Closes https://github.com/whitequark/parser/issues/480

@whitequark Does this bug mean that using `fcall` may be dangerous? Should we avoid it in the future?