### PR TITLE
Fix cmdargs after command_args followed by tLBRACE_ARG.

### DIFF
--- a/lib/parser/ruby24.y
+++ b/lib/parser/ruby24.y
@@ -875,7 +875,20 @@ rule
                     }
                   call_args
                     {
-                      @lexer.cmdarg.pop
+                      # call_args can be followed by tLBRACE_ARG (that does cmdarg.push(0) in the lexer)
+                      # but the push must be done after cmdarg.pop() in the parser.
+                      # So this code does cmdarg.pop() to pop 0 pushed by tLBRACE_ARG,
+                      # cmdarg.pop() to pop 1 pushed by command_args,
+                      # and cmdarg.push(0) to restore back the flag set by tLBRACE_ARG.
+                      last_token = @last_token[0]
+                      lookahead = last_token == :tLBRACE_ARG
+                      if lookahead
+                        top = @lexer.cmdarg.pop
+                        @lexer.cmdarg.pop
+                        @lexer.cmdarg.push(top)
+                      else
+                        @lexer.cmdarg.pop
+                      end
 
                       result = val[1]
                     }

--- a/lib/parser/ruby25.y
+++ b/lib/parser/ruby25.y
@@ -885,7 +885,20 @@ rule
                     }
                   call_args
                     {
-                      @lexer.cmdarg.pop
+                      # call_args can be followed by tLBRACE_ARG (that does cmdarg.push(0) in the lexer)
+                      # but the push must be done after cmdarg.pop() in the parser.
+                      # So this code does cmdarg.pop() to pop 0 pushed by tLBRACE_ARG,
+                      # cmdarg.pop() to pop 1 pushed by command_args,
+                      # and cmdarg.push(0) to restore back the flag set by tLBRACE_ARG.
+                      last_token = @last_token[0]
+                      lookahead = last_token == :tLBRACE_ARG
+                      if lookahead
+                        top = @lexer.cmdarg.pop
+                        @lexer.cmdarg.pop
+                        @lexer.cmdarg.push(top)
+                      else
+                        @lexer.cmdarg.pop
+                      end
 
                       result = val[1]
                     }

--- a/lib/parser/ruby26.y
+++ b/lib/parser/ruby26.y
@@ -885,7 +885,20 @@ rule
                     }
                   call_args
                     {
-                      @lexer.cmdarg.pop
+                      # call_args can be followed by tLBRACE_ARG (that does cmdarg.push(0) in the lexer)
+                      # but the push must be done after cmdarg.pop() in the parser.
+                      # So this code does cmdarg.pop() to pop 0 pushed by tLBRACE_ARG,
+                      # cmdarg.pop() to pop 1 pushed by command_args,
+                      # and cmdarg.push(0) to restore back the flag set by tLBRACE_ARG.
+                      last_token = @last_token[0]
+                      lookahead = last_token == :tLBRACE_ARG
+                      if lookahead
+                        top = @lexer.cmdarg.pop
+                        @lexer.cmdarg.pop
+                        @lexer.cmdarg.push(top)
+                      else
+                        @lexer.cmdarg.pop
+                      end
 
                       result = val[1]
                     }

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6980,4 +6980,19 @@ class TestParser < Minitest::Test
       %q{},
       ALL_VERSIONS)
   end
+
+  def test_ruby_bug_14690
+    assert_parses(
+      s(:block,
+        s(:send, nil, :let,
+          s(:begin)),
+        s(:args),
+        s(:block,
+          s(:send, nil, :m,
+            s(:send, nil, :a)),
+          s(:args), nil)),
+      %q{let () { m(a) do; end }},
+      %q{},
+      SINCE_2_0)
+  end
 end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/502
Fixes https://github.com/whitequark/parser/issues/501.

This commit tracks upstream commit ruby/ruby@f168dbd.

The spec says `SINCE_2_0` because 1.8 doesn't emit empty parens (so there's no `s(:begin)` in the ast) and 1.9 fails parsing it (no ideas why).

There's one test in the suite that verifies it - https://github.com/whitequark/parser/blob/master/test/test_parser.rb#L4128-L4164 - and it expect exactly what I described above. @whitequark do you remember why this syntax is not supported by 1.9?