### PR TITLE
Print empty string when --emit-json and empty input are given.

### DIFF
--- a/lib/parser/runner/ruby_parse.rb
+++ b/lib/parser/runner/ruby_parse.rb
@@ -123,7 +123,7 @@ module Parser
       opts.on '--emit-ruby', 'Emit S-expressions as valid Ruby code' do
         @emit_ruby = true
       end
-      
+
       opts.on '--emit-json', 'Emit S-expressions as valid JSON' do
         @emit_json = true
       end
@@ -146,7 +146,7 @@ module Parser
         if @emit_ruby
           puts ast.inspect
         elsif @emit_json
-          puts JSON.generate(ast.to_sexp_array)
+          puts(ast ? JSON.generate(ast.to_sexp_array) : nil)
         else
           puts ast.to_s
         end

--- a/test/test_runner_parse.rb
+++ b/test/test_runner_parse.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'helper'
+require 'open3'
+
+class TestRunnerParse < Minitest::Test
+  PATH_TO_RUBY_PARSE = File.expand_path('../bin/ruby-parse', __dir__).freeze
+
+  def assert_prints(argv, expected_output)
+    stdout, stderr, status = Open3.capture3(PATH_TO_RUBY_PARSE, *argv)
+
+    assert_equal 0, status.to_i
+    assert_includes(stdout, expected_output)
+  end
+
+  def test_emit_ruby
+    assert_prints ['--emit-ruby', '-e 123'],
+                  's(:int, 123)'
+  end
+
+  def test_emit_json
+    assert_prints ['--emit-json', '-e', '123'],
+                  '["int",123]'
+  end
+
+  def test_emit_ruby_empty
+    assert_prints ['--emit-ruby', '-e', ''],
+                  "\n"
+  end
+
+  def test_emit_json_empty
+    assert_prints ['--emit-json', '-e', ''],
+                  "\n"
+  end
+end


### PR DESCRIPTION
```
$ bin/ruby-parse --emit-json -e ''
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.3-compliant syntax, but you are running 2.6.0.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.

```

Closes https://github.com/whitequark/parser/issues/515