### PR TITLE
+ lexer.rl: changed max numparam to `@9`

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -89,7 +89,7 @@ class Parser::Lexer
 
   REGEXP_META_CHARACTERS = Regexp.union(*"\\$()*+.<>?[]^{|}".chars).freeze
 
-  NUMPARAM_MAX = 100
+  NUMPARAM_MAX = 9
 
   attr_reader   :source_buffer
   attr_reader   :max_numparam_stack

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -3654,11 +3654,11 @@ class TestLexer < Minitest::Test
     assert_equal(@lex.max_numparam, 1)
 
     setup_lexer(27)
-    assert_scanned_numbered_parameter('@100')
-    assert_equal(@lex.max_numparam, 100)
+    assert_scanned_numbered_parameter('@9')
+    assert_equal(@lex.max_numparam, 9)
 
     setup_lexer(27)
-    refute_scanned_numbered_parameter('@101', :too_large_numparam)
+    refute_scanned_numbered_parameter('@10', :too_large_numparam)
 
     setup_lexer(27)
     refute_scanned_numbered_parameter('@01', :leading_zero_in_numparam)

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7295,31 +7295,31 @@ class TestParser < Minitest::Test
     assert_parses(
       s(:numblock,
         s(:send, nil, :m),
-        15,
+        9,
         s(:send,
           s(:numparam, 1), :+,
-          s(:numparam, 15))),
-      %q{m { @1 + @15 }},
-      %q{^^^^^^^^^^^^^^ expression
+          s(:numparam, 9))),
+      %q{m { @1 + @9 }},
+      %q{^^^^^^^^^^^^^ expression
         |    ^^ name (send/2.numparam/1)
         |    ^^ expression (send/2.numparam/1)
-        |         ^^^ name (send/2.numparam/2)
-        |         ^^^ expression (send/2.numparam/2)},
+        |         ^^ name (send/2.numparam/2)
+        |         ^^ expression (send/2.numparam/2)},
       SINCE_2_7)
 
     assert_parses(
       s(:numblock,
         s(:send, nil, :m),
-        15,
+        9,
         s(:send,
           s(:numparam, 1), :+,
-          s(:numparam, 15))),
-      %q{m do @1 + @15 end},
-      %q{^^^^^^^^^^^^^^^^^ expression
+          s(:numparam, 9))),
+      %q{m do @1 + @9 end},
+      %q{^^^^^^^^^^^^^^^^ expression
         |     ^^ name (send/2.numparam/1)
         |     ^^ expression (send/2.numparam/1)
-        |          ^^^ name (send/2.numparam/2)
-        |          ^^^ expression (send/2.numparam/2)},
+        |          ^^ name (send/2.numparam/2)
+        |          ^^ expression (send/2.numparam/2)},
       SINCE_2_7)
 
     # Lambdas
@@ -7327,31 +7327,31 @@ class TestParser < Minitest::Test
     assert_parses(
       s(:numblock,
         s(:lambda),
-        15,
+        9,
         s(:send,
           s(:numparam, 1), :+,
-          s(:numparam, 15))),
-      %q{-> { @1 + @15}},
-      %q{^^^^^^^^^^^^^^ expression
+          s(:numparam, 9))),
+      %q{-> { @1 + @9}},
+      %q{^^^^^^^^^^^^^ expression
         |     ^^ name (send.numparam/1)
         |     ^^ expression (send.numparam/1)
-        |          ^^^ name (send.numparam/2)
-        |          ^^^ expression (send.numparam/2)},
+        |          ^^ name (send.numparam/2)
+        |          ^^ expression (send.numparam/2)},
       SINCE_2_7)
 
     assert_parses(
       s(:numblock,
         s(:lambda),
-        15,
+        9,
         s(:send,
           s(:numparam, 1), :+,
-          s(:numparam, 15))),
-      %q{-> do @1 + @15 end},
-      %q{^^^^^^^^^^^^^^^^^^ expression
+          s(:numparam, 9))),
+      %q{-> do @1 + @9 end},
+      %q{^^^^^^^^^^^^^^^^^ expression
         |      ^^ name (send.numparam/1)
         |      ^^ expression (send.numparam/1)
-        |           ^^^ name (send.numparam/2)
-        |           ^^^ expression (send.numparam/2)},
+        |           ^^ name (send.numparam/2)
+        |           ^^ expression (send.numparam/2)},
       SINCE_2_7)
   end
 


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@2698f13.

`@10` (well, starting from https://github.com/whitequark/parser/issues/616 it's `_10`) gives a syntax error

Closes https://github.com/whitequark/parser/issues/615
