### PR TITLE
2.6.0 was released, unmark is as -dev.

### DIFF
--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -66,7 +66,7 @@ module Parser
     CurrentRuby = Ruby25
 
   when /^2\.6\./
-    current_version = '2.6.0-dev'
+    current_version = '2.6.0'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby26', current_version
     end


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/