### PR TITLE
Add method reference operator.

### DIFF
--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -583,6 +583,18 @@ Format:
  ~~~~~~~~~~~~~ expression
 ~~~
 
+### Method reference operator
+
+Format:
+
+~~~
+(meth-ref (self) :foo)
+"self.:foo"
+     ^^ dot
+       ^^^ selector
+ ^^^^^^^^^ expression
+~~~
+
 ### Multiple assignment
 
 #### Multiple left hand side

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -963,6 +963,11 @@ module Parser
       end
     end
 
+    def method_ref(receiver, dot_t, selector_t)
+      n(:meth_ref, [ receiver, value(selector_t).to_sym ],
+          send_map(receiver, dot_t, selector_t, nil, [], nil))
+    end
+
     #
     # Control flow
     #

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -446,7 +446,7 @@ class Parser::Lexer
     '=>'  => :tASSOC,   '::'  => :tCOLON2,  '===' => :tEQQ,
     '<=>' => :tCMP,     '[]'  => :tAREF,    '[]=' => :tASET,
     '{'   => :tLCURLY,  '}'   => :tRCURLY,  '`'   => :tBACK_REF2,
-    '!@'  => :tBANG,    '&.'  => :tANDDOT,
+    '!@'  => :tBANG,    '&.'  => :tANDDOT,  '.:'  => :tMETHREF
   }
 
   PUNCTUATION_BEGIN = {
@@ -2215,7 +2215,13 @@ class Parser::Lexer
       # METHOD CALLS
       #
 
-      '.' | '&.' | '::'
+      '.:' w_space+
+      => { emit(:tDOT, '.', @ts, @ts + 1)
+           emit(:tCOLON, ':', @ts + 1, @ts + 2)
+           p = p - tok.length + 2
+           fnext expr_dot; fbreak; };
+
+      '.:' | '.' | '&.' | '::'
       => { emit_table(PUNCTUATION)
            fnext expr_dot; fbreak; };
 

--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -17,7 +17,7 @@ token kCLASS kMODULE kDEF kUNDEF kBEGIN kRESCUE kENSURE kEND kIF kUNLESS
       tWORDS_BEG tQWORDS_BEG tSYMBOLS_BEG tQSYMBOLS_BEG tSTRING_DBEG
       tSTRING_DVAR tSTRING_END tSTRING_DEND tSTRING tSYMBOL
       tNL tEH tCOLON tCOMMA tSPACE tSEMI tLAMBDA tLAMBEG tCHARACTER
-      tRATIONAL tIMAGINARY tLABEL_END tANDDOT
+      tRATIONAL tIMAGINARY tLABEL_END tANDDOT tMETHREF
 
 prechigh
   right    tBANG tTILDE tUPLUS
@@ -1225,6 +1225,10 @@ rule
                 | kRETRY
                     {
                       result = @builder.keyword_cmd(:retry, val[0])
+                    }
+                | primary_value tMETHREF operation2
+                    {
+                      result = @builder.method_ref(val[0], val[1], val[2])
                     }
 
    primary_value: primary

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -3540,4 +3540,45 @@ class TestLexer < Minitest::Test
                    :tIDENTIFIER, 're', [1, 3])
   end
 
+  def test_meth_ref
+    assert_scanned('foo.:bar',
+                  :tIDENTIFIER, 'foo', [0, 3],
+                  :tMETHREF,   '.:',   [3, 5],
+                  :tIDENTIFIER, 'bar', [5, 8])
+
+    assert_scanned('foo .:bar',
+                   :tIDENTIFIER, 'foo', [0, 3],
+                   :tMETHREF,   '.:',   [4, 6],
+                   :tIDENTIFIER, 'bar', [6, 9])
+  end
+
+  def test_meth_ref_unary_op
+    assert_scanned('foo.:+',
+                  :tIDENTIFIER, 'foo', [0, 3],
+                  :tMETHREF,    '.:',  [3, 5],
+                  :tPLUS,       '+',   [5, 6])
+
+    assert_scanned('foo.:-@',
+                  :tIDENTIFIER, 'foo', [0, 3],
+                  :tMETHREF,    '.:',  [3, 5],
+                  :tUMINUS,     '-@',  [5, 7])
+  end
+
+  def test_meth_ref_unsupported_newlines
+    # MRI emits exactly the same sequence of tokens,
+    # the error happens later in the parser
+
+    assert_scanned('foo. :+',
+                  :tIDENTIFIER, 'foo', [0, 3],
+                  :tDOT,        '.',   [3, 4],
+                  :tCOLON,      ':',   [5, 6],
+                  :tUPLUS,       '+',  [6, 7])
+
+    assert_scanned('foo.: +',
+                  :tIDENTIFIER, 'foo', [0, 3],
+                  :tDOT,        '.',   [3, 4],
+                  :tCOLON,      ':',   [4, 5],
+                  :tPLUS,       '+',   [6, 7])
+  end
+
 end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7085,4 +7085,36 @@ class TestParser < Minitest::Test
         SINCE_2_0)
     end
   end
+
+  def test_meth_ref
+    assert_parses(
+      s(:meth_ref, s(:lvar, :foo), :bar),
+      %q{foo.:bar},
+      %q{   ^^ dot
+        |     ~~~ selector
+        |~~~~~~~~ expression},
+      SINCE_2_7)
+
+    assert_parses(
+      s(:meth_ref, s(:lvar, :foo), :+@),
+      %q{foo.:+@},
+      %q{   ^^ dot
+        |     ~~ selector
+        |~~~~~~~ expression},
+      SINCE_2_7)
+  end
+
+  def test_meth_ref_unsupported_newlines
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tCOLON' }],
+      %Q{foo. :+},
+      %q{     ^ location},
+      SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tCOLON' }],
+      %Q{foo.: +},
+      %q{    ^ location},
+      SINCE_2_7)
+  end
 end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/541

This commit tracks upstream commit ruby/ruby@67c5747.

Special rule `'.:' w_space+` is required to reject code like `foo.: +`