### PR TITLE
Bump racc dependency to 1.4.15

### DIFF
--- a/parser.gemspec
+++ b/parser.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler',   '>= 1.15', '< 3.0.0'
   spec.add_development_dependency 'rake',      '~> 10.0'
-  spec.add_development_dependency 'racc',      '= 1.4.14'
+  spec.add_development_dependency 'racc',      '= 1.4.15'
   spec.add_development_dependency 'cliver',    '~> 0.3.2'
 
   spec.add_development_dependency 'yard'


### PR DESCRIPTION
This PR fixes the following build error when using Ruby 2.7.

```console
% cd path/to/parser
% ruby -v
ruby 2.7.0dev (2019-08-30T07:09:08Z master 998ee350b9) [x86_64-darwin17]
% bundle install
Fetching gem metadata from https://rubygems.org/.............
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Using rake 10.5.0
Using ast 2.4.0
Using bundler 1.17.3
Using cliver 0.3.2
Using json 2.2.0
Using net-http-persistent 1.4.1
Using minitest 5.11.3
Using kramdown 2.1.0
Using simplecov-html 0.10.2
Using yard 0.9.20
Using parser 2.6.3.0 from source at `.`
Using docile 1.1.5
Using gauntlet 2.1.0
Using simplecov 0.15.1
Fetching racc 1.4.14 (was 1.4.15)
Installing racc 1.4.14 (was 1.4.15) with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
```

https://travis-ci.org/whitequark/parser/jobs/578700574

It can be solved by bumping racc to 1.4.15.