### PR TITLE
+ ruby27.y: dsym should be treated as string.

### DIFF
--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -1895,7 +1895,7 @@ regexp_contents: # nothing
                       result = @builder.symbol(val[0])
                     }
 
-            dsym: tSYMBEG xstring_contents tSTRING_END
+            dsym: tSYMBEG string_contents tSTRING_END
                     {
                       @lexer.state = :expr_end
                       result = @builder.symbol_compose(val[0], val[1], val[2])


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@7006fde.

`xstring_contents` and `string_contents` rules are equivalent, so it doesn't change anything for parser.