### PR TITLE
Reject safe navigator in LHS of mass-assignment.

### DIFF
--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -66,6 +66,7 @@ module Parser
     :block_given_to_yield    => 'block given to yield',
     :invalid_regexp          => '%{message}',
     :invalid_return          => 'Invalid return in class/module body',
+    :csend_in_lhs_of_masgn   => '&. inside multiple assignment destination',
 
     # Parser warnings
     :useless_else            => 'else without rescue is useless',

--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -480,6 +480,10 @@ rule
                     }
                 | primary_value call_op tIDENTIFIER
                     {
+                      if (val[1][0] == :anddot)
+                        diagnostic :error, :csend_in_lhs_of_masgn, nil, val[1]
+                      end
+
                       result = @builder.attr_asgn(val[0], val[1], val[2])
                     }
                 | primary_value tCOLON2 tIDENTIFIER
@@ -488,6 +492,10 @@ rule
                     }
                 | primary_value call_op tCONSTANT
                     {
+                      if (val[1][0] == :anddot)
+                        diagnostic :error, :csend_in_lhs_of_masgn, nil, val[1]
+                      end
+
                       result = @builder.attr_asgn(val[0], val[1], val[2])
                     }
                 | primary_value tCOLON2 tCONSTANT

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7459,4 +7459,24 @@ class TestParser < Minitest::Test
       %q{ ^^^ location},
       SINCE_2_7)
   end
+
+  def test_csend_inside_lhs_of_masgn__since_27
+    assert_diagnoses(
+      [:error, :csend_in_lhs_of_masgn],
+      %q{*a&.x = 0},
+      %q{  ^^ location},
+      SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :csend_in_lhs_of_masgn],
+      %q{a&.x, = 0},
+      %q{ ^^ location},
+      SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :csend_in_lhs_of_masgn],
+      %q{*a&.A = 0},
+      %q{  ^^ location},
+      SINCE_2_7)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commits ruby/ruby@140b811 and ruby/ruby@39ae88a.

Closes https://github.com/whitequark/parser/issues/583

