### PR TITLE
Bump 2.4 branch to 2.4.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ matrix:
     - name: 2.3.8 / Parser tests
       rvm: 2.3.8
       script: bundle exec rake test_cov
-    - name: 2.4.5 / Parser tests
-      rvm: 2.4.5
+    - name: 2.4.6 / Parser tests
+      rvm: 2.4.6
       script: bundle exec rake test_cov
     - name: 2.5.5 / Parser tests
       rvm: 2.5.5

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -48,7 +48,7 @@ module Parser
     CurrentRuby = Ruby23
 
   when /^2\.4\./
-    current_version = '2.4.5'
+    current_version = '2.4.6'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby24', current_version
     end
@@ -85,8 +85,8 @@ module Parser
 
   else # :nocov:
     # Keep this in sync with released Ruby.
-    warn_syntax_deviation 'parser/ruby25', '2.5.x'
-    require 'parser/ruby25'
-    CurrentRuby = Ruby25
+    warn_syntax_deviation 'parser/ruby26', '2.6.x'
+    require 'parser/ruby26'
+    CurrentRuby = Ruby26
   end
 end


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/04/01/ruby-2-4-6-released/