### PR TITLE
has_rdoc option was deprecated

### DIFF
--- a/parser.gemspec
+++ b/parser.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |spec|
   spec.summary       = spec.description
   spec.homepage      = 'https://github.com/whitequark/parser'
   spec.license       = 'MIT'
-  spec.has_rdoc      = 'yard'
 
   spec.files         = `git ls-files`.split + %w(
                           lib/parser/lexer.rb


### PR DESCRIPTION
I noticed that following warnings occured while bundle installing.

```
$ bunlde install
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
```

SEE ALSO

https://blog.rubygems.org/2011/03/28/1.7.0-released.html
https://blog.rubygems.org/2009/05/04/1.3.3-released.html
