### PR TITLE
Move Context to lexer.

### DIFF
--- a/lib/parser/base.rb
+++ b/lib/parser/base.rb
@@ -123,13 +123,16 @@ module Parser
 
       @static_env  = StaticEnvironment.new
 
+      # Stack that holds current parsing context
+      @context = Context.new
+
       @lexer = Lexer.new(version)
       @lexer.diagnostics = @diagnostics
       @lexer.static_env  = @static_env
+      @lexer.context     = @context
 
       @builder = builder
       @builder.parser = self
-      @context = Context.new
 
       # Last emitted token
       @last_token = nil

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -95,13 +95,14 @@ class Parser::Lexer
   attr_accessor :static_env
   attr_accessor :force_utf32
 
-  attr_accessor :cond, :cmdarg, :in_kwarg
+  attr_accessor :cond, :cmdarg, :in_kwarg, :context
 
   attr_accessor :tokens, :comments
 
   def initialize(version)
     @version    = version
     @static_env = nil
+    @context    = nil
 
     @tokens     = nil
     @comments   = nil


### PR DESCRIPTION
Lexer needs to know current context (however `parser` is still responsible for controlling it).

@whitequark WDYT about using a shared context in `parser` and `lexer`? (parser can create it and assign to lexer via a simple setter, like we do with shared `diagnostics` and `static_env`). To make it available in the parser via `@context` (like it was before) and reduce commit size.

EDIT: applied it, please let me know if it should be reverted.