### PR TITLE
Remove unreachable code from lexer.rl

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -1039,13 +1039,8 @@ class Parser::Lexer
       if current_literal.end_interp_brace_and_try_closing
         if version?(18, 19)
           emit(:tRCURLY, '}'.freeze, p - 1, p)
-          if @version < 24
-            @cond.lexpop
-            @cmdarg.lexpop
-          else
-            @cond.pop
-            @cmdarg.pop
-          end
+          @cond.lexpop
+          @cmdarg.lexpop
         else
           emit(:tSTRING_DEND, '}'.freeze, p - 1, p)
         end


### PR DESCRIPTION
It is a meaningless condition. Because it checks the version is less than 2.4, but it has been checked the version is 1.8 or 1.9.