### PR TITLE
call String#getbyte

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -1795,7 +1795,7 @@ class Parser::Lexer
         value = @escape || tok(@ts + 1)
 
         if version?(18)
-          emit(:tINTEGER, value.dup.force_encoding(Encoding::BINARY)[0].ord)
+          emit(:tINTEGER, value.getbyte(0))
         else
           emit(:tCHARACTER, value)
         end


### PR DESCRIPTION
I forgot about pushing this. It's related to my previous PR #457 but even though `value.b[0].ord` already would've been an improvement, `value.getbyte(0)` is even better.