### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/parser.gemspec
+++ b/parser.gemspec
@@ -13,6 +13,13 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/whitequark/parser'
   spec.license       = 'MIT'
 
+  spec.metadata = {
+    'bug_tracker_uri' => 'https://github.com/whitequark/parser/issues',
+    'changelog_uri' => "https://github.com/whitequark/parser/blob/v#{spec.version}/CHANGELOG.md",
+    'documentation_uri' => "https://www.rubydoc.info/gems/parser/#{spec.version}",
+    'source_code_uri' => "https://github.com/whitequark/parser/tree/v#{spec.version}"
+  }
+
   spec.files         = `git ls-files`.split + %w(
                           lib/parser/lexer.rb
                           lib/parser/ruby18.rb


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` links will appear on the rubygems page at https://rubygems.org/gems/parser after the next release.