### PR TITLE
AST::Processor: Recurse into `kwsplat`s

### DIFF
--- a/lib/parser/ast/processor.rb
+++ b/lib/parser/ast/processor.rb
@@ -16,6 +16,7 @@ module Parser
       alias on_regexp   process_regular_node
       alias on_xstr     process_regular_node
       alias on_splat    process_regular_node
+      alias on_kwsplat  process_regular_node
       alias on_array    process_regular_node
       alias on_pair     process_regular_node
       alias on_hash     process_regular_node


### PR DESCRIPTION
An easy test case is to use `bin/ruby-parse -L`, which uses a `Processor` to recurse over the tree:

## before:
```
$ ruby-parse -L -e 'foo(**y)'
s(:send, nil, :foo,
  s(:hash,
    s(:kwsplat,
      s(:send, nil, :y))))
foo(**y)
~~~ selector
       ~ end
   ~ begin
~~~~~~~~ expression
s(:hash,
  s(:kwsplat,
    s(:send, nil, :y)))
foo(**y)
    ~~~ expression
s(:kwsplat,
  s(:send, nil, :y))
foo(**y)
    ~~ operator
    ~~~ expression
```

## after
```
$ ruby-parse -L -e 'foo(**y)'
s(:send, nil, :foo,
  s(:hash,
    s(:kwsplat,
      s(:send, nil, :y))))
foo(**y)
~~~ selector
       ~ end
   ~ begin
~~~~~~~~ expression
s(:hash,
  s(:kwsplat,
    s(:send, nil, :y)))
foo(**y)
    ~~~ expression
s(:kwsplat,
  s(:send, nil, :y))
foo(**y)
    ~~ operator
    ~~~ expression
s(:send, nil, :y)
foo(**y)
      ~ selector
      ~ expression
```

Or, in diff form:
```diff
diff --git a/before b/after
index 516b8b0..bb19254 100644
--- a/before
+++ b/after
@@ -17,3 +17,7 @@ s(:kwsplat,
 foo(**y)
     ~~ operator
     ~~~ expression
+s(:send, nil, :y)
+foo(**y)
+      ~ selector
+      ~ expression
```

The latter recursed into `y`, and the former did not.

I wanted to write a test but there didn't seem to be a convenient test harness for AST processors. I'm happy to throw something together on request.