### PR TITLE
Fix parsing of 'm :key => m do; m() do end; end'.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -2244,16 +2244,16 @@ class Parser::Lexer
       # OPERATORS
       #
 
-      '*'
+      '*' | '=>'
       => {
-        emit(:tSTAR2)
+        emit_table(PUNCTUATION)
         fgoto expr_value;
       };
 
       # When '|', '~', '!', '=>' are used as operators
       # they do not accept any symbols (or quoted labels) after.
       # Other binary operators accept it.
-      ( operator_arithmetic | operator_rest ) - ( '|' | '~' | '!' - '*' )
+      ( operator_arithmetic | operator_rest ) - ( '|' | '~' | '!' | '*' )
       => {
         emit_table(PUNCTUATION);
         fnext expr_value; fbreak;

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7035,4 +7035,21 @@ class TestParser < Minitest::Test
       %q{},
       ALL_VERSIONS)
   end
+
+  def test_parser_bug_525
+    assert_parses(
+      s(:block,
+        s(:send, nil, :m1,
+          s(:hash,
+            s(:pair,
+              s(:sym, :k),
+              s(:send, nil, :m2)))),
+        s(:args),
+        s(:block,
+          s(:send, nil, :m3),
+          s(:args), nil)),
+      'm1 :k => m2 do; m3() do end; end',
+      %q{},
+      ALL_VERSIONS)
+  end
 end


### PR DESCRIPTION
Closes #525 

I've checked other values that are handled by `operator_arithmetic` and `operator_rest`, none of them are affected by this issue.