### PR TITLE
Parser::Current: bump latest 2.2 branch to 2.2.10.

### DIFF
--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -30,7 +30,7 @@ module Parser
     CurrentRuby = Ruby21
 
   when /^2\.2\./
-    current_version = '2.2.9'
+    current_version = '2.2.10'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby22', current_version
     end


### PR DESCRIPTION
I apologize, somehow missed it in https://github.com/whitequark/parser/pull/489
Closes https://github.com/whitequark/parser/issues/494