### PR TITLE
Bump maintenance branches to 2.6.3, 2.5.6, and 2.4.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ matrix:
     - name: 2.3.8 / Parser tests
       rvm: 2.3.8
       script: bundle exec rake test_cov
-    - name: 2.4.6 / Parser tests
-      rvm: 2.4.6
+    - name: 2.4.7 / Parser tests
+      rvm: 2.4.7
       script: bundle exec rake test_cov
-    - name: 2.5.5 / Parser tests
-      rvm: 2.5.5
+    - name: 2.5.6 / Parser tests
+      rvm: 2.5.6
       script: bundle exec rake test_cov
-    - name: 2.6.3 / Parser tests
-      rvm: 2.6.3
+    - name: 2.6.4 / Parser tests
+      rvm: 2.6.4
       script: bundle exec rake test_cov
     - name: ruby-head / Parser tests
       rvm: ruby-head
@@ -29,11 +29,11 @@ matrix:
     - name: rbx-2 / Parser tests
       rvm: rbx-2
       script: bundle exec rake test_cov
-    - name: 2.5.5 / Rubocop tests
-      rvm: 2.5.5
+    - name: 2.5.6 / Rubocop tests
+      rvm: 2.5.6
       script: ./ci/run_rubocop_specs
-    - name: 2.6.3 / Rubocop tests
-      rvm: 2.6.3
+    - name: 2.6.4 / Rubocop tests
+      rvm: 2.6.4
       script: ./ci/run_rubocop_specs
   allow_failures:
     - rvm: ruby-head

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -48,7 +48,7 @@ module Parser
     CurrentRuby = Ruby23
 
   when /^2\.4\./
-    current_version = '2.4.6'
+    current_version = '2.4.7'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby24', current_version
     end
@@ -57,7 +57,7 @@ module Parser
     CurrentRuby = Ruby24
 
   when /^2\.5\./
-    current_version = '2.5.5'
+    current_version = '2.5.6'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby25', current_version
     end
@@ -66,7 +66,7 @@ module Parser
     CurrentRuby = Ruby25
 
   when /^2\.6\./
-    current_version = '2.6.3'
+    current_version = '2.6.4'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby26', current_version
     end

--- a/lib/parser/ruby25.y
+++ b/lib/parser/ruby25.y
@@ -1885,7 +1885,7 @@ regexp_contents: # nothing
                       result = @builder.symbol(val[0])
                     }
 
-            dsym: tSYMBEG xstring_contents tSTRING_END
+            dsym: tSYMBEG string_contents tSTRING_END
                     {
                       @lexer.state = :expr_end
                       result = @builder.symbol_compose(val[0], val[1], val[2])


### PR DESCRIPTION
These Rubies has been released.

- https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-6-4-released/
- https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-5-6-released/
- https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-4-7-released/

## Ruby 2.6 branch

Bump 2.6 branch from 2.6.2 to 2.6.3
https://github.com/ruby/ruby/compare/v2_6_3...v2_6_4

There seems to be no change to the syntax.

## Ruby 2.5 branch

Bump 2.5 branch from 2.5.5 to 2.5.6
https://github.com/ruby/ruby/compare/v2_5_5...v2_5_6

There is the following change to the syntax:

```diff
-dsym	: tSYMBEG xstring_contents tSTRING_END
+dsym	: tSYMBEG string_contents tSTRING_END
```

This is a backport #560 to Ruby 2.5 branch.

cf. https://github.com/ruby/ruby/commit/764fe09

## Ruby 2.4 branch

Bump 2.4 branch from 2.4.6 to 2.4.7
https://github.com/ruby/ruby/compare/v2_4_6...v2_4_7

There seems to be no change to the syntax.