### PR TITLE
Revert parsing of '-> do rescue; end' for ruby25, it's valid only starting from 26.

### DIFF
--- a/lib/parser/ruby25.y
+++ b/lib/parser/ruby25.y
@@ -1517,7 +1517,7 @@ opt_block_args_tail:
                     {
                       @context.push(:lambda)
                     }
-                  bodystmt kEND
+                  compstmt kEND
                     {
                       result = [ val[0], val[2], val[3] ]
                       @context.pop

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -6676,7 +6676,7 @@ class TestParser < Minitest::Test
       [:error, :unexpected_token, { :token => 'kRESCUE'}],
       %q{-> do rescue; end},
       %q{      ~~~~~~ location},
-      SINCE_1_9 - SINCE_2_5)
+      SINCE_1_9 - SINCE_2_6)
 
     assert_parses(
       s(:block,
@@ -6686,7 +6686,7 @@ class TestParser < Minitest::Test
           s(:resbody, nil, nil, nil), nil)),
       %q{-> do rescue; end},
       %q{      ~~~~~~ keyword (rescue.resbody)},
-      SINCE_2_5)
+      SINCE_2_6)
 
     assert_diagnoses(
       [:error, :unexpected_token, { :token => 'kRESCUE'}],


### PR DESCRIPTION
See https://github.com/whitequark/parser/pull/431#issuecomment-392535487