### PR TITLE
Partially revert 5ba072d and properly handle 'm = -> *args do end'.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -2243,13 +2243,19 @@ class Parser::Lexer
       # OPERATORS
       #
 
+      '*'
+      => {
+        emit(:tSTAR2)
+        fgoto expr_value;
+      };
+
       # When '|', '~', '!', '=>' are used as operators
       # they do not accept any symbols (or quoted labels) after.
       # Other binary operators accept it.
-      ( operator_arithmetic | operator_rest ) - ( '|' | '~' | '!' )
+      ( operator_arithmetic | operator_rest ) - ( '|' | '~' | '!' - '*' )
       => {
         emit_table(PUNCTUATION);
-        fgoto expr_value;
+        fnext expr_value; fbreak;
       };
 
       ( e_lparen | '|' | '~' | '!' )

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7025,4 +7025,14 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_1_9)
   end
+
+  def test_parser_bug_518
+    assert_parses(
+      s(:class,
+        s(:const, nil, :A),
+        s(:const, nil, :B), nil),
+      "class A < B\nend",
+      %q{},
+      ALL_VERSIONS)
+  end
 end


### PR DESCRIPTION
The bug was introduced in https://github.com/whitequark/parser/commit/5ba072dba6d0f1270eab9cc782dad2fa5e759abe, but we didn't know about it. Sad, but our test suite doesn't cover all cases.

@whitequark I'm getting more and more unconfident in every patch that I send. Is there any way to improve our CI to handle trivial cases like this one? Any ideas?

Closes https://github.com/whitequark/parser/issues/518