### PR TITLE
Reject whitespaces in meta and control chars.

### DIFF
--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -162,6 +162,24 @@ class TestLexer < Minitest::Test
     refute_escape 'u{123 f0'
   end
 
+  def test_read_escape_whitespaces__27
+    setup_lexer 27
+
+    [ *(0..8), *(14..31) ].each do |code|
+      @lex.reset
+      refute_scanned "\"\\C-" + code.chr + "\""
+
+      @lex.reset
+      refute_scanned "\"\\M-" + code.chr + "\""
+
+      @lex.reset
+      refute_scanned "\"\\C-\\M-" + code.chr + "\""
+
+      @lex.reset
+      refute_scanned "\"\\M-\\C-" + code.chr + "\""
+    end
+  end
+
   def test_ambiguous_uminus
     assert_scanned("m -3",
                    :tIDENTIFIER, "m", [0, 1],


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@c730c25.

Closes https://github.com/whitequark/parser/issues/579

meta and control chars are a bit broken, the algorithm of parsing escaped chars is recursive, and `\M-`/`\C-` prefixes work as functions:
```
"\C-<char>" => apply_C_mask_on(parse_escaped("<char>")
"\M-<char>" => apply_M_mask_on(parse_escaped("<char>")
```
however, in `lexer.rl` it's not recursive, and because of that it parse code like `"\C-\377"` incorrectly. I don't want to fix it for now, literally nobody uses syntax like this.