### PR TITLE
Add missing node types to Meta::NODE_TYPES

### DIFF
--- a/lib/parser/meta.rb
+++ b/lib/parser/meta.rb
@@ -23,6 +23,9 @@ module Parser
         until_post for break next redo return resbody
         kwbegin begin retry preexe postexe iflipflop eflipflop
         shadowarg complex rational __FILE__ __LINE__ __ENCODING__
+        ident root lambda indexasgn index procarg0
+        meth_ref restarg_expr blockarg_expr
+        objc_kwarg objc_restarg objc_varargs
       ).map(&:to_sym).to_set.freeze
 
   end # Meta

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -50,3 +50,10 @@ require 'minitest/autorun'
 
 $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 require 'parser'
+
+class Parser::AST::Node
+  def initialize(type, *)
+    raise "Type #{type} missing from Parser::Meta::NODE_TYPES" unless Parser::Meta::NODE_TYPES.include?(type)
+    super
+  end
+end


### PR DESCRIPTION
I noticed that `:procarg0` was missing from `Meta::NODE_TYPES`.

I added a crude way to check that `Meta::NODE_TYPES` was complete and found 18 more were missing, although most seem to be for RubyMotion / Ruby 1.8...