### PR TITLE
Fix parsing of `let (:a) { m do; end }`.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -1628,7 +1628,7 @@ class Parser::Lexer
         else
           emit(:tLBRACE_ARG, '{'.freeze)
         end
-        fnext expr_value;
+        fnext expr_value; fbreak;
       };
 
       'do'

--- a/lib/parser/lexer/stack_state.rb
+++ b/lib/parser/lexer/stack_state.rb
@@ -35,6 +35,10 @@ module Parser
       @stack[0] == 1
     end
 
+    def empty?
+      @stack == 0
+    end
+
     def to_s
       "[#{@stack.to_s(2)} <= #{@name}]"
     end

--- a/test/parse_helper.rb
+++ b/test/parse_helper.rb
@@ -124,7 +124,7 @@ module ParseHelper
       assert_source_range(begin_pos, end_pos, range, version, line.inspect)
     end
 
-    assert_equal parser.instance_eval { @lexer }.cmdarg.instance_eval { @stack }, 0,
+    assert parser.instance_eval { @lexer }.cmdarg.empty?,
       "(#{version}) expected cmdarg to be empty after parsing"
   end
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6965,4 +6965,19 @@ class TestParser < Minitest::Test
       %q{      ^ location},
       SINCE_2_2)
   end
+
+  def test_lbrace_arg_after_command_args
+    assert_parses(
+      s(:block,
+        s(:send, nil, :let,
+          s(:begin,
+            s(:sym, :a))),
+        s(:args),
+        s(:block,
+          s(:send, nil, :m),
+          s(:args), nil)),
+      %q{let (:a) { m do; end }},
+      %q{},
+      ALL_VERSIONS)
+  end
 end


### PR DESCRIPTION
In this case lexer emits multiple tokens (`tLBRACE_ARG` + one more token because there's no `fbreak`) and `cmdarg.push` gets called for both tokens. Later parser does `pop` after `command_args` and as a result it pops a wrong value. 

Also I've added `empty?` method to the `StackState` class to use it in tests and rely on the interface.

Found it during stress testing (~40k files from rubygems)