### PR TITLE
Add `kwnilarg` for `**nil` argument

### DIFF
--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -1032,6 +1032,17 @@ Format:
  ~~ expression
 ~~~
 
+### Keyword nil argument
+
+Format:
+
+~~~
+(kwnilarg)
+"**nil"
+   ~~~ name
+ ~~~~~ expression
+~~~
+
 ### Objective-C arguments
 
 MacRuby includes a few more syntactic "arguments" whose name becomes

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -730,6 +730,11 @@ module Parser
       end
     end
 
+    def kwnilarg(dstar_t, nil_t)
+      n0(:kwnilarg,
+        arg_prefix_map(dstar_t, nil_t))
+    end
+
     def shadowarg(name_t)
       n(:shadowarg, [ value(name_t).to_sym ],
         variable_map(name_t))

--- a/lib/parser/meta.rb
+++ b/lib/parser/meta.rb
@@ -18,7 +18,7 @@ module Parser
         match_with_lvasgn match_current_line
         module class sclass def defs undef alias args
         cbase arg optarg restarg blockarg block_pass kwarg kwoptarg
-        kwrestarg send csend super zsuper yield block
+        kwrestarg kwnilarg send csend super zsuper yield block
         and not or if when case while until while_post
         until_post for break next redo return resbody
         kwbegin begin retry preexe postexe iflipflop eflipflop

--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -1352,6 +1352,10 @@ rule
                     {
                       result = val[0].concat(val[1])
                     }
+                | f_no_kwarg opt_f_block_arg
+                    {
+                      result = val[0].concat(val[1])
+                    }
                 | f_block_arg
                     {
                       result = [ val[0] ]
@@ -2092,6 +2096,10 @@ keyword_variable: kNIL
                     {
                       result = val[0].concat(val[1])
                     }
+                | f_no_kwarg opt_f_block_arg
+                    {
+                      result = val[0].concat(val[1])
+                    }
                 | f_block_arg
                     {
                       result = [ val[0] ]
@@ -2294,6 +2302,11 @@ keyword_variable: kNIL
                     }
 
      kwrest_mark: tPOW | tDSTAR
+
+      f_no_kwarg: kwrest_mark kNIL
+                    {
+                      result = [ @builder.kwnilarg(val[0], val[1]) ]
+                    }
 
         f_kwrest: kwrest_mark tIDENTIFIER
                     {

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -2095,6 +2095,37 @@ class TestParser < Minitest::Test
       SINCE_2_0)
   end
 
+  def test_kwnilarg
+    assert_parses(
+      s(:def, :f,
+        s(:args, s(:kwnilarg)),
+        nil),
+      %q{def f(**nil); end},
+      %q{      ~~~~~ expression (args.kwnilarg)
+        |        ~~~ name (args.kwnilarg)},
+      SINCE_2_7)
+
+    assert_parses(
+      s(:block,
+        s(:send, nil, :m),
+        s(:args,
+          s(:kwnilarg)), nil),
+      %q{m { |**nil| }},
+      %q{     ~~~~~ expression (args.kwnilarg)
+        |       ~~~ name (args.kwnilarg)},
+      SINCE_2_7)
+
+    assert_parses(
+      s(:block,
+        s(:lambda),
+        s(:args,
+          s(:kwnilarg)), nil),
+      %q{->(**nil) {}},
+      %q{   ~~~~~ expression (args.kwnilarg)
+        |     ~~~ name (args.kwnilarg)},
+      SINCE_2_7)
+  end
+
   def test_blockarg
     assert_parses(
       s(:def, :f,


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@6a9ce1f.

Closes https://github.com/whitequark/parser/issues/603 