### PR TITLE
2.7 Pattern matching

### DIFF
--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -1821,3 +1821,322 @@ Format:
 "__ENCODING__"
  ~~~~~~~~~~~~ expression
 ~~~
+
+## Pattern matching
+
+### Using `in` modifier
+
+Format:
+
+~~~
+(in-match
+  (int 1)
+  (match-var :a))
+"1 in a"
+   ~~ operator
+ ~~~~~~ expression
+~~~
+
+### Case with pattern matching
+
+#### Without else
+
+Format:
+
+~~~
+(case-match
+  (str "str")
+  (in-pattern
+    (match-var :foo)
+    (lvar :bar)) nil)
+"case "str"; in foo; bar; end"
+ ~~~~ keyword             ~~~ end
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ expression
+~~~
+
+#### With else
+
+Format:
+
+~~~
+(case-match,
+  (str "str")
+  (in-pattern
+    (match-var :foo)
+    (lvar :bar))
+  (lvar :baz))
+"case "str"; in foo; bar; else; baz; end"
+ ~~~~ keyword             ~~~~ else  ~~~ end
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ expression
+~~~
+
+### In clause
+
+Format:
+
+~~~
+(in-pattern
+  (match-var :foo)
+  (lvar :bar))
+"in foo then bar"
+ ~~ keyword
+        ~~~~ begin
+ ~~~~~~~~~~~~~~~ expression
+~~~
+
+### If guard
+
+This guard runs after matching, so it's not an `if` modifier.
+
+Format:
+
+~~~
+(in-pattern
+  (match-var :foo)
+  (if-guard
+    (lvar :bar)) nil)
+"in foo if bar"
+        ~~ keyword
+        ~~~~~~ expression
+~~~
+
+### Unless guard
+
+This guard runs after matching, so it's not an `unless` modifier.
+
+Format:
+
+~~~
+(in-pattern
+  (match-var :foo)
+  (unless-guard
+    (lvar :bar)) nil)
+"in foo unless bar"
+        ~~~~~~ keyword
+        ~~~~~~~~~~ expression
+~~~
+
+### Match variable
+
+Format:
+
+~~~
+(match-var :foo)
+"in foo"
+    ~~~ name
+    ~~~ expression
+~~~
+
+### Match rest
+
+#### With name
+
+Format:
+
+~~~
+(match-rest
+  (match-var :foo))
+"in *foo"
+    ~ operator
+    ~~~~ expression
+~~~
+
+#### Without name
+
+Format:
+
+~~~
+(match-rest)
+"in *"
+    ~ operator
+    ~ expression
+~~~
+
+### Pin operator
+
+Format:
+
+~~~
+(pin
+  (lvar :foo))
+"in ^foo"
+    ~ selector
+    ~~~~ expression
+~~~
+
+### Match alternative
+
+Format:
+
+~~~
+(match-alt
+  (pin
+    (lvar :foo))
+  (int 1))
+"in ^foo | 1"
+         ~ operator
+    ~~~~~~~~ expression
+~~~
+
+### Match with alias
+
+Format:
+
+~~~
+(match-as
+  (int 1)
+  (match-var :foo))
+"in 1 => foo"
+      ~~ operator
+    ~~~~~~~~ expression
+~~~
+
+### Match using array pattern
+
+#### Explicit
+
+Format:
+
+~~~
+(array-pattern
+  (pin
+    (lvar :foo))
+  (match-var :bar))
+"in [^foo, bar]"
+    ~ begin   ~ end
+    ~~~~~~~~~~~ expression
+~~~
+
+#### Explicit with tail
+
+Adding a trailing comma in the end works as `, *`
+
+Format:
+
+~~~
+(array-pattern-with-tail
+  (pin
+    (lvar :foo))
+  (match-var :bar))
+"in [^foo, bar,]"
+    ~ begin    ~ end
+    ~~~~~~~~~~~~ expression
+~~~
+
+#### Implicit
+
+Format:
+
+~~~
+(array-pattern
+  (pin
+    (lvar :foo))
+  (match-var :bar))
+"in ^foo, bar"
+    ~~~~~~~~~ expression
+~~~
+
+#### Implicit with tail
+
+Format:
+
+Adding a trailing comma in the end works as `, *`,
+so a single item match with comma gets interpreted as an array.
+
+~~~
+(array-pattern-with-tail
+  (match-var :foo))
+"in foo,"
+    ~~~ expression
+~~~
+
+### Matching using hash pattern
+
+#### Explicit
+
+Format:
+
+~~~
+(hash-pattern
+  (pair
+    (sym :a)
+    (int 10)))
+"in { a: 10 }"
+    ~ begin ~ end
+    ~~~~~~~~~ expression
+~~~
+
+#### Implicit
+
+Format:
+
+~~~
+(hash-pattern
+  (pair
+    (sym :a)
+    (int 10)))
+"in a: 10"
+    ~~~~~ expression
+~~~
+
+#### Assignment using hash pattern
+
+Format:
+
+~~~
+(hash-pattern
+  (match-var :a))
+"in a:"
+    ~ name (match-var)
+    ~~ expression (match-var)
+~~~
+
+#### Nil hash pattern
+
+Format:
+~~~
+(hash-pattern
+  (match-nil-pattern))
+"in **nil"
+    ~~~~~ expression (match-nil-pattern)
+      ~~~ name (match-nil-pattern)
+~~~
+
+### Matching using const pattern
+
+#### With array pattern
+
+Format:
+
+~~~
+(const-pattern
+  (const nil :X)
+  (array-pattern
+    (pin
+      (lvar :foo))
+    (match-var :bar)))
+"in X[^foo bar]"
+     ~ begin (const-pattern)
+               ~ end (const-pattern)
+     ~~~~~~~~~~~ expression (const-pattern)
+    ~ name (const-pattern.const)
+    ~ expression (const-pattern.const)
+~~~
+
+#### With hash pattern
+
+Format:
+
+~~~
+(const-pattern
+  (const nil :X)
+  (hash-pattern
+    (match-var :foo)
+    (match-var :bar)))
+"in X[foo:, bar:]"
+     ~ begin (const-pattern)
+                ~ end (const-pattern)
+     ~~~~~~~~~~~~ expression (const-pattern)
+    ~ name (const-pattern.const)
+    ~ expression (const-pattern.const)
+~~~

