### PR TITLE
Emit :!@ as :!, :~@ as :~.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -1760,6 +1760,14 @@ class Parser::Lexer
         fgoto *push_literal(type, delimiter, @ts);
       };
 
+      # :!@ is :!
+      # :~@ is :~
+      ':' [!~] '@'
+      => {
+        emit(:tSYMBOL, tok(@ts + 1, @ts + 2))
+        fnext expr_end; fbreak;
+      };
+
       ':' bareword ambiguous_symbol_suffix
       => {
         emit(:tSYMBOL, tok(@ts + 1, tm), @ts, tm)

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -3498,4 +3498,14 @@ class TestLexer < Minitest::Test
                    :tIDENTIFIER, 'cond',   [11, 15])
   end
 
+  def test_parser_bug_486
+    setup_lexer(19)
+    assert_scanned(':!@',
+                   :tSYMBOL, '!', [0, 3])
+
+    setup_lexer(19)
+    assert_scanned(':~@',
+                   :tSYMBOL, '~', [0, 3])
+  end
+
 end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/486

Any content after these magical chars is rejected:
```
2.5.0 :001 > :!@1
Traceback (most recent call last):
        1: from /Users/ilya/.rvm/rubies/ruby-2.5.0/bin/irb:11:in `<main>'
SyntaxError ((irb):1: syntax error, unexpected tINTEGER, expecting end-of-input)
```
So instant transition to `expr_end` looks correct. 