### PR TITLE
Reject numparams as symbol literals.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -1855,6 +1855,20 @@ class Parser::Lexer
         fnext expr_end; fbreak;
       };
 
+      ':' ( '@'  %{ tm = p - 1; diag_msg = :ivar_name }
+          | '@@' %{ tm = p - 2; diag_msg = :cvar_name }
+          ) [0-9]*
+      => {
+        if @version >= 27
+          diagnostic :error, diag_msg, { name: tok(tm, @te) }, range(tm, @te)
+        else
+          emit(:tCOLON, tok(@ts, @ts + 1), @ts, @ts + 1)
+          p = @ts
+        end
+
+        fnext expr_end; fbreak;
+      };
+
       #
       # AMBIGUOUS TERNARY OPERATOR
       #

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7433,4 +7433,30 @@ class TestParser < Minitest::Test
         TEXT
       })
   end
+
+  def test_numparam_as_symbols
+    assert_diagnoses(
+      [:error, :ivar_name, { :name => '@' }],
+      %q{:@},
+      %q{ ^ location},
+      SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :ivar_name, { :name => '@1' }],
+      %q{:@1},
+      %q{ ^^ location},
+      SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :cvar_name, { :name => '@@' }],
+      %q{:@@},
+      %q{ ^^ location},
+      SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :cvar_name, { :name => '@@1' }],
+      %q{:@@1},
+      %q{ ^^^ location},
+      SINCE_2_7)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@1cdaa17.

`else` branch does what previous versions of lexer would do.

@whitequark Should I split it into two machines (one for ivar, one for cvar, to avoid dynamic diagnostic name)? Or is it ok as it is?

Closes https://github.com/whitequark/parser/issues/578