--- a/lib/parser.rb
+++ b/lib/parser.rb
@@ -75,6 +75,7 @@ module Parser
   require 'parser/context'
   require 'parser/max_numparam_stack'
   require 'parser/current_arg_stack'
+  require 'parser/variables_stack'
 
   require 'parser/base'
 

--- a/lib/parser/ast/processor.rb
+++ b/lib/parser/ast/processor.rb
@@ -236,6 +236,21 @@ module Parser
       alias on_preexe   process_regular_node
       alias on_postexe  process_regular_node
 
+      alias on_case_match              process_regular_node
+      alias on_in_match                process_regular_node
+      alias on_in_pattern              process_regular_node
+      alias on_if_guard                process_regular_node
+      alias on_unless_guard            process_regular_node
+      alias on_match_var               process_variable_node
+      alias on_match_rest              process_regular_node
+      alias on_pin                     process_regular_node
+      alias on_match_alt               process_regular_node
+      alias on_match_as                process_regular_node
+      alias on_array_pattern           process_regular_node
+      alias on_array_pattern_with_tail process_regular_node
+      alias on_hash_pattern            process_regular_node
+      alias on_const_pattern           process_regular_node
+
       # @private
       def process_variable_node(node)
         warn 'Parser::AST::Processor#process_variable_node is deprecated as a' \

--- a/lib/parser/base.rb
+++ b/lib/parser/base.rb
@@ -116,6 +116,8 @@ module Parser
     attr_reader :context
     attr_reader :max_numparam_stack
     attr_reader :current_arg_stack
+    attr_reader :pattern_variables
+    attr_reader :pattern_hash_keys
 
     ##
     # @param [Parser::Builders::Default] builder The AST builder to use.
@@ -133,6 +135,12 @@ module Parser
 
       # Current argument names stack
       @current_arg_stack = CurrentArgStack.new
+
+      # Stack of set of variables used in the current pattern
+      @pattern_variables = VariablesStack.new
+
+      # Stack of set of keys used in the current hash in pattern matchinig
+      @pattern_hash_keys = VariablesStack.new
 
       @lexer = Lexer.new(version)
       @lexer.diagnostics = @diagnostics
@@ -162,6 +170,8 @@ module Parser
       @static_env.reset
       @context.reset
       @current_arg_stack.reset
+      @pattern_variables.reset
+      @pattern_hash_keys.reset
 
       self
     end

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1208,6 +1208,188 @@ module Parser
       end
     end
 
