### PR TITLE
Fix parsing of 'm = -> *args do end'.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -2249,7 +2249,7 @@ class Parser::Lexer
       ( operator_arithmetic | operator_rest ) - ( '|' | '~' | '!' )
       => {
         emit_table(PUNCTUATION);
-        fnext expr_value; fbreak;
+        fgoto expr_value;
       };
 
       ( e_lparen | '|' | '~' | '!' )

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7013,4 +7013,16 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_2_0)
   end
+
+  def test_parser_bug_507
+    assert_parses(
+      s(:lvasgn, :m,
+        s(:block,
+          s(:lambda),
+          s(:args,
+            s(:restarg, :args)), nil)),
+      %q{m = -> *args do end},
+      %q{},
+      SINCE_1_9)
+  end
 end


### PR DESCRIPTION
That's a regression introduced in f0a5c6b5a55ccadc784489d966efc8975b3f4e32.

`fgoto` doesn't exit from `advance`, so `@command_state` remains the same and later `arg_or_cmdarg` can properly select the next state. Sorry, that was not obvious in https://github.com/whitequark/parser/pull/498.

@whitequark A quick question. `Parser#last_token` in some cases requires lexer to emit tokens one by one, but in this case we have to use `fgoto` to continue parsing without changing `@command_state`.  I feel like it can become a problem in the future. There are 54 occurrences of `fgoto` in the lexer, I know, some of them are safe because they do `fhold; fgoto ...`. But this specific action emits a token **and** does `fgoto`. Is there a way to rewrite `@command_state` somehow to not depend on `Lexer#advance` (and thus do `fnext; fbreak` when we need)?

Closes https://github.com/whitequark/parser/issues/507#event-1593145674