### PR TITLE
Add specs for heredocs with mixed encoding.

### DIFF
--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7394,4 +7394,43 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_2_7)
   end
+
+  def test_ruby_bug_15839
+    assert_diagnoses(
+      [:error, :invalid_encoding],
+      %q{# encoding: cp932
+        <<-TEXT
+        \xe9\x9d\u1234
+        TEXT
+      })
+
+    assert_diagnoses(
+      [:error, :invalid_encoding],
+      %q{
+        # encoding: cp932
+        <<-TEXT
+        \xe9\x9d
+        \u1234
+        TEXT
+      })
+
+    assert_diagnoses(
+      [:error, :invalid_encoding],
+      %q{
+        # encoding: cp932
+        <<-TEXT
+        \u1234\xe9\x9d
+        TEXT
+      })
+
+    assert_diagnoses(
+      [:error, :invalid_encoding],
+      %q{
+        # encoding: cp932
+        <<-TEXT
+        \u1234
+        \xe9\x9d
+        TEXT
+      })
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@c05eaa9.

Closes https://github.com/whitequark/parser/issues/576

There's nothing to backport, the builder emits an error if the string has an invalid encoding (strings with mixed encodings are always invalid). But I've noticed that we have no specs for this case, I guess it's worth adding them.