### PR TITLE
Fix return type annotation for Parser::Base#parse

### DIFF
--- a/lib/parser/base.rb
+++ b/lib/parser/base.rb
@@ -158,7 +158,7 @@ module Parser
     # Parses a source buffer and returns the AST.
     #
     # @param [Parser::Source::Buffer] source_buffer The source buffer to parse.
-    # @return [Parser::AST::Node]
+    # @return [Parser::AST::Node, false]
     #
     def parse(source_buffer)
       @lexer.source_buffer = source_buffer


### PR DESCRIPTION
`Parser::Base#parse` sometimes returns `false` but it's return type annotations doesn't show that

Example

```ruby
require 'parser/current'

parser = Parser::CurrentRuby.new
buf = Parser::Source::Buffer.new("(string)")
buf.source = "foo *"
exp = parser.parse(buf)
#=> false
```