### PR TITLE
Bump 2.6 branch to 2.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ matrix:
     - name: 2.5.5 / Parser tests
       rvm: 2.5.5
       script: bundle exec rake test_cov
-    - name: 2.6.2 / Parser tests
-      rvm: 2.6.2
+    - name: 2.6.3 / Parser tests
+      rvm: 2.6.3
       script: bundle exec rake test_cov
     - name: ruby-head / Parser tests
       rvm: ruby-head
@@ -32,8 +32,8 @@ matrix:
     - name: 2.5.5 / Rubocop tests
       rvm: 2.5.5
       script: ./ci/run_rubocop_specs
-    - name: 2.6.2 / Rubocop tests
-      rvm: 2.6.2
+    - name: 2.6.3 / Rubocop tests
+      rvm: 2.6.3
       script: ./ci/run_rubocop_specs
   allow_failures:
     - rvm: ruby-head

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -66,7 +66,7 @@ module Parser
     CurrentRuby = Ruby25
 
   when /^2\.6\./
-    current_version = '2.6.2'
+    current_version = '2.6.3'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby26', current_version
     end

--- a/lib/parser/ruby26.y
+++ b/lib/parser/ruby26.y
@@ -1893,7 +1893,7 @@ regexp_contents: # nothing
                       result = @builder.symbol(val[0])
                     }
 
-            dsym: tSYMBEG xstring_contents tSTRING_END
+            dsym: tSYMBEG string_contents tSTRING_END
                     {
                       @lexer.state = :expr_end
                       result = @builder.symbol_compose(val[0], val[1], val[2])


### PR DESCRIPTION
Backport #560 to Ruby 2.6 branch.

This PR tracks upstream commit ruby/ruby@8bf06cb.
`xstring_contents` and `string_contents` rules are equivalent, so it doesn't change anything for parser.

Ruby 2.6.3 has been released.
https://www.ruby-lang.org/en/news/2019/04/17/ruby-2-6-3-released/

This seems to be the only syntax change from Ruby 2.6.2 to Ruby 2.6.3.
https://github.com/ruby/ruby/compare/v2_6_2...v2_6_3
