### PR TITLE
Follow "Separate Keyword Arguments from Positional Arguments"

### DIFF
--- a/lib/parser/source/tree_rewriter.rb
+++ b/lib/parser/source/tree_rewriter.rb
@@ -281,7 +281,7 @@ module Parser
       def enforce_policy(event)
         return if @policy[event] == :accept
         return unless (values = yield)
-        trigger_policy(event, values)
+        trigger_policy(event, **values)
       end
 
       POLICY_TO_LEVEL = {warn: :warning, raise: :error}.freeze


### PR DESCRIPTION
Follow https://github.com/ruby/ruby/pull/2395.

RuboCop's CI of Ruby 2.7 matrix is failing. This is due to a deprecation warning in Ruby 2.7.

```console
  1) RuboCop::CLI when BlockDelimiters has braces_for_chaining style
  corrects SpaceBeforeBlockBraces, SpaceInsideBlockBraces offenses
     Failure/Error: expect($stderr.string).to eq('')

       expected: ""
            got:
            "/usr/local/bundle/gems/parser-2.6.4.0/lib/parser/source/tree_rewriter.rb:284:
            warning: The last
            argu...parser-2.6.4.0/lib/parser/source/tree_rewriter.rb:288:
            warning: for `trigger_policy' defined here\n"
```

https://circleci.com/gh/rubocop-hq/rubocop/67195

This PR suppress the following Ruby 2.7's warning.

```console
% cd path/to/parser
% bundle exec rake

(snip)

/Users/koic/src/github.com/whitequark/parser/lib/parser/source/tree_rewriter.rb:284:
warning: The last argument for `trigger_policy' (defined at
/Users/koic/src/github.com/whitequark/parser/lib/parser/source/tree_rewriter.rb:288)
is used as the keyword parameter
```