### PR TITLE
lexer.rl: Fix parsing of `a ? b + '': nil`.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -2226,10 +2226,16 @@ class Parser::Lexer
       # OPERATORS
       #
 
-      ( e_lparen
-      | operator_arithmetic
-      | operator_rest
-      )
+      # When '|', '~', '!', '=>' are used as operators
+      # they do not accept any symbols (or quoted labels) after.
+      # Other binary operators accept it.
+      ( operator_arithmetic | operator_rest ) - ( '|' | '~' | '!' )
+      => {
+        emit_table(PUNCTUATION);
+        fnext expr_value; fbreak;
+      };
+
+      ( e_lparen | '|' | '~' | '!' )
       => { emit_table(PUNCTUATION)
            fnext expr_beg; fbreak; };
 

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -1944,7 +1944,7 @@ class TestLexer < Minitest::Test
                    :tIDENTIFIER, "a", [0, 1],
                    :tSTAR2,      "*", [2, 3])
 
-    assert_equal :expr_beg, @lex.state
+    assert_equal :expr_value, @lex.state
   end
 
   def test_star2
@@ -1952,7 +1952,7 @@ class TestLexer < Minitest::Test
                    :tIDENTIFIER, "a",  [0, 1],
                    :tPOW,        "**", [2, 4])
 
-    assert_equal :expr_beg, @lex.state
+    assert_equal :expr_value, @lex.state
   end
 
   def test_star2_equals

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6916,4 +6916,35 @@ class TestParser < Minitest::Test
       %q{},
       ALL_VERSIONS)
   end
+
+  def test_ambiuous_quoted_label_in_ternary_operator
+    assert_parses(
+      s(:if,
+        s(:send, nil, :a),
+        s(:send,
+          s(:send, nil, :b), :&,
+          s(:str, '')),
+        s(:nil)),
+      %q{a ? b & '': nil},
+      %q{},
+      ALL_VERSIONS)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tLABEL_END' }],
+      %q{a ? b | '': nil},
+      %q{         ^~ location},
+      SINCE_2_2)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tTILDE' }],
+      %q{a ? b ~ '': nil},
+      %q{      ^ location},
+      SINCE_2_2)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tBANG' }],
+      %q{a ? b ! '': nil},
+      %q{      ^ location},
+      SINCE_2_2)
+  end
 end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/492

All operators in `operator_arithmetic` and `operator_rest` (except `|`, `~`, `!`) can be followed by quoted labels if this symbol is actually a string + tCOLON from the ternary operator.