### PR TITLE
fix parsing of 'm a + b do end'

### DIFF
--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7532,4 +7532,17 @@ class TestParser < Minitest::Test
       %q{  ^^ location},
       SINCE_2_7)
   end
+
+  def test_parser_bug_604
+    assert_parses(
+      s(:block,
+        s(:send, nil, :m,
+          s(:send,
+            s(:send, nil, :a), :+,
+            s(:send, nil, :b))),
+        s(:args), nil),
+      %q{m a + b do end},
+      %q{},
+      ALL_VERSIONS)
+  end
 end


### PR DESCRIPTION
Fixed #604 

The idea is simple: we have an instance variable `@command_start` (I renamed it to follow MRI naming) and a local variable `cmd_state`. Initially it's set to `true` (because we are in the beginning of the line, we do the same thing on `\n` and so does MRI), in the `advance` method we copy ivar to lvar to use this "snapshot" everywhere, `arg_or_cmdarg` now takes this lvar as an argument.

There's 1 small difference between MRI and parser: we change lvar in one place (on newlines) because we don't emit it and simply do `fgoto expr_value` while MRI emits it. So in this case we change "command mode" for the current token, and that's the only exception. Everywhere else we change "command mode" for next token by changing ivar.

I tested it with rubocop (CI will show it), opal and sorbet. Looks like it doesn't break anything.