### PR TITLE
Fix parsing of ambiguous 1re.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -625,6 +625,7 @@ class Parser::Lexer
   | 'r'      % { @num_xfrm = lambda { |chars| emit(:tRATIONAL,  Rational(chars)) } }
   | 'i'      % { @num_xfrm = lambda { |chars| emit(:tIMAGINARY, Complex(0, chars)) } }
   | 'ri'     % { @num_xfrm = lambda { |chars| emit(:tIMAGINARY, Complex(0, Rational(chars))) } }
+  | 're'     % { @num_xfrm = lambda { |chars| emit(:tINTEGER,   chars, @ts, @te - 2); p -= 2 } }
   | 'if'     % { @num_xfrm = lambda { |chars| emit(:tINTEGER,   chars, @ts, @te - 2); p -= 2 } }
   | 'rescue' % { @num_xfrm = lambda { |chars| emit(:tINTEGER,   chars, @ts, @te - 6); p -= 6 } };
 

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -3534,4 +3534,10 @@ class TestLexer < Minitest::Test
                    :tNL,             nil,                [4, 5])
   end
 
+  def test_ambiguous_integer_re
+    assert_scanned('1re',
+                   :tINTEGER, 1, [0, 1],
+                   :tIDENTIFIER, 're', [1, 3])
+  end
+
 end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/522.

That's what MRI emits from the lexer:

```
$ ruby -y -e '1re' | grep token
-e:1: syntax error, unexpected tIDENTIFIER, expecting end-of-input
Reading a token:
Next token is token tINTEGER (1.1-1.1: )
Shifting token tINTEGER (1.1-1.1: )
   $1 = token tINTEGER (1.1-1.1: )
Reading a token:
Next token is token tIDENTIFIER (1.1-1.3: )
Next token is token tIDENTIFIER (1.1-1.3: )
Next token is token tIDENTIFIER (1.1-1.3: )
Next token is token tIDENTIFIER (1.1-1.3: )
Next token is token tIDENTIFIER (1.1-1.3: )
Next token is token tIDENTIFIER (1.1-1.3: )
Cleanup: discarding lookahead token tIDENTIFIER (1.1-1.3: )
```

And so the errors comes later from the parser.