### PR TITLE
Fix parsing of "\\\n" escaped sequences in various literals.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -894,27 +894,27 @@ class Parser::Lexer
       end
     else
       # It does not. So this is an actual escape sequence, yay!
-      if current_literal.regexp?
-        # Regular expressions should include escape sequences in their
-        # escaped form. On the other hand, escaped newlines are removed.
+      if current_literal.squiggly_heredoc? && escaped_char == "\n".freeze
+        # Squiggly heredocs like
+        #   <<~-HERE
+        #     1\
+        #     2
+        #   HERE
+        # treat '\' as a line continuation, but still dedent the body, so the heredoc above becomes "12\n".
+        # This information is emitted as is, without escaping,
+        # later this escape sequence (\\\n) gets handled manually in the Lexer::Dedenter
+        current_literal.extend_string(tok, @ts, @te)
+      elsif current_literal.supports_line_continuation_via_slash? && escaped_char == "\n".freeze
+        # Heredocs, regexp and a few other types of literals support line
+        # continuation via \\\n sequence. The code like
+        #   "a\
+        #   b"
+        # must be parsed as "ab"
         current_literal.extend_string(tok.gsub("\\\n".freeze, ''.freeze), @ts, @te)
-      elsif current_literal.heredoc? && escaped_char == "\n".freeze
-        if current_literal.squiggly_heredoc?
-          # Squiggly heredocs like
-          #   <<~-HERE
-          #     1\
-          #     2
-          #   HERE
-          # treat '\' as a line continuation, but still dedent the body, so the heredoc above becomes "12\n".
-          # This information is emitted as is, without escaping,
-          # later this escape sequence (\\n) gets handled manually in the Lexer::Dedenter
-          current_literal.extend_string(tok, @ts, @te)
-        else
-          # Plain heredocs also parse \\n as a line continuation,
-          # but they don't need to know that there was originally a newline in the
-          # code, so we escape it and emit as "  1  2\n"
-          current_literal.extend_string(tok.gsub("\\\n".freeze, ''.freeze), @ts, @te)
-        end
+      elsif current_literal.regexp?
+        # Regular expressions should include escape sequences in their
+        # escaped form. On the other hand, escaped newlines are removed (in cases like "\\C-\\\n\\M-x")
+        current_literal.extend_string(tok.gsub("\\\n".freeze, ''.freeze), @ts, @te)
       else
         current_literal.extend_string(@escape || tok, @ts, @te)
       end

--- a/lib/parser/lexer/literal.rb
+++ b/lib/parser/lexer/literal.rb
@@ -227,6 +227,10 @@ module Parser
       end
     end
 
+    def supports_line_continuation_via_slash?
+      !words? && @interpolate
+    end
+
     protected
 
     def delimiter?(delimiter)

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7052,4 +7052,36 @@ class TestParser < Minitest::Test
       %q{},
       ALL_VERSIONS)
   end
+
+  def test_parser_slash_slash_n_escaping_in_literals
+    [
+      ["'",             "'",       s(:dstr, s(:str, "a\\\n"), s(:str, "b"))  ],
+      ["<<-'HERE'\n",   "\nHERE",  s(:dstr, s(:str, "a\\\n"), s(:str, "b\n"))],
+      ["%q{",           "}",       s(:dstr, s(:str, "a\\\n"), s(:str, "b"))  ],
+      ['"',             '"',       s(:str, "ab")                             ],
+      ["<<-\"HERE\"\n", "\nHERE",  s(:str, "ab\n")                           ],
+      ["%{",            "}",       s(:str, "ab")                             ],
+      ["%Q{",           "}",       s(:str, "ab")                             ],
+      ["%w{",           "}",       s(:array, s(:str, "a\nb"))                ],
+      ["%W{",           "}",       s(:array, s(:str, "a\nb"))                ],
+      ["%i{",           "}",       s(:array, s(:sym, :"a\nb"))               ],
+      ["%I{",           "}",       s(:array, s(:sym, :"a\nb"))               ],
+      [":'",            "'",       s(:dsym, s(:str, "a\\\n"), s(:str, "b"))  ],
+      ["%s{",           "}",       s(:dsym, s(:str, "a\\\n"), s(:str, "b"))  ],
+      [':"',            '"',       s(:sym, :ab)                              ],
+      ['/',             '/',       s(:regexp, s(:str, "ab"), s(:regopt))     ],
+      ['%r{',           '}',       s(:regexp, s(:str, "ab"), s(:regopt))     ],
+      ['%x{',           '}',       s(:xstr, s(:str, "ab"))                   ],
+      ['`',             '`',       s(:xstr, s(:str, "ab"))                   ],
+      ["<<-`HERE`\n",   "\nHERE",  s(:xstr, s(:str, "ab\n"))                 ],
+    ].each do |literal_s, literal_e, expected|
+      source = literal_s + "a\\\nb" + literal_e
+
+      assert_parses(
+        expected,
+        source,
+        %q{},
+        SINCE_2_0)
+    end
+  end
 end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/537

