### PR TITLE
- ruby27.y: add "arguments forwarding"

### DIFF
--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -1125,6 +1125,36 @@ s(:numblock,
  ~~~~~~~~~~~~~~~~ expression
 ~~~
 
+## Forward arguments
+
+### Method definition accepting forwarding arguments
+
+Ruby 2.7 introduced a feature called "arguments forwarding".
+When a method takes any arguments for forwarding them in the future
+the whole `args` node gets replaced with `forward-args` node.
+
+Format:
+
+~~~
+(def :foo
+  (forward-args) nil)
+"def foo(...); end"
+            ~ end
+        ~ begin
+        ~~~~~ expression
+~~~
+
+### Method call taking arguments of the currently forwarding method
+
+Format:
+
+~~~
+(send nil :foo
+  (forwarded-args))
+"foo(...)"
+     ~~~ expression
+~~~
+
 ## Send
 
 ### To self

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -683,6 +683,10 @@ module Parser
       n(:numargs, [ max_numparam ], nil)
     end
 
+    def forward_args(begin_t, dots_t, end_t)
+      n(:forward_args, [], collection_map(begin_t, token_map(dots_t), end_t))
+    end
+
     def arg(name_t)
       n(:arg, [ value(name_t).to_sym ],
         variable_map(name_t))
@@ -832,6 +836,10 @@ module Parser
       end
     end
 
+    def forwarded_args(dots_t)
+      n(:forwarded_args, [], token_map(dots_t))
+    end
+
     def call_method(receiver, dot_t, selector_t,
                     lparen_t=nil, args=[], rparen_t=nil)
       type = call_type_for_dot(dot_t)
@@ -861,10 +869,9 @@ module Parser
       end
 
       last_arg = call_args.last
-      if last_arg && last_arg.type == :block_pass
+      if last_arg && (last_arg.type == :block_pass || last_arg.type == :forwarded_args)
         diagnostic :error, :block_and_blockarg, nil, last_arg.loc.expression, [loc(begin_t)]
       end
-
 
       if args.type == :numargs
         block_type = :numblock

--- a/lib/parser/meta.rb
+++ b/lib/parser/meta.rb
@@ -26,7 +26,7 @@ module Parser
         ident root lambda indexasgn index procarg0
         meth_ref restarg_expr blockarg_expr
         objc_kwarg objc_restarg objc_varargs
-        numargs numblock
+        numargs numblock forward_args forwarded_args
       ).map(&:to_sym).to_set.freeze
 
   end # Meta

--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -843,6 +843,14 @@ rule
                     {
                       result = val
                     }
+                | tLPAREN2 args_forward rparen
+                    {
+                      unless @static_env.declared_forward_args?
+                        diagnostic :error, :unexpected_token, { :token => 'tBDOT3' } , val[1]
+                      end
+
+                      result = [val[0], [@builder.forwarded_args(val[1])], val[2]]
+                    }
 
   opt_paren_args: # nothing
                     {
@@ -2110,6 +2118,13 @@ keyword_variable: kNIL
 
                       @lexer.state = :expr_value
                     }
+                | tLPAREN2 args_forward rparen
+                    {
+                      result = @builder.forward_args(val[0], val[1], val[2])
+                      @static_env.declare_forward_args
+
+                      @lexer.state = :expr_value
+                    }
                 |   {
                       result = @lexer.in_kwarg
                       @lexer.in_kwarg = true
@@ -2238,6 +2253,11 @@ keyword_variable: kNIL
                 | # nothing
                     {
                       result = []
+                    }
+
+    args_forward: tBDOT3
+                    {
+                      result = val[0]
                     }
 
        f_bad_arg: tCONSTANT

--- a/lib/parser/static_environment.rb
+++ b/lib/parser/static_environment.rb
@@ -3,6 +3,8 @@
 module Parser
 
   class StaticEnvironment
+    FORWARD_ARGS = :FORWARD_ARGS
+
     def initialize
       reset
     end
@@ -40,6 +42,14 @@ module Parser
 
     def declared?(name)
       @variables.include?(name.to_sym)
+    end
+
+    def declare_forward_args
+      declare(FORWARD_ARGS)
+    end
+
+    def declared_forward_args?
+      declared?(FORWARD_ARGS)
     end
   end
 


### PR DESCRIPTION
This commit tracks upstream commits ruby/ruby@62d4382 and ruby/ruby@6279e45.

Closes #624 

Feel free to leave any comments, I'll merge it in a few days