### PR TITLE
Reject `m a: {} {}` and `m [] {}` since 25.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -2245,10 +2245,8 @@ class Parser::Lexer
           @cmdarg.pop
         end
 
-        if tok == '}'.freeze
-          fnext expr_endarg;
-        elsif tok == ']'
-          if @version >= 24
+        if tok == '}'.freeze || tok == ']'.freeze
+          if @version >= 25
             fnext expr_end;
           else
             fnext expr_endarg;

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -3916,7 +3916,8 @@ class TestParser < Minitest::Test
         s(:args),
         s(:int, 1)),
       %q{f 1, {1 => 2} {1}},
-      %q{})
+      %q{},
+      ALL_VERSIONS - SINCE_2_5)
   end
 
   def test_space_args_arg_call
@@ -6427,9 +6428,9 @@ class TestParser < Minitest::Test
 
   def test_context_cmd_brace_block
     [
-      'tap 1, { 1 => 2 } {',
-      'foo.tap 1, { 1 => 2 } {',
-      'foo::tap 1, { 1 => 2 } {'
+      'tap foo {',
+      'foo.tap foo {',
+      'foo::tap foo {'
     ].each do |code|
       assert_context([:block], code, ALL_VERSIONS)
     end
@@ -6747,7 +6748,7 @@ class TestParser < Minitest::Test
       [:error, :unexpected_token, { :token => 'tLCURLY' }],
       %q{m [] {}},
       %q{     ^ location},
-      SINCE_2_4)
+      SINCE_2_5)
 
     assert_parses(
       s(:block,
@@ -6756,7 +6757,7 @@ class TestParser < Minitest::Test
         s(:args), nil),
       %q{meth[] {}},
       %q{},
-      SINCE_2_4
+      SINCE_2_5
     )
 
     assert_diagnoses_many(


### PR DESCRIPTION
MRI 2.4.4:
```
$ ruby -vce 'm {} {}'
ruby 2.4.4p296 (2018-03-28 revision 63013) [x86_64-darwin17]
-e:1: syntax error, unexpected { arg, expecting end-of-input
m {} {}
      ^

$ ruby -vce 'm [] {}'
ruby 2.4.4p296 (2018-03-28 revision 63013) [x86_64-darwin17]
Syntax OK

$ ruby -vce 'm a: {} {}'
ruby 2.4.4p296 (2018-03-28 revision 63013) [x86_64-darwin17]
Syntax OK
```

Parser 2.4:
```
$ bin/ruby-parse --24 -e 'm {} {}'
(fragment:0):1:6: error: unexpected token tLBRACE_ARG
(fragment:0):1: m {} {}
(fragment:0):1:      ^

$ bin/ruby-parse --24 -e 'm [] {}'
(block
  (send nil :m
    (array))
  (args) nil)

$ bin/ruby-parse --24 -e 'm a: {} {}'
(block
  (send nil :m
    (hash
      (pair
        (sym :a)
        (hash))))
  (args) nil)
```

MRI 2.5.0
```
$ ruby -vce 'm {} {}'
ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-darwin17]
-e:1: syntax error, unexpected '{', expecting end-of-input
m {} {}
     ^

$ ruby -vce 'm [] {}'
ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-darwin17]
-e:1: syntax error, unexpected '{', expecting end-of-input
m [] {}
     ^

$ ruby -vce 'm a: {} {}'
ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-darwin17]
-e:1: syntax error, unexpected '{', expecting end-of-input
m a: {} {}
        ^
```

Parser 2.5:
```
$ bin/ruby-parse --25 -e 'm {} {}'
(fragment:0):1:6: error: unexpected token tLCURLY
(fragment:0):1: m {} {}
(fragment:0):1:      ^

$ bin/ruby-parse --25 -e 'm [] {}'
(fragment:0):1:6: error: unexpected token tLCURLY
(fragment:0):1: m [] {}
(fragment:0):1:      ^

$ bin/ruby-parse --25 -e 'm a: {} {}'
(fragment:0):1:9: error: unexpected token tLCURLY
(fragment:0):1: m a: {} {}
(fragment:0):1:         ^
```

Closes https://github.com/whitequark/parser/issues/495

@whitequark The first snippet says `syntax error, unexpected { arg, expecting end-of-input`, but points to the tRCURLY. Is it a bug in MRI? And by the way, is `{ arg` the same as `tLBRACE_ARG`? Do we emit a right token there?