### PR TITLE
Bump latest versions to 2.3.7, 2.4.4, 2.5.1.

### DIFF
--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -39,7 +39,7 @@ module Parser
     CurrentRuby = Ruby22
 
   when /^2\.3\./
-    current_version = '2.3.6'
+    current_version = '2.3.7'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby23', current_version
     end
@@ -48,7 +48,7 @@ module Parser
     CurrentRuby = Ruby23
 
   when /^2\.4\./
-    current_version = '2.4.3'
+    current_version = '2.4.4'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby24', current_version
     end
@@ -57,7 +57,7 @@ module Parser
     CurrentRuby = Ruby24
 
   when /^2\.5\./
-    current_version = '2.5.0'
+    current_version = '2.5.1'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby25', current_version
     end


### PR DESCRIPTION
https://www.ruby-lang.org/en/downloads/
```
Stable releases:
Ruby 2.5.1
sha256: dac81822325b79c3ba9532b048c2123357d3310b2b40024202f360251d9829b1
Ruby 2.4.4
sha256: 254f1c1a79e4cc814d1e7320bc5bdd995dc57e08727d30a767664619a9c8ae5a
Ruby 2.3.7
sha256: 35cd349cddf78e4a0640d28ec8c7e88a2ae0db51ebd8926cd232bb70db2c7d7f
```