### PR TITLE
Suppress keyword argument warnings in Ruby 2.7

### DIFF
--- a/lib/parser/source/tree_rewriter.rb
+++ b/lib/parser/source/tree_rewriter.rb
@@ -266,7 +266,7 @@ module Parser
 
       def combine(range, attributes)
         range = check_range_validity(range)
-        action = TreeRewriter::Action.new(range, @enforcer, attributes)
+        action = TreeRewriter::Action.new(range, @enforcer, **attributes)
         @action_root = @action_root.combine(action)
         self
       end


### PR DESCRIPTION
Follow up of https://github.com/whitequark/parser/issues/608#issuecomment-531774628.

RuboCop's CI of Ruby 2.7 matrix is failing. This is due to a deprecation warning in Ruby 2.7.

```console
/usr/local/bundle/gems/parser-2.6.4.1/lib/parser/source/tree_rewriter.rb:269:
warning: The last argument is used as the keyword parameter
/usr/local/bundle/gems/parser-2.6.4.1/lib/parser/source/tree_rewriter/action.rb:16:
warning: for `initialize' defined here
```

https://circleci.com/gh/rubocop-hq/rubocop/68131

cf. https://bugs.ruby-lang.org/issues/14183