### PR TITLE
Reject \n and \r in heredoc identifiers starting from 2.7.

### DIFF
--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -30,6 +30,7 @@ module Parser
     :embedded_document       => 'embedded document meets end of file (and they embark on a romantic journey)',
     :heredoc_id_has_newline  => 'here document identifier across newlines, never match',
     :heredoc_id_ends_with_nl => 'here document identifier ends with a newline',
+    :unterminated_heredoc_id => 'unterminated heredoc id',
 
     # Lexer warnings
     :invalid_escape_use      => 'invalid character syntax; use ?%{escape}',

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7153,4 +7153,27 @@ class TestParser < Minitest::Test
       %q{    ^ location},
       SINCE_2_7)
   end
+
+  def test_unterimated_heredoc_id__27
+    assert_diagnoses(
+      [:error, :unterminated_heredoc_id],
+      %Q{<<\"EOS\n\nEOS\n},
+      %q{^ location},
+      SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :unterminated_heredoc_id],
+      %Q{<<\"EOS\n\"\nEOS\n},
+      %q{^ location},
+      SINCE_2_7)
+
+    %W[\r\n \n].each do |nl|
+      assert_diagnoses(
+        [:error, :unterminated_heredoc_id],
+        %Q{<<\"\r\"#{nl}\r#{nl}},
+        %q{^ location},
+        SINCE_2_7)
+    end
+
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commits ruby/ruby@330b376 and ruby/ruby@1432471.

Closes https://github.com/whitequark/parser/issues/573.

I've added one more rule to reject the code like
``` ruby
<<"HERE
# EOF
```
Before this patch it'd throw `expected token tLSHIFT`