### PR TITLE
ruby26.y: Endless ranges support.

### DIFF
--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -322,6 +322,20 @@ Format:
  ~~~~~ expression
 ~~~
 
+
+### Endless (2.6)
+
+Can be inclusive or exclusive.
+
+Format:
+
+~~~
+(irange (int 1) nil)
+"1.."
+  ~~ operator
+ ~~~ expression
+~~~
+
 ## Access
 
 ### Self

--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -325,8 +325,6 @@ Format:
 
 ### Endless (2.6)
 
-Can be inclusive or exclusive.
-
 Format:
 
 ~~~
@@ -334,6 +332,11 @@ Format:
 "1.."
   ~~ operator
  ~~~ expression
+
+(erange (int 1) nil)
+"1..."
+  ~~~ operator
+ ~~~~ expression
 ~~~
 
 ## Access

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -400,12 +400,12 @@ module Parser
 
     def range_inclusive(lhs, dot2_t, rhs)
       n(:irange, [ lhs, rhs ],
-        binary_op_map(lhs, dot2_t, rhs))
+        range_map(lhs, dot2_t, rhs))
     end
 
     def range_exclusive(lhs, dot3_t, rhs)
       n(:erange, [ lhs, rhs ],
-        binary_op_map(lhs, dot3_t, rhs))
+        range_map(lhs, dot3_t, rhs))
     end
 
     #
@@ -1383,6 +1383,16 @@ module Parser
         expr_l = loc(op_t)
       else
         expr_l = loc(op_t).join(arg_e.loc.expression)
+      end
+
+      Source::Map::Operator.new(loc(op_t), expr_l)
+    end
+
+    def range_map(start_e, op_t, end_e)
+      if end_e
+        expr_l = join_exprs(start_e, end_e)
+      else
+        expr_l = start_e.loc.expression.join(loc(op_t))
       end
 
       Source::Map::Operator.new(loc(op_t), expr_l)

--- a/lib/parser/ruby26.y
+++ b/lib/parser/ruby26.y
@@ -665,6 +665,14 @@ rule
                     {
                       result = @builder.range_exclusive(val[0], val[1], val[2])
                     }
+                | arg tDOT2
+                    {
+                      result = @builder.range_inclusive(val[0], val[1], nil)
+                    }
+                | arg tDOT3
+                    {
+                      result = @builder.range_exclusive(val[0], val[1], nil)
+                    }
                 | arg tPLUS arg
                     {
                       result = @builder.binary_op(val[0], val[1], val[2])

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6980,4 +6980,22 @@ class TestParser < Minitest::Test
       %q{},
       ALL_VERSIONS)
   end
+
+  def test_endless_range
+    assert_parses(
+      s(:irange,
+        s(:int, 1), nil),
+      %q{1..},
+      %q{~~~ expression
+        | ~~ operator},
+      SINCE_2_6)
+
+    assert_parses(
+      s(:erange,
+        s(:int, 1), nil),
+      %q{1...},
+      %q{~~~~ expression
+        | ~~~ operator},
+      SINCE_2_6)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@7f95eed.
Closes https://github.com/whitequark/parser/issues/504