+    #
+    # PATTERN MATCHING
+    #
+
+    def case_match(case_t, expr, in_bodies, else_t, else_body, end_t)
+      n(:case_match, [ expr, *(in_bodies << else_body)],
+        condition_map(case_t, expr, nil, nil, else_t, else_body, end_t))
+    end
+
+    def in_match(lhs, in_t, rhs)
+      n(:in_match, [lhs, rhs],
+        binary_op_map(lhs, in_t, rhs))
+    end
+
+    def in_pattern(in_t, pattern, guard, then_t, body)
+      children = [pattern, guard, body]
+      n(:in_pattern, children,
+        keyword_map(in_t, then_t, children.compact, nil))
+    end
+
+    def if_guard(if_t, if_body)
+      n(:if_guard, [if_body], guard_map(if_t, if_body))
+    end
+
+    def unless_guard(unless_t, unless_body)
+      n(:unless_guard, [unless_body], guard_map(unless_t, unless_body))
+    end
+
+    def match_var(name_t)
+      name = value(name_t).to_sym
+
+      check_duplicate_pattern_variable(name, loc(name_t))
+      @parser.static_env.declare(name)
+
+      n(:match_var, [ name ],
+        variable_map(name_t))
+    end
+
+    def match_hash_var(name_t)
+      name = value(name_t).to_sym
+
+      expr_l = loc(name_t)
+      name_l = expr_l.adjust(end_pos: -1)
+
+      check_duplicate_pattern_variable(name, name_l)
+      @parser.static_env.declare(name)
+
+      n(:match_var, [ name ],
+        Source::Map::Variable.new(name_l, expr_l))
+    end
+
+    def match_hash_var_from_str(begin_t, strings, end_t)
+      if strings.length > 1
+        diagnostic :error, :pm_interp_in_var_name, nil, loc(begin_t).join(loc(end_t))
+      end
+
+      string = strings[0]
+
+      case string.type
+      when :str
+        # MRI supports plain strings in hash pattern matching
+        name, = *string
+        name_l = string.loc.expression
+
+        check_lvar_name(name, name_l)
+        check_duplicate_pattern_variable(name, name_l)
+
+        @parser.static_env.declare(name)
+
+        if (begin_l = string.loc.begin)
+          # exclude beginning of the string from the location of the variable
+          name_l = name_l.adjust(begin_pos: begin_l.length)
+        end
+
+        if (end_l = string.loc.end)
+          # exclude end of the string from the location of the variable
+          name_l = name_l.adjust(end_pos: -end_l.length)
+        end
+
+        expr_l = loc(begin_t).join(string.loc.expression).join(loc(end_t))
+        n(:match_var, [ name.to_sym ],
+          Source::Map::Variable.new(name_l, expr_l))
+      when :begin
+        match_hash_var_from_str(begin_t, string.children, end_t)
+      end
+    end
+
+    def match_rest(star_t, name_t = nil)
+      if name_t.nil?
+        n0(:match_rest,
+          unary_op_map(star_t))
+      else
+        name = match_var(name_t)
+        n(:match_rest, [ name ],
+          unary_op_map(star_t, name))
+      end
+    end
+
+    def hash_pattern(lbrace_t, kwargs, rbrace_t)
+      args = check_duplicate_args(kwargs)
+      n(:hash_pattern, args,
+        collection_map(lbrace_t, args, rbrace_t))
+    end
+
+    def array_pattern(lbrack_t, elements, rbrack_t)
+      trailing_comma = false
+
+      elements = elements.map do |element|
+        if element.type == :match_with_trailing_comma
+          trailing_comma = true
+          element.children.first
+        else
+          trailing_comma = false
+          element
+        end
+      end
+
+      node_type = trailing_comma ? :array_pattern_with_tail : :array_pattern
+      n(node_type, elements,
+        collection_map(lbrack_t, elements, rbrack_t))
+    end
+
+    def match_with_trailing_comma(match)
+      n(:match_with_trailing_comma, [ match ], nil)
+    end
+
+    def const_pattern(const, ldelim_t, pattern, rdelim_t)
+      n(:const_pattern, [const, pattern],
+        collection_map(ldelim_t, [pattern], rdelim_t))
+    end
+
+    def pin(pin_t, var)
+      n(:pin, [ var ],
+        send_unary_op_map(pin_t, var))
+    end
+
+    def match_alt(left, pipe_t, right)
+      source_map = binary_op_map(left, pipe_t, right)
+
+      n(:match_alt, [ left, right ],
+        source_map)
+    end
+
+    def match_as(value, assoc_t, as)
+      source_map = binary_op_map(value, assoc_t, as)
+
+      n(:match_as, [ value, as ],
+        source_map)
+    end
+
+    def match_nil_pattern(dstar_t, nil_t)
+      n0(:match_nil_pattern,
+        arg_prefix_map(dstar_t, nil_t))
+    end
+
+    def match_pair(label_type, label, value)
+      if label_type == :label
+        check_duplicate_pattern_key(label[0], label[1])
+        pair_keyword(label, value)
+      else
+        begin_t, parts, end_t = label
+
+        # quoted label like "label": value
+        if (var_name = static_string(parts))
+          loc = loc(begin_t).join(loc(end_t))
+          check_duplicate_pattern_key(var_name, loc)
+        end
+
+        pair_quoted(begin_t, parts, end_t, value)
+      end
+    end
+
+    def match_label(label_type, label)
+      if label_type == :label
+        match_hash_var(label)
+      else
+        # quoted label like "label": value
+        begin_t, strings, end_t = label
+        match_hash_var_from_str(begin_t, strings, end_t)
+      end
+    end
+
     private
 
     #
@@ -1323,6 +1505,32 @@ module Parser
         this_name && this_name[0] != '_' &&
           this_name == that_name
       end
+    end
+
+    def check_lvar_name(name, loc)
+      if name =~ /\A[[[:lower:]]|_][[[:alnum:]]_]*\z/
+        # OK
+      else
+        diagnostic :error, :lvar_name, { name: name }, loc
+      end
+    end
+
+    def check_duplicate_pattern_variable(name, loc)
+      return if name.to_s.start_with?('_')
+
+      if @parser.pattern_variables.declared?(name)
+        diagnostic :error, :duplicate_variable_name, { name: name.to_s }, loc
+      end
+
+      @parser.pattern_variables.declare(name)
+    end
+
+    def check_duplicate_pattern_key(name, loc)
+      if @parser.pattern_hash_keys.declared?(name)
+        diagnostic :error, :duplicate_pattern_key, { name: name.to_s }, loc
+      end
+
+      @parser.pattern_hash_keys.declare(name)
     end
 
     #
@@ -1671,6 +1879,13 @@ module Parser
 
       Source::Map::Condition.new(loc(keyword_t), nil, loc(else_t), nil,
                                  begin_l.join(end_l))
+    end
+
+    def guard_map(keyword_t, guard_body_e)
+      keyword_l = loc(keyword_t)
+      guard_body_l = guard_body_e.loc.expression
+
+      Source::Map::Keyword.new(keyword_l, nil, nil, keyword_l.join(guard_body_l))
     end
 
     #

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -95,7 +95,7 @@ class Parser::Lexer
   attr_accessor :static_env
   attr_accessor :force_utf32
 
-  attr_accessor :cond, :cmdarg, :in_kwarg, :context
+  attr_accessor :cond, :cmdarg, :in_kwarg, :context, :command_start
 
   attr_accessor :tokens, :comments
 

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -68,6 +68,10 @@ module Parser
     :ordinary_param_defined       => 'ordinary parameter is defined',
     :numparam_used_in_outer_scope => 'numbered parameter is already used in an outer scope',
     :circular_argument_reference  => 'circular argument reference %{var_name}',
+    :pm_interp_in_var_name        => 'symbol literal with interpolation is not allowed',
+    :lvar_name                    => "`%{name}' is not allowed as a local variable name",
+    :duplicate_variable_name      => 'duplicate variable name %{name}',
+    :duplicate_pattern_key        => 'duplicate hash pattern key %{name}',
 
     # Parser warnings
     :useless_else            => 'else without rescue is useless',

