### PR TITLE
* Bump ruby versions to 2.4.9, 2.5.7 and 2.6.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ matrix:
     - name: 2.3.8 / Parser tests
       rvm: 2.3.8
       script: bundle exec rake test_cov
-    - name: 2.4.7 / Parser tests
-      rvm: 2.4.7
+    - name: 2.4.9 / Parser tests
+      rvm: 2.4.9
       script: bundle exec rake test_cov
-    - name: 2.5.6 / Parser tests
-      rvm: 2.5.6
+    - name: 2.5.7 / Parser tests
+      rvm: 2.5.7
       script: bundle exec rake test_cov
-    - name: 2.6.4 / Parser tests
-      rvm: 2.6.4
+    - name: 2.6.5 / Parser tests
+      rvm: 2.6.5
       script: bundle exec rake test_cov
     - name: ruby-head / Parser tests
       rvm: ruby-head
@@ -29,11 +29,11 @@ matrix:
     - name: rbx-2 / Parser tests
       rvm: rbx-2
       script: bundle exec rake test_cov
-    - name: 2.5.6 / Rubocop tests
-      rvm: 2.5.6
+    - name: 2.5.7 / Rubocop tests
+      rvm: 2.5.7
       script: ./ci/run_rubocop_specs
-    - name: 2.6.4 / Rubocop tests
-      rvm: 2.6.4
+    - name: 2.6.5 / Rubocop tests
+      rvm: 2.6.5
       script: ./ci/run_rubocop_specs
   allow_failures:
     - rvm: ruby-head

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -48,7 +48,7 @@ module Parser
     CurrentRuby = Ruby23
 
   when /^2\.4\./
-    current_version = '2.4.7'
+    current_version = '2.4.9'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby24', current_version
     end
@@ -57,7 +57,7 @@ module Parser
     CurrentRuby = Ruby24
 
   when /^2\.5\./
-    current_version = '2.5.6'
+    current_version = '2.5.7'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby25', current_version
     end
@@ -66,7 +66,7 @@ module Parser
     CurrentRuby = Ruby25
 
   when /^2\.6\./
-    current_version = '2.6.4'
+    current_version = '2.6.5'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby26', current_version
     end


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/10/02/ruby-2-4-9-released/
https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-5-7-released/
https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-6-5-released/