### PR TITLE
- ruby27.y: reject circular argument reference.

### DIFF
--- a/lib/parser.rb
+++ b/lib/parser.rb
@@ -75,6 +75,10 @@ module Parser
   require 'parser/context'
   require 'parser/max_numparam_stack'
 
+  module Helpers
+    require 'parser/helpers/circular_argument_reference'
+  end
+
   require 'parser/base'
 
   require 'parser/rewriter'

--- a/lib/parser/helpers/circular_argument_reference.rb
+++ b/lib/parser/helpers/circular_argument_reference.rb
@@ -1,0 +1,42 @@
+module Parser
+  module Helpers
+
+    # @private
+    #
+    # Performs a check that optional argument is not used
+    # in its own definition. Rejects code like
+    #   def m(a = a)...
+    #   def m(a = proc { 1 + a })...
+    #
+    class CircularArgumentReference < Parser::AST::Processor
+      def initialize(arg_name, &on_error)
+        @arg_name = arg_name
+        @on_error = on_error
+      end
+
+      def on_lvar(node)
+        name, = *node
+        if name == @arg_name
+          @on_error.call(node)
+        end
+      end
+
+      def stop_traversing(_node); end
+
+      alias on_class stop_traversing
+
+      def on_sclass(node)
+        of, _body = *node
+        process(of)
+      end
+
+      alias on_def stop_traversing
+
+      def on_defs(node)
+        recv, _mid, _body = *node
+        process(recv)
+      end
+    end
+
+  end
+end

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -66,6 +66,7 @@ module Parser
     :numparam_outside_block       => 'numbered parameter outside block',
     :ordinary_param_defined       => 'ordinary parameter is defined',
     :numparam_used_in_outer_scope => 'numbered parameter is already used in an outer scope',
+    :circular_argument_reference  => 'circular argument reference %{var_name}',
 
     # Parser warnings
     :useless_else            => 'else without rescue is useless',


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@0162e7e.

Closes https://github.com/whitequark/parser/issues/621

```
$ bin/ruby-parse --27 -e 'm { |a: proc { 1 + a }| }'
(fragment:0):1:6: error: circular argument reference a
(fragment:0):1: m { |a: proc { 1 + a }| }
(fragment:0):1:      ^             ~
```