--- a/lib/parser/meta.rb
+++ b/lib/parser/meta.rb
@@ -27,6 +27,10 @@ module Parser
         restarg_expr blockarg_expr
         objc_kwarg objc_restarg objc_varargs
         numargs numblock forward_args forwarded_args
+        case_match in_match in_pattern
+        match_var pin match_alt match_as match_rest
+        array_pattern match_with_trailing_comma array_pattern_with_tail
+        hash_pattern const_pattern if_guard unless_guard match_nil_pattern
       ).map(&:to_sym).to_set.freeze
 
   end # Meta

--- a/lib/parser/variables_stack.rb
+++ b/lib/parser/variables_stack.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Parser
+
+  class VariablesStack
+    def initialize
+      @stack = []
+      push
+    end
+
+    def push
+      @stack << Set.new
+    end
+
+    def pop
+      @stack.pop
+    end
+
+    def reset
+      @stack.clear
+    end
+
+    def declare(name)
+      @stack.last << name.to_sym
+    end
+
+    def declared?(name)
+      @stack.last.include?(name.to_sym)
+    end
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -19,6 +19,7 @@ if ENV.include?('COVERAGE') && SimpleCov.usable?
       ruby24.y
       ruby25.y
       ruby26.y
+      ruby27.y
     ),
     File.expand_path('../../lib/parser', __FILE__))
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -8305,4 +8305,985 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_2_7)
   end
