### PR TITLE
Relax bundler dev dependency to allow bundler v2.0.0.pre2

### DIFF
--- a/parser.gemspec
+++ b/parser.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency             'ast',       '~> 2.4.0'
 
-  spec.add_development_dependency 'bundler',   '~> 1.15'
+  spec.add_development_dependency 'bundler',   '>= 1.15', '< 3.0.0'
   spec.add_development_dependency 'rake',      '~> 10.0'
   spec.add_development_dependency 'racc',      '= 1.4.14'
   spec.add_development_dependency 'cliver',    '~> 0.3.2'


### PR DESCRIPTION
ruby 2.6.0-rc1 was released.
https://www.ruby-lang.org/en/news/2018/12/06/ruby-2-6-0-rc1-released/

it seems to bundles bundler v2.0.0.pre2 https://github.com/bundler/bundler/releases/tag/v2.0.0.pre.2

I'd like to test rubocop with v2.6.0-rc1. But without this changes, it got following errors.

```
$ bunlde install
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /Users/yoshimin/src/github.com/whitequark/parser/parser.gemspec:15.
Fetching gem metadata from https://rubygems.org/.............
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.15)

  Current Bundler version:
    bundler (2.0.0)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 1.15)' in any of the relevant sources:
  the local ruby installation
```

