### PR TITLE
Parse slash + newline in heredocs as a line continuation.

### DIFF
--- a/lib/parser/lexer/dedenter.rb
+++ b/lib/parser/lexer/dedenter.rb
@@ -12,13 +12,41 @@ module Parser
     def dedent(string)
       space_begin = space_end = offset = 0
       last_index  = string.length - 1
+      escape = false
+      _at_line_begin = nil
+
       string.chars.each_with_index do |char, index|
-        if @at_line_begin
+        if char == '\\'
+          # entering escape mode
+          escape = true
+          string.slice!(index - offset)
+          offset += 1
+          _at_line_begin = @at_line_begin
+          @at_line_begin = false
+        elsif escape
+          if char == ?\n
+            # trimming \n, starting a new line
+            string.slice!(index - offset)
+            offset += 1
+            @at_line_begin = true
+            space_begin = space_end = index - offset
+            @indent_level = 0
+          elsif char == ?n
+            # replacing \\n to \n
+            string.slice!(index - offset)
+            string.insert(index - offset, ?\n)
+          else
+            # exiting escape mode as it's not an escape sequence
+            @at_line_begin = _at_line_begin
+            escape = false
+            redo
+          end
+          escape = false
+        elsif @at_line_begin
           if char == ?\n || @indent_level >= @dedent_level
             string.slice!(space_begin...space_end)
-            offset += space_end - space_begin - 1
+            offset += space_end - space_begin
             @at_line_begin = false
-            redo if char == ?\n
           end
 
           case char

--- a/lib/parser/lexer/literal.rb
+++ b/lib/parser/lexer/literal.rb
@@ -103,6 +103,14 @@ module Parser
       !!@heredoc_e
     end
 
+    def plain_heredoc?
+      heredoc? && !@dedent_body
+    end
+
+    def squiggly_heredoc?
+      heredoc? && @dedent_body
+    end
+
     def backslash_delimited?
       @end_delim == '\\'.freeze
     end

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -3508,4 +3508,30 @@ class TestLexer < Minitest::Test
                    :tSYMBOL, '~', [0, 3])
   end
 
+  def test_slash_only_in_heredocs
+    setup_lexer(23)
+    refute_scanned(%Q{<<~E\n\\\nE})
+
+    setup_lexer(23)
+    refute_scanned(%Q{<<-E\n\\\nE})
+  end
+
+  def test_escapes_in_squiggly_heredoc
+    setup_lexer(23)
+
+    assert_scanned(%Q{<<~E\n\a\b\e\f\r\t\\\v\nE},
+                   :tSTRING_BEG,     '<<"',              [0, 4],
+                   :tSTRING_CONTENT, "\a\b\e\f\r\t\v\n", [5, 14],
+                   :tSTRING_END,     'E',                [14, 15],
+                   :tNL,             nil,                [4, 5])
+
+    setup_lexer(23)
+
+    assert_scanned(%Q{<<-E\n\a\b\e\f\r\t\\\v\nE},
+                   :tSTRING_BEG,     '<<"',              [0, 4],
+                   :tSTRING_CONTENT, "\a\b\e\f\r\t\v\n", [5, 14],
+                   :tSTRING_END,     'E',                [14, 15],
+                   :tNL,             nil,                [4, 5])
+  end
+
 end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6916,4 +6916,22 @@ class TestParser < Minitest::Test
       %q{},
       ALL_VERSIONS)
   end
+
+  def test_slash_newline_in_heredocs
+    assert_parses(
+      s(:dstr,
+        s(:str, "1 2\n"),
+        s(:str, "3\n")),
+      %Q{<<~E\n    1 \\\n    2\n    3\nE\n},
+      %q{},
+      SINCE_2_3)
+
+    assert_parses(
+      s(:dstr,
+        s(:str, "    1     2\n"),
+        s(:str, "    3\n")),
+      %Q{<<-E\n    1 \\\n    2\n    3\nE\n},
+      %q{},
+      ALL_VERSIONS)
+  end
 end


### PR DESCRIPTION
Upstream commits: ruby/ruby@491f523 and ruby/ruby@58fbe69.
Closes https://github.com/whitequark/parser/issues/479

The lexer must emit `"\\\n"` without escaping to let `Dedenter` know that there's a newline (and so that the code after must be dedented).