+
+  def assert_parses_pattern_match(ast, code, source_maps = '', versions = SINCE_2_7)
+    case_pre = "case foo; "
+    source_maps_offset = case_pre.length
+    source_maps_prefix = ' ' * source_maps_offset
+    source_maps = source_maps
+      .lines
+      .map { |line| source_maps_prefix + line.sub(/^\s*\|/, '') }
+      .join("\n")
+
+    assert_parses(
+      s(:case_match,
+        s(:lvar, :foo),
+        ast,
+        nil),
+      "#{case_pre}#{code}; end",
+      source_maps,
+      SINCE_2_7
+    )
+  end
+
+  def test_pattern_matching_single_match
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:match_var, :x),
+        nil,
+        s(:lvar, :x)),
+      %q{in x then x},
+      %q{~~ keyword (in_pattern)
+        |~~~~~~~~~~~ expression (in_pattern)
+        |     ~~~~ begin (in_pattern)
+        |   ~ expression (in_pattern.match_var)
+        |   ~ name (in_pattern.match_var)}
+    )
+  end
+
+  def test_pattern_matching_no_body
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:int, 1), nil, nil),
+      %q{in 1}
+    )
+  end
+
+  def test_pattern_matching_if_unless_modifiers
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:match_var, :x),
+        s(:if_guard, s(:true)),
+        s(:nil)
+      ),
+      %q{in x if true; nil},
+      %q{~~ keyword (in_pattern)
+        |~~~~~~~~~~~~~~~~~ expression (in_pattern)
+        |            ~ begin (in_pattern)
+        |     ~~ keyword (in_pattern.if_guard)
+        |     ~~~~~~~ expression (in_pattern.if_guard)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:match_var, :x),
+        s(:unless_guard, s(:true)),
+        s(:nil)
+      ),
+      %q{in x unless true; nil},
+      %q{~~ keyword (in_pattern)
+        |~~~~~~~~~~~~~~~~~~~~~ expression (in_pattern)
+        |                ~ begin (in_pattern)
+        |     ~~~~~~ keyword (in_pattern.unless_guard)
+        |     ~~~~~~~~~~~ expression (in_pattern.unless_guard)}
+    )
+  end
+
+  def test_pattern_matching_pin_variable
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:pin, s(:lvar, :foo)),
+        nil,
+        s(:nil)),
+      %q{in ^foo then nil},
+      %q{   ~ selector (in_pattern.pin)
+        |   ~~~~ expression (in_pattern.pin)
+        |    ~~~ name (in_pattern.pin.lvar)}
+    )
+  end
+
+  def test_pattern_matching_implicit_array_match
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern_with_tail,
+          s(:match_var, :x)),
+        nil,
+        s(:nil)),
+      %q{in x, then nil},
+      %q{   ~ expression (in_pattern.array_pattern_with_tail)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern,
+          s(:match_rest,
+            s(:match_var, :x))),
+        nil,
+        s(:nil)),
+      %q{in *x then nil},
+      %q{   ~~ expression (in_pattern.array_pattern)
+        |   ~ operator (in_pattern.array_pattern.match_rest)
+        |    ~ name (in_pattern.array_pattern.match_rest.match_var)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern,
+          s(:match_rest)),
+        nil,
+        s(:nil)),
+      %q{in * then nil},
+      %q{   ~ expression (in_pattern.array_pattern)
+        |   ~ operator (in_pattern.array_pattern.match_rest)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern,
+          s(:match_var, :x),
+          s(:match_var, :y)),
+        nil,
+        s(:nil)),
+      %q{in x, y then nil},
+      %q{   ~~~~ expression (in_pattern.array_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern_with_tail,
+          s(:match_var, :x),
+          s(:match_var, :y)),
+        nil,
+        s(:nil)),
+      %q{in x, y, then nil},
+      %q{   ~~~~ expression (in_pattern.array_pattern_with_tail)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern,
+          s(:match_var, :x),
+          s(:match_rest, s(:match_var, :y)),
+          s(:match_var, :z)),
+        nil,
+        s(:nil)),
+      %q{in x, *y, z then nil},
+      %q{   ~~~~~~~~ expression (in_pattern.array_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern,
+          s(:match_rest, s(:match_var, :x)),
+          s(:match_var, :y),
+          s(:match_var, :z)),
+        nil,
+        s(:nil)),
+      %q{in *x, y, z then nil},
+      %q{   ~~~~~~~~ expression (in_pattern.array_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern,
+          s(:int, 1),
+          s(:str, 'a'),
+          s(:array_pattern),
+          s(:hash_pattern)),
+        nil,
+        s(:nil)),
+      %q{in 1, "a", [], {} then nil},
+      %q{   ~~~~~~~~~~~~~~ expression (in_pattern.array_pattern)}
+    )
+  end
+
+  def test_pattern_matching_explicit_array_match
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern,
+          s(:match_var, :x)),
+        nil,
+        s(:nil)),
+      %q{in [x] then nil},
+      %q{   ~~~ expression (in_pattern.array_pattern)
+        |   ~ begin (in_pattern.array_pattern)
+        |     ~ end (in_pattern.array_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern_with_tail,
+          s(:match_var, :x)),
+        nil,
+        s(:nil)),
+      %q{in [x,] then nil},
+      %q{   ~~~~ expression (in_pattern.array_pattern_with_tail)
+        |   ~ begin (in_pattern.array_pattern_with_tail)
+        |      ~ end (in_pattern.array_pattern_with_tail)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern,
+          s(:match_var, :x),
+          s(:match_var, :y)),
+        nil,
+        s(:true)),
+      %q{in [x, y] then true},
+      %q{   ~~~~~~ expression (in_pattern.array_pattern)
+        |   ~ begin (in_pattern.array_pattern)
+        |        ~ end (in_pattern.array_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern_with_tail,
+          s(:match_var, :x),
+          s(:match_var, :y)),
+        nil,
+        s(:true)),
+      %q{in [x, y,] then true},
+      %q{   ~~~~~~~ expression (in_pattern.array_pattern_with_tail)
+        |   ~ begin (in_pattern.array_pattern_with_tail)
+        |         ~ end (in_pattern.array_pattern_with_tail)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern,
+          s(:match_var, :x),
+          s(:match_var, :y),
+          s(:match_rest)),
+        nil,
+        s(:true)),
+      %q{in [x, y, *] then true},
+      %q{   ~~~~~~~~~ expression (in_pattern.array_pattern)
+        |   ~ begin (in_pattern.array_pattern)
+        |           ~ end (in_pattern.array_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern,
+          s(:match_var, :x),
+          s(:match_var, :y),
+          s(:match_rest, s(:match_var, :z))),
+        nil,
+        s(:true)),
+      %q{in [x, y, *z] then true},
+      %q{   ~~~~~~~~~~ expression (in_pattern.array_pattern)
+        |   ~ begin (in_pattern.array_pattern)
+        |            ~ end (in_pattern.array_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern,
+          s(:match_var, :x),
+          s(:match_rest, s(:match_var, :y)),
+          s(:match_var, :z)),
+        nil,
+        s(:true)),
+      %q{in [x, *y, z] then true},
+      %q{   ~~~~~~~~~~ expression (in_pattern.array_pattern)
+        |   ~ begin (in_pattern.array_pattern)
+        |            ~ end (in_pattern.array_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern,
+          s(:match_var, :x),
+          s(:match_rest),
+          s(:match_var, :y)),
+        nil,
+        s(:true)),
+      %q{in [x, *, y] then true},
+      %q{   ~~~~~~~~~ expression (in_pattern.array_pattern)
+        |   ~ begin (in_pattern.array_pattern)
+        |           ~ end (in_pattern.array_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern,
+          s(:match_rest, s(:match_var, :x)),
+          s(:match_var, :y)),
+        nil,
+        s(:true)),
+      %q{in [*x, y] then true},
+      %q{   ~~~~~~~ expression (in_pattern.array_pattern)
+        |   ~ begin (in_pattern.array_pattern)
+        |         ~ end (in_pattern.array_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:array_pattern,
+          s(:match_rest),
+          s(:match_var, :x)),
+        nil,
+        s(:true)),
+      %q{in [*, x] then true},
+      %q{   ~~~~~~ expression (in_pattern.array_pattern)
+        |   ~ begin (in_pattern.array_pattern)
+        |        ~ end (in_pattern.array_pattern)}
+    )
+  end
+
+  def test_pattern_matching_hash
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern),
+        nil,
+        s(:true)),
+      %q{in {} then true},
+      %q{   ~~ expression (in_pattern.hash_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:pair, s(:sym, :a), s(:int, 1))),
+        nil,
+        s(:true)),
+      %q{in a: 1 then true},
+      %q{   ~~~~ expression (in_pattern.hash_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:pair, s(:sym, :a), s(:int, 1))),
+        nil,
+        s(:true)),
+      %q{in { a: 1 } then true},
+      %q{   ~~~~~~~~ expression (in_pattern.hash_pattern)
+        |   ~ begin (in_pattern.hash_pattern)
+        |          ~ end (in_pattern.hash_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:match_var, :a)),
+        nil,
+        s(:true)),
+      %q{in a: then true},
+      %q{   ~~ expression (in_pattern.hash_pattern)
+        |   ~ name (in_pattern.hash_pattern.match_var)
+        |   ~~ expression (in_pattern.hash_pattern.match_var)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:match_rest, s(:match_var, :a))),
+        nil,
+        s(:true)),
+      %q{in **a then true},
+      %q{   ~~~ expression (in_pattern.hash_pattern)
+        |   ~~~ expression (in_pattern.hash_pattern.match_rest)
+        |   ~~ operator (in_pattern.hash_pattern.match_rest)
+        |     ~ expression (in_pattern.hash_pattern.match_rest.match_var)
+        |     ~ name (in_pattern.hash_pattern.match_rest.match_var)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:match_rest)),
+        nil,
+        s(:true)),
+      %q{in ** then true},
+      %q{   ~~ expression (in_pattern.hash_pattern)
+        |   ~~ expression (in_pattern.hash_pattern.match_rest)
+        |   ~~ operator (in_pattern.hash_pattern.match_rest)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:pair, s(:sym, :a), s(:int, 1)),
+          s(:pair, s(:sym, :b), s(:int, 2))),
+        nil,
+        s(:true)),
+      %q{in a: 1, b: 2 then true},
+      %q{   ~~~~~~~~~~ expression (in_pattern.hash_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:match_var, :a),
+          s(:match_var, :b)),
+        nil,
+        s(:true)),
+      %q{in a:, b: then true},
+      %q{   ~~~~~~ expression (in_pattern.hash_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:pair, s(:sym, :a), s(:int, 1)),
+          s(:match_var, :_a),
+          s(:match_rest)),
+        nil,
+        s(:true)),
+      %q{in a: 1, _a:, ** then true},
+      %q{   ~~~~~~~~~~~~~ expression (in_pattern.hash_pattern)}
+    )
+  end
+
+  def test_pattern_matching_hash_with_string_keys
+    # Match + assign
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:match_var, :a)),
+        nil,
+        s(:true)),
+      %q{in "a": then true},
+      %q{   ~~~~ expression (in_pattern.hash_pattern.match_var)
+        |    ~ name (in_pattern.hash_pattern.match_var)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:match_var, :a)),
+        nil,
+        s(:true)),
+      %q{in "#{ 'a' }": then true},
+      %q{   ~~~~~~~~~~~ expression (in_pattern.hash_pattern.match_var)
+        |        ~ name (in_pattern.hash_pattern.match_var)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:match_var, :a)),
+        nil,
+        s(:true)),
+      %q{in "#{ %q{a} }": then true},
+      %q{   ~~~~~~~~~~~~~ expression (in_pattern.hash_pattern.match_var)
+        |          ~ name (in_pattern.hash_pattern.match_var)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:match_var, :a)),
+        nil,
+        s(:true)),
+      %q{in "#{ %Q{a} }": then true},
+      %q{   ~~~~~~~~~~~~~ expression (in_pattern.hash_pattern.match_var)
+        |          ~ name (in_pattern.hash_pattern.match_var)}
+    )
+
+    # Only match
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:pair, s(:sym, :a), s(:int, 1))),
+        nil,
+        s(:true)),
+      %q{in "a": 1 then true},
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:pair,
+            s(:dsym, s(:begin, s(:str, "a"))),
+            s(:int, 1))),
+        nil,
+        s(:true)),
+      %q{in "#{ 'a' }": 1 then true},
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:pair,
+            s(:dsym, s(:begin, s(:str, "a"))),
+            s(:int, 1))),
+        nil,
+        s(:true)),
+      %q{in "#{ %q{a} }": 1 then true},
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:pair,
+            s(:dsym, s(:begin, s(:str, "a"))),
+            s(:int, 1))),
+        nil,
+        s(:true)),
+      %q{in "#{ %Q{a} }": 1 then true},
+    )
+  end
+
+  def test_pattern_matching_hash_with_heredoc_keys
+    # Ruby <3, the following case is acceptable by the MRI's grammar,
+    # so it has to be reducable by parser.
+    # We have a code for that in the builder.rb that reject it via
+    # diagnostic error because of the wrong lvar name
+    assert_diagnoses(
+      [:error, :lvar_name, { name: "a\n" }],
+      %Q{case nil; in "\#{ <<-HERE }":;\na\nHERE\nelse\nend},
+      %q{                 ~~~~~~~ location},
+      SINCE_2_7
+    )
+  end
+
+  def test_pattern_matching_keyword_variable
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:self),
+        nil,
+        s(:true)),
+      %q{in self then true}
+    )
+  end
+
+  def test_pattern_matching_lambda
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:block,
+          s(:lambda),
+          s(:args),
+          s(:int, 42)),
+        nil,
+        s(:true)),
+      %q{in ->{ 42 } then true}
+    )
+  end
+
+  def test_pattern_matching_ranges
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:irange, s(:int, 1), s(:int, 2)),
+        nil,
+        s(:true)),
+      %q{in 1..2 then true}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:irange, s(:int, 1), nil),
+        nil,
+        s(:true)),
+      %q{in 1.. then true}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:irange, nil, s(:int, 2)),
+        nil,
+        s(:true)),
+      %q{in ..2 then true}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:erange, s(:int, 1), s(:int, 2)),
+        nil,
+        s(:true)),
+      %q{in 1...2 then true}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:erange, s(:int, 1), nil),
+        nil,
+        s(:true)),
+      %q{in 1... then true}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:erange, nil, s(:int, 2)),
+        nil,
+        s(:true)),
+      %q{in ...2 then true}
+    )
+  end
+
+  def test_pattern_matching_expr_in_paren
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:begin, s(:int, 1)),
+        nil,
+        s(:true)),
+      %q{in (1) then true},
+      %q{   ~~~ expression (in_pattern.begin)
+        |   ~ begin (in_pattern.begin)
+        |     ~ end (in_pattern.begin)}
+    )
+  end
+
+  def test_pattern_matching_constants
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:const, nil, :A),
+        nil,
+        s(:true)),
+      %q{in A then true},
+      %q{   ~ expression (in_pattern.const)
+        |   ~ name (in_pattern.const)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:const, s(:const, nil, :A), :B),
+        nil,
+        s(:true)),
+      %q{in A::B then true},
+      %q{   ~~~~ expression (in_pattern.const)
+        |    ~~ double_colon (in_pattern.const)
+        |      ~ name (in_pattern.const)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:const, s(:cbase), :A),
+        nil,
+        s(:true)),
+      %q{in ::A then true},
+      %q{   ~~~ expression (in_pattern.const)
+        |   ~~ double_colon (in_pattern.const)
+        |     ~ name (in_pattern.const)}
+    )
+  end
+
+  def test_pattern_matching_const_pattern
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:const_pattern,
+          s(:const, nil, :A),
+          s(:array_pattern,
+            s(:int, 1),
+            s(:int, 2))),
+        nil,
+        s(:true)),
+      %q{in A(1, 2) then true},
+      %q{    ~~~~~~ expression (in_pattern.const_pattern)
+        |    ~ begin (in_pattern.const_pattern)
+        |         ~ end (in_pattern.const_pattern)
+        |   ~ expression (in_pattern.const_pattern.const)
+        |     ~~~~ expression (in_pattern.const_pattern.array_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:const_pattern,
+          s(:const, nil, :A),
+          s(:hash_pattern,
+            s(:match_var, :x))),
+        nil,
+        s(:true)),
+      %q{in A(x:) then true},
+      %q{    ~~~~ expression (in_pattern.const_pattern)
+        |    ~ begin (in_pattern.const_pattern)
+        |       ~ end (in_pattern.const_pattern)
+        |   ~ expression (in_pattern.const_pattern.const)
+        |     ~~ expression (in_pattern.const_pattern.hash_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:const_pattern,
+          s(:const, nil, :A),
+          nil),
+        nil,
+        s(:true)),
+      %q{in A() then true},
+      %q{    ~~ expression (in_pattern.const_pattern)
+        |    ~ begin (in_pattern.const_pattern)
+        |     ~ end (in_pattern.const_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:const_pattern,
+          s(:const, nil, :A),
+          s(:array_pattern,
+            s(:int, 1),
+            s(:int, 2))),
+        nil,
+        s(:true)),
+      %q{in A[1, 2] then true},
+      %q{    ~~~~~~ expression (in_pattern.const_pattern)
+        |    ~ begin (in_pattern.const_pattern)
+        |         ~ end (in_pattern.const_pattern)
+        |   ~ expression (in_pattern.const_pattern.const)
+        |     ~~~~ expression (in_pattern.const_pattern.array_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:const_pattern,
+          s(:const, nil, :A),
+          s(:hash_pattern,
+            s(:match_var, :x))),
+        nil,
+        s(:true)),
+      %q{in A[x:] then true},
+      %q{    ~~~~ expression (in_pattern.const_pattern)
+        |    ~ begin (in_pattern.const_pattern)
+        |       ~ end (in_pattern.const_pattern)
+        |   ~ expression (in_pattern.const_pattern.const)
+        |     ~~ expression (in_pattern.const_pattern.hash_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:const_pattern,
+          s(:const, nil, :A),
+          nil),
+        nil,
+        s(:true)),
+      %q{in A[] then true},
+      %q{    ~~ expression (in_pattern.const_pattern)
+        |    ~ begin (in_pattern.const_pattern)
+        |     ~ end (in_pattern.const_pattern)}
+    )
+  end
+
+  def test_pattern_matching_match_alt
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:match_alt, s(:int, 1), s(:int, 2)),
+        nil,
+        s(:true)),
+      %q{in 1 | 2 then true},
+      %q{   ~~~~~ expression (in_pattern.match_alt)
+        |     ~ operator (in_pattern.match_alt)}
+    )
+  end
+
+  def test_pattern_matching_match_as
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:match_as,
+          s(:int, 1),
+          s(:match_var, :a)),
+        nil,
+        s(:true)),
+      %q{in 1 => a then true},
+      %q{   ~~~~~~ expression (in_pattern.match_as)
+        |     ~~ operator (in_pattern.match_as)}
+    )
+  end
+
+  def test_pattern_matching_else
+    assert_parses(
+      s(:case_match,
+        s(:int, 1),
+        s(:in_pattern,
+          s(:int, 2), nil,
+          s(:int, 3)),
+        s(:int, 4)),
+      %q{case 1; in 2; 3; else; 4; end},
+      %q{                 ~~~~ else},
+      SINCE_2_7
+    )
+  end
+
+  def assert_pattern_matching_defines_local_variables(match_code, lvar_names, versions = SINCE_2_7)
+    code = "case 1; #{match_code}; then [#{lvar_names.join(', ')}]; end"
+
+    with_versions(versions) do |version, parser|
+      source_file = Parser::Source::Buffer.new('(assert_context)')
+      source_file.source = code
+
+      lvar_names.each do |lvar_name|
+        refute parser.static_env.declared?(lvar_name),
+          "(#{version}) local variable #{lvar_name.to_s.inspect} has to be undefined before asserting"
+      end
+
+      before = parser.static_env.instance_variable_get(:@variables).to_a
+
+      begin
+        parsed_ast = parser.parse(source_file)
+      rescue Parser::SyntaxError => exc
+        backtrace = exc.backtrace
+        Exception.instance_method(:initialize).bind(exc).
+          call("(#{version}) #{exc.message}")
+        exc.set_backtrace(backtrace)
+        raise
+      end
+
+      lvar_names.each do |lvar_name|
+        assert parser.static_env.declared?(lvar_name),
+          "(#{version}) expected local variable #{lvar_name.to_s.inspect} to be defined after parsing"
+      end
+
+      after = parser.static_env.instance_variable_get(:@variables).to_a
+      extra = after - before - lvar_names
+
+      assert extra.empty?,
+             "(#{version}) expected only #{lvar_names.inspect} " \
+             "to be defined during parsing, but also got #{extra.inspect}"
+    end
+  end
+
+  def test_pattern_matching_creates_locals
+    assert_pattern_matching_defines_local_variables(
+      %q{in a, *b, c},
+      [:a, :b, :c]
+    )
+
+    assert_pattern_matching_defines_local_variables(
+      %q{in d | e | f},
+      [:d, :e, :f]
+    )
+
+    assert_pattern_matching_defines_local_variables(
+      %q{in { g:, **h }},
+      [:g, :h]
+    )
+
+    assert_pattern_matching_defines_local_variables(
+      %q{in A(i, *j, k)},
+      [:i, :j, :k]
+    )
+
+    assert_pattern_matching_defines_local_variables(
+      %q{in 1 => l},
+      [:l]
+    )
+
+    assert_pattern_matching_defines_local_variables(
+      %q{in "m":},
+      [:m]
+    )
+  end
+
+  def test_pattern_matching__FILE__LINE_literals
+    assert_parses(
+      s(:case_match,
+        s(:array,
+          s(:str, "(assert_parses)"),
+          s(:send,
+            s(:int, 1), :+,
+            s(:int, 1)),
+          s(:__ENCODING__)),
+        s(:in_pattern,
+          s(:array_pattern,
+            s(:str, "(assert_parses)"),
+            s(:int, 2),
+            s(:__ENCODING__)), nil, nil), nil),
+      <<-RUBY,
+        case [__FILE__, __LINE__ + 1, __ENCODING__]
+          in [__FILE__, __LINE__, __ENCODING__]
+        end
+      RUBY
+      %q{},
+      SINCE_2_7)
+  end
+
+  def test_pattern_matching_nil_pattern
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:match_nil_pattern)),
+        nil,
+        s(:true)),
+      %q{in **nil then true},
+      %q{   ~~~~~ expression (in_pattern.hash_pattern.match_nil_pattern)
+        |     ~~~ name (in_pattern.hash_pattern.match_nil_pattern)}
+    )
+  end
+
+  def test_pattern_matching_single_line
+    assert_parses(
+      s(:begin,
+        s(:in_match,
+          s(:int, 1),
+          s(:array_pattern,
+            s(:match_var, :a))),
+        s(:lvar, :a)),
+      %q{1 in [a]; a},
+      %q{~~~~~~~~ expression (in_match)
+        |  ~~ operator (in_match)},
+      SINCE_2_7)
+  end
+
+  def test_ruby_bug_pattern_matching_restore_in_kwarg_flag
+    refute_diagnoses(
+      "p(({} in {a:}), a:\n 1)",
+      SINCE_2_7)
+  end
+
+  def test_pattern_matching_duplicate_variable_name
+    assert_diagnoses(
+      [:error, :duplicate_variable_name, { :name => 'a' }],
+      %q{case 0; in a, a; end},
+      %q{              ^ location},
+      SINCE_2_7)
+
+    refute_diagnoses(
+      %q{case [0, 1, 2, 3]; in _, _, _a, _a; end},
+      SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :duplicate_variable_name, { :name => 'a' }],
+      %q{case 0; in a, {a:}; end},
+      %q{               ^ location},
+      SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :duplicate_variable_name, { :name => 'a' }],
+      %q{case 0; in a, {"a":}; end},
+      %q{                ^ location},
+      SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :duplicate_variable_name, { :name => 'a' }],
+      %q{0 in [a, a]},
+      %q{         ^ location},
+      SINCE_2_7)
+  end
+
+  def test_pattern_matching_duplicate_hash_keys
+    assert_diagnoses(
+      [:error, :duplicate_pattern_key, { :name => 'a' }],
+      %q{ case 0; in a: 1, a: 2; end },
+      %q{                  ^^ location},
+      SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :duplicate_pattern_key, { :name => 'a' }],
+      %q{ case 0; in a: 1, "a": 2; end },
+      %q{                  ^^^^ location},
+      SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :duplicate_pattern_key, { :name => 'a' }],
+      %q{ case 0; in "a": 1, "a": 2; end },
+      %q{                    ^^^^ location},
+      SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :duplicate_pattern_key, { :name => "a\0" }],
+      %q{ case 0; in "a\x0":a1, "a\0":a2; end },
+      %q{                       ^^^^^^ location},
+      SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :duplicate_pattern_key, { :name => "abc" }],
+      %q{ case 0; in "abc":a1, "a#{"b"}c":a2; end },
+      %q{                      ^^^^^^^^^^^ location},
+      SINCE_2_7)
+  end
+
+  def test_pattern_matching_required_parentheses_for_in_match
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tCOMMA' }],
+      %{1 in a, b},
+      %{      ^ location},
+      SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tLABEL' }],
+      %{1 in a:},
+      %{     ^^ location},
+      SINCE_2_7)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@9738f96.

Closes https://github.com/whitequark/parser/issues/571

No rush, this commit is 100% isolated (literally 0 deletions)

Specs cover 100% of the new grammar.

Feel free to to add comments!

A bunch of code for error handling is still missing, but at least that's something to discuss.