### PR TITLE
Fix YARD type annotations

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -46,7 +46,7 @@ module Parser
       # magic encoding comment or UTF-8 BOM. `string` can be in any encoding.
       #
       # @param [String]  string
-      # @return [String|nil] encoding name, if recognized
+      # @return [String, nil] encoding name, if recognized
       #
       def self.recognize_encoding(string)
         return if string.empty?

--- a/lib/parser/source/comment.rb
+++ b/lib/parser/source/comment.rb
@@ -24,8 +24,8 @@ module Parser
       # Associate `comments` with `ast` nodes by their corresponding node.
       #
       # @param [Parser::AST::Node] ast
-      # @param [Array(Comment)]    comments
-      # @return [Hash(Parser::AST::Node, Array(Comment))]
+      # @param [Array<Comment>]    comments
+      # @return [Hash<Parser::AST::Node, Array<Comment>>]
       # @see Parser::Source::Comment::Associator#associate
       # @deprecated Use {associate_locations}.
       #
@@ -39,8 +39,8 @@ module Parser
       # source.
       #
       # @param [Parser::AST::Node] ast
-      # @param [Array(Comment)]    comments
-      # @return [Hash(Parser::Source::Map, Array(Comment))]
+      # @param [Array<Comment>]    comments
+      # @return [Hash<Parser::Source::Map, Array<Comment>>]
       # @see Parser::Source::Comment::Associator#associate_locations
       #
       def self.associate_locations(ast, comments)

--- a/lib/parser/source/comment/associator.rb
+++ b/lib/parser/source/comment/associator.rb
@@ -47,7 +47,7 @@ module Parser
 
       ##
       # @param [Parser::AST::Node] ast
-      # @param [Array(Parser::Source::Comment)] comments
+      # @param [Array<Parser::Source::Comment>] comments
       def initialize(ast, comments)
         @ast         = ast
         @comments    = comments
@@ -85,7 +85,7 @@ module Parser
       # Note that {associate} produces unexpected result for nodes which are
       # equal but have distinct locations; comments for these nodes are merged.
       #
-      # @return [Hash(Parser::AST::Node, Array(Parser::Source::Comment))]
+      # @return [Hash<Parser::AST::Node, Array<Parser::Source::Comment>>]
       # @deprecated Use {associate_locations}.
       #
       def associate
@@ -98,7 +98,7 @@ module Parser
       # the hash key, thus producing an unambiguous result even in presence
       # of equal nodes.
       #
-      # @return [Hash(Parser::Source::Map, Array(Parser::Source::Comment))]
+      # @return [Hash<Parser::Source::Map, Array<Parser::Source::Comment>>]
       #
       def associate_locations
         @map_using_locations = true

--- a/lib/parser/source/map.rb
+++ b/lib/parser/source/map.rb
@@ -161,7 +161,7 @@ module Parser
       #  #   :expression => #<Source::Range (string) 0...6>
       #  # }
       #
-      # @return [Hash(Symbol, Parser::Source::Range)]
+      # @return [Hash<Symbol, Parser::Source::Range>]
       #
       def to_hash
         instance_variables.inject({}) do |hash, ivar|

--- a/lib/parser/source/range.rb
+++ b/lib/parser/source/range.rb
@@ -143,7 +143,7 @@ module Parser
       end
 
       ##
-      # @return [Array(Integer)] a set of character indexes contained in this range.
+      # @return [Array<Integer>] a set of character indexes contained in this range.
       #
       def to_a
         (@begin_pos...@end_pos).to_a

--- a/lib/parser/source/tree_rewriter.rb
+++ b/lib/parser/source/tree_rewriter.rb
@@ -133,8 +133,8 @@ module Parser
       # Inserts the given strings before and after the given range.
       #
       # @param [Range] range
-      # @param [String or nil] insert_before
-      # @param [String or nil] insert_after
+      # @param [String, nil] insert_before
+      # @param [String, nil] insert_after
       # @return [Rewriter] self
       # @raise [ClobberingError] when clobbering is detected
       #


### PR DESCRIPTION
This PR does not impact the API.

The correct YARD annotations to express multiple types is as a list of multiple values ([source](https://www.rubydoc.info/gems/yard/file/docs/Tags.md#Types_Specifier_List))

```
[Type1, Type2]
```

This PR corrects usages of `|` and `or` to achieve the same result.

---

The correct way to represent parameterized classes is using angled brackets ([source](https://www.rubydoc.info/gems/yard/file/docs/Tags.md#Parametrized_Types))

```
Hash<String, Integer>
```

This PR corrects usage of parentheses to achieve the same result. 