### PR TITLE
+ lexer.rl: support comments before leading dot in 27 mode.

### DIFF
--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -477,14 +477,18 @@ class TestLexer < Minitest::Test
   end
 
   def test_comment
-    assert_scanned("1 # one\n# two\n2",
-                   :tINTEGER, 1,   [0, 1],
-                   :tNL,      nil, [7, 8],
-                   :tINTEGER, 2,   [14, 15])
+    [26, 27].each do |version|
+      setup_lexer(version)
 
-    assert_equal 2, @lex.comments.length
-    assert_equal '# one', @lex.comments[0].text
-    assert_equal '# two', @lex.comments[1].text
+      assert_scanned("1 # one\n# two\n2",
+                     :tINTEGER, 1,   [0, 1],
+                     :tNL,      nil, [7, 8],
+                     :tINTEGER, 2,   [14, 15])
+
+      assert_equal 2, @lex.comments.length
+      assert_equal '# one', @lex.comments[0].text
+      assert_equal '# two', @lex.comments[1].text
+    end
   end
 
   def test_comment_expr_beg

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7598,4 +7598,47 @@ class TestParser < Minitest::Test
       %q{},
       ALL_VERSIONS)
   end
+
+  def test_comments_before_leading_dot__27
+    assert_parses(
+      s(:send,
+        s(:send, nil, :a), :foo),
+      %Q{a #\n#\n.foo\n},
+      %q{},
+      SINCE_2_7)
+
+    assert_parses(
+      s(:csend,
+        s(:send, nil, :a), :foo),
+      %Q{a #\n#\n&.foo\n},
+      %q{},
+      SINCE_2_7)
+
+    assert_parses(
+      s(:meth_ref,
+        s(:send, nil, :a), :foo),
+      %Q{a #\n#\n.:foo\n},
+      %q{},
+      SINCE_2_7)
+  end
+
+  def test_comments_before_leading_dot__before_27
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tDOT' }],
+      %q{a #!#!.foo!}.gsub('!', "\n"),
+      %q{      ^ location},
+      ALL_VERSIONS - SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tAMPER' }],
+      %q{a #!#!&.foo!}.gsub('!', "\n"),
+      %q{      ^ location},
+      ALL_VERSIONS - SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tDOT' }],
+      %q{a #!#!.:foo!}.gsub('!', "\n"),
+      %q{      ^ location},
+      ALL_VERSIONS - SINCE_2_7)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@3a3f48f.

Closes https://github.com/whitequark/parser/issues/610

I've added a bunch comments, please LMK if there's anything that could be improved.

Also I've fixed parsing of `.:` operator for pre-27 lexer. Previously it was emitted as `tMETHREF` for all versions of lexer, but since it's a 27-specific token we had an "unknown token " error for pre-27 parsers.