### PR TITLE
emit tMETHREF as tDOT+tCOLON for rubies < 27.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -2339,7 +2339,19 @@ class Parser::Lexer
            p = p - tok.length + 2
            fnext expr_dot; fbreak; };
 
-      '.:' | '.' | '&.' | '::'
+      '.:'
+      => {
+        if @version >= 27
+          emit_table(PUNCTUATION)
+        else
+          emit(:tDOT, tok(@ts, @ts + 1), @ts, @ts + 1)
+          fhold;
+        end
+
+        fnext expr_dot; fbreak;
+      };
+
+      '.' | '&.' | '::'
       => { emit_table(PUNCTUATION)
            fnext expr_dot; fbreak; };
 

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -3559,6 +3559,8 @@ class TestLexer < Minitest::Test
   end
 
   def test_meth_ref
+    setup_lexer(27)
+
     assert_scanned('foo.:bar',
                   :tIDENTIFIER, 'foo', [0, 3],
                   :tMETHREF,   '.:',   [3, 5],
@@ -3571,6 +3573,8 @@ class TestLexer < Minitest::Test
   end
 
   def test_meth_ref_unary_op
+    setup_lexer(27)
+
     assert_scanned('foo.:+',
                   :tIDENTIFIER, 'foo', [0, 3],
                   :tMETHREF,    '.:',  [3, 5],

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7214,7 +7214,7 @@ class TestParser < Minitest::Test
     end
   end
 
-  def test_meth_ref
+  def test_meth_ref__27
     assert_parses(
       s(:meth_ref, s(:lvar, :foo), :bar),
       %q{foo.:bar},
@@ -7230,6 +7230,20 @@ class TestParser < Minitest::Test
         |     ~~ selector
         |~~~~~~~ expression},
       SINCE_2_7)
+  end
+
+  def test_meth_ref__before_27
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tCOLON' }],
+      %q{foo.:bar},
+      %q{    ^ location },
+      ALL_VERSIONS - SINCE_2_7)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tCOLON' }],
+      %q{foo.:+@},
+      %q{    ^ location },
+      ALL_VERSIONS - SINCE_2_7)
   end
 
   def test_meth_ref_unsupported_newlines


### PR DESCRIPTION
Part of https://github.com/whitequark/parser/pull/613