### PR TITLE
2.7 pipeline operator

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -2358,6 +2358,18 @@ class Parser::Lexer
         fgoto expr_value;
       };
 
+      '|>'
+      => {
+        if @version >= 27
+          emit(:tPIPE2)
+          fnext expr_dot; fbreak;
+        else
+          emit(:tPIPE)
+          p -= 1
+          fnext expr_value; fbreak;
+        end
+      };
+
       # When '|', '~', '!', '=>' are used as operators
       # they do not accept any symbols (or quoted labels) after.
       # Other binary operators accept it.
@@ -2442,7 +2454,7 @@ class Parser::Lexer
       # Insane leading dots:
       # a #comment
       #  .b: a.b
-      c_space* %{ tm = p } ('.' | '&.')
+      c_space* %{ tm = p } ('.' | '&.' | '|>')
       => { p = tm - 1; fgoto expr_end; };
 
       any

--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -18,6 +18,7 @@ token kCLASS kMODULE kDEF kUNDEF kBEGIN kRESCUE kENSURE kEND kIF kUNLESS
       tSTRING_DVAR tSTRING_END tSTRING_DEND tSTRING tSYMBOL
       tNL tEH tCOLON tCOMMA tSPACE tSEMI tLAMBDA tLAMBEG tCHARACTER
       tRATIONAL tIMAGINARY tLABEL_END tANDDOT tMETHREF tBDOT2 tBDOT3 tNUMPARAM
+      tPIPE2
 
 prechigh
   right    tBANG tTILDE tUPLUS
@@ -36,6 +37,7 @@ prechigh
   right    tEH tCOLON
   left     kRESCUE_MOD
   right    tEQL tOP_ASGN
+  left     tPIPE2
   nonassoc kDEFINED
   right    kNOT
   left     kOR kAND
@@ -275,6 +277,38 @@ rule
                       result = @builder.not_op(val[0], nil, val[1], nil)
                     }
                 | arg
+                | pipeline
+
+        pipeline: expr tPIPE2 operation opt_paren_args
+                  {
+                    lparen_t, args, rparen_t = val[3]
+                    result      = @builder.call_method(val[0], val[1], val[2],
+                                    lparen_t, args, rparen_t)
+                  }
+                | expr tPIPE2 operation opt_paren_args brace_block
+                  {
+                    lparen_t, args, rparen_t = val[3]
+                    method_call = @builder.call_method(val[0], val[1], val[2],
+                                    lparen_t, args, rparen_t)
+
+                    begin_t, args, body, end_t = val[4]
+                    result      = @builder.block(method_call,
+                                    begin_t, args, body, end_t)
+                  }
+                | expr tPIPE2 operation command_args
+                  {
+                    result = @builder.call_method(val[0], val[1], val[2],
+                                  nil, val[3], nil)
+                  }
+                | expr tPIPE2 operation command_args do_block
+                  {
+                    method_call = @builder.call_method(val[0], val[1], val[2],
+                                      nil, val[3], nil)
+
+                    begin_t, args, body, end_t = val[4]
+                    result      = @builder.block(method_call,
+                                    begin_t, args, body, end_t)
+                  }
 
       expr_value: expr
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7512,4 +7512,93 @@ class TestParser < Minitest::Test
       %q{  ^^ location},
       SINCE_2_7)
   end
+
+  def test_pipeline_operator__27
+    assert_parses(
+      s(:send,
+        s(:lvar, :foo), :bar),
+      %q{foo |> bar},
+      %q{    ~~ dot
+        |       ~~~ selector
+        |~~~~~~~~~~ expression},
+      SINCE_2_7)
+
+    assert_parses(
+      s(:send,
+        s(:lvar, :foo), :bar,
+        s(:int, 1)),
+      %q{foo |> bar(1)},
+      %q{    ~~ dot
+        |       ~~~ selector
+        |          ~ begin
+        |            ~ end
+        |~~~~~~~~~~~~~ expression},
+      SINCE_2_7)
+
+    assert_parses(
+      s(:block,
+        s(:send,
+          s(:lvar, :foo), :bar),
+        s(:args),
+        s(:int, 1)),
+      %q{foo |> bar { 1 }},
+      %q{    ~~ dot (send)},
+      SINCE_2_7
+    )
+
+    assert_parses(
+      s(:send,
+        s(:lvar, :foo), :bar,
+        s(:int, 1)),
+      %q{foo |> bar 1},
+      %q{    ~~ dot},
+      SINCE_2_7)
+
+    assert_parses(
+      s(:block,
+        s(:send,
+          s(:lvar, :foo), :bar,
+          s(:int, 1)),
+        s(:args),
+        s(:int, 2)),
+      %q{foo |> bar 1 do 2 end},
+      %q{},
+      SINCE_2_7)
+  end
+
+  def test_pipeline_operator_before_27
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tGT' }],
+      %q{a |> b},
+      %q{   ^ location},
+      ALL_VERSIONS - SINCE_2_7)
+  end
+
+  def test_pipeline_operator_newline
+    assert_parses(
+      s(:send,
+        s(:lvar, :foo), :bar),
+      %q{foo!|> bar}.gsub('!', "\n"),
+      %q{    ~~ dot
+        |       ~~~ selector
+        |~~~~~~~~~~ expression},
+      SINCE_2_7)
+
+    assert_parses(
+      s(:send,
+        s(:lvar, :foo), :bar),
+      %q{foo |>! bar}.gsub('!', "\n"),
+      %q{    ~~ dot
+        |        ~~~ selector
+        |~~~~~~~~~~~ expression},
+      SINCE_2_7)
+  end
+
+  def test_pipeline_operator_operation_before_pipe2
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tMINUS' }],
+      %q{a |> -b},
+      %q{     ^ location},
+      SINCE_2_7)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commits ruby/ruby@f169043, ruby/ruby@043f010, ruby/ruby@aa72118 and ruby/ruby@d365fd5

Closes https://github.com/whitequark/parser/issues/584