### PR TITLE
Setup diagnostic to throw a Parser::SyntaxError on any error.

### DIFF
--- a/lib/parser/base.rb
+++ b/lib/parser/base.rb
@@ -120,6 +120,7 @@ module Parser
     #
     def initialize(builder=Parser::Builders::Default.new)
       @diagnostics = Diagnostic::Engine.new
+      @diagnostics.all_errors_are_fatal = true
 
       @static_env  = StaticEnvironment.new
 

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -28,4 +28,14 @@ class TestBase < Minitest::Test
     assert_nil ast.loc.dup.node
     Parser::AST::Node.new(:root, [], :location => ast.loc)
   end
+
+  def test_raising_errors_by_default
+    parser = Parser::CurrentRuby.new
+    buffer = Parser::Source::Buffer.new("(eval)")
+    buffer.source = "foo *"
+
+    assert_raises Parser::SyntaxError do
+      parser.parse(buffer)
+    end
+  end
 end


### PR DESCRIPTION
Also I think #517 should be merged because `parse` *technically* still can return `false` if parser is configured with `diagnostics.all_errors_are_fatal = false`. In such case `Diagnostic::Engine` doesn't throw any errors.

Also I'm not sure why there are 3 kinds of diagnostic messages, I think `warning` and `error` should be enough. @whitequark Could you explain it please? I just can't imagine a case when someone may want parser to ignore errors.