Introduced `Literal#supports_line_continuation_via_slash?` method that returns `true/false` depending on the type of the literal. I wasn't able to find any correlation between interpolation and escaping rules. Looks like that's a completely new separate property of the literal. Ruby ❤️ 

Added spec that verifies that `"\\\n"` gets properly escaped for all kinds of literals. @whitequark Please let me know if I should convert it from acceptance table to a list of plain assertions.

<details><summary>test data</summary>
<p>

``` ruby
$ cat test.rb
def `(str); str; end

p 'a\
b'

p <<'HERE'
  a\
  b
HERE

p %q{a\
b}

p "a\
b"

p <<"HERE"
  a\
  b
HERE

p %{a\
b}

p %Q{a\
b}

p %w{a\
b}

p %W{a\
b}

p %i{a\
b}
p %I{a\
b}

p :'a\
b'

p %s{a\
b}

p :"a\
b"

p /a\
b/

p %r{a\
b}

p %x{a\
b}

p `a\
b`

p <<`HERE`
a\
b
HERE
```

</p>
</details>

<details><summary>ruby -e</summary>
<p>

``` bash
$ ruby test.rb
"a\\\nb"
"  a\\\n  b\n"
"a\\\nb"
"ab"
"  a  b\n"
"ab"
"ab"
["a\nb"]
["a\nb"]
[:"a\nb"]
[:"a\nb"]
:"a\\\nb"
:"a\\\nb"
:ab
/ab/
/ab/
"ab"
"ab"
"ab\n"
```
</p>
</details>

<details><summary>bin/ruby-parse</summary>
<p>

``` ruby
$ bin/ruby-parse test.rb
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.0-dev-compliant syntax, but you are running 2.6.0.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
(begin
  (def :`
    (args
      (arg :str))
    (lvar :str))
  (send nil :p
    (dstr
      (str "a\\\n")
      (str "b")))
  (send nil :p
    (dstr
      (str "  a\\\n")
      (str "  b\n")))
  (send nil :p
    (dstr
      (str "a\\\n")
      (str "b")))
  (send nil :p
    (str "ab"))
  (send nil :p
    (str "  a  b\n"))
  (send nil :p
    (str "ab"))
  (send nil :p
    (str "ab"))
  (send nil :p
    (array
      (str "a\nb")))
  (send nil :p
    (array
      (str "a\nb")))
  (send nil :p
    (array
      (sym :"a\nb")))
  (send nil :p
    (array
      (sym :"a\nb")))
  (send nil :p
    (dsym
      (str "a\\\n")
      (str "b")))
  (send nil :p
    (dsym
      (str "a\\\n")
      (str "b")))
  (send nil :p
    (sym :ab))
  (send nil :p
    (regexp
      (str "ab")
      (regopt)))
  (send nil :p
    (regexp
      (str "ab")
      (regopt)))
  (send nil :p
    (xstr
      (str "ab")))
  (send nil :p
    (xstr
      (str "ab")))
  (send nil :p
    (xstr
      (str "ab\n"))))
```

</p>
</details>