### PR TITLE
Bump ruby versions to 2.5.5 and 2.6.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ matrix:
     - name: 2.4.5 / Parser tests
       rvm: 2.4.5
       script: bundle exec rake test_cov
-    - name: 2.5.3 / Parser tests
-      rvm: 2.5.3
+    - name: 2.5.5 / Parser tests
+      rvm: 2.5.5
       script: bundle exec rake test_cov
-    - name: 2.6.1 / Parser tests
-      rvm: 2.6.1
+    - name: 2.6.2 / Parser tests
+      rvm: 2.6.2
       script: bundle exec rake test_cov
     - name: ruby-head / Parser tests
       rvm: ruby-head
@@ -29,11 +29,11 @@ matrix:
     - name: rbx-2 / Parser tests
       rvm: rbx-2
       script: bundle exec rake test_cov
-    - name: 2.5.3 / Rubocop tests
-      rvm: 2.5.3
+    - name: 2.5.5 / Rubocop tests
+      rvm: 2.5.5
       script: ./ci/run_rubocop_specs
-    - name: 2.6.1 / Rubocop tests
-      rvm: 2.6.1
+    - name: 2.6.2 / Rubocop tests
+      rvm: 2.6.2
       script: ./ci/run_rubocop_specs
   allow_failures:
     - rvm: ruby-head

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -57,7 +57,7 @@ module Parser
     CurrentRuby = Ruby24
 
   when /^2\.5\./
-    current_version = '2.5.3'
+    current_version = '2.5.5'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby25', current_version
     end
@@ -66,7 +66,7 @@ module Parser
     CurrentRuby = Ruby25
 
   when /^2\.6\./
-    current_version = '2.6.1'
+    current_version = '2.6.2'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby26', current_version
     end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/561 and https://github.com/whitequark/parser/issues/562