### PR TITLE
+ ruby27.y: Fix parsing of mutiple assignment with rescue modifier

### DIFF
--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -195,6 +195,15 @@ rule
                       result = @builder.assign(val[0], val[1],
                                   @builder.array(nil, val[2], nil))
                     }
+                | mlhs tEQL mrhs_arg kRESCUE_MOD stmt
+                    {
+                      rescue_body = @builder.rescue_body(val[3],
+                                                         nil, nil, nil,
+                                                         nil, val[4])
+                      begin_body = @builder.begin_body(val[2], [ rescue_body ])
+
+                      result = @builder.multi_assign(val[0], val[1], begin_body)
+                    }
                 | mlhs tEQL mrhs_arg
                     {
                       result = @builder.multi_assign(val[0], val[1], val[2])

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -5149,6 +5149,26 @@ class TestParser < Minitest::Test
         |~~~~~~~~~~~~~~~~~~~~~ expression})
   end
 
+  def test_rescue_mod_masgn
+    assert_parses(
+      s(:masgn,
+        s(:mlhs,
+          s(:lvasgn, :foo),
+          s(:lvasgn, :bar)),
+        s(:rescue,
+          s(:send, nil, :meth),
+          s(:resbody, nil, nil,
+            s(:array,
+              s(:int, 1),
+              s(:int, 2))), nil)),
+      %q{foo, bar = meth rescue [1, 2]},
+      %q{                ~~~~~~ keyword (rescue.resbody)
+        |                ~~~~~~~~~~~~~ expression (rescue.resbody)
+        |           ~~~~~~~~~~~~~~~~~~ expression (rescue)
+        |~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ expression},
+      SINCE_2_7)
+  end
+
   def test_rescue_mod_op_assign
     assert_parses(
       s(:op_asgn,


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@53b3be5.

Closes #595.