### PR TITLE
+ ruby27.y: treat numparams as locals outside numblock.

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -551,6 +551,9 @@ module Parser
 
       when :ident
         name, = *node
+
+        check_assignment_to_numparam(node)
+
         @parser.static_env.declare(name)
 
         node.updated(:lvasgn)
@@ -1291,6 +1294,19 @@ module Parser
       elsif arg_name_collides?(this_name, that_name)
         diagnostic :error, :duplicate_argument, nil,
                    this_arg.loc.name, [ that_arg.loc.name ]
+      end
+    end
+
+    def check_assignment_to_numparam(node)
+      name = node.children[0].to_s
+
+      assigning_to_numparam =
+        @parser.context.in_dynamic_block? &&
+        name =~ /\A_([1-9])\z/ &&
+        @parser.max_numparam_stack.has_numparams?
+
+      if assigning_to_numparam
+        diagnostic :error, :cant_assign_to_numparam, { :name => name }, node.loc.expression
       end
     end
 

--- a/lib/parser/context.rb
+++ b/lib/parser/context.rb
@@ -55,5 +55,9 @@ module Parser
     def in_lambda?
       @stack.last == :lambda
     end
+
+    def in_dynamic_block?
+      in_block? || in_lambda?
+    end
   end
 end

--- a/lib/parser/max_numparam_stack.rb
+++ b/lib/parser/max_numparam_stack.rb
@@ -17,6 +17,10 @@ module Parser
       top < 0
     end
 
+    def has_numparams?
+      top > 0
+    end
+
     def register(numparam)
       set( [top, numparam].max )
     end

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -63,7 +63,7 @@ module Parser
     :invalid_regexp               => '%{message}',
     :invalid_return               => 'Invalid return in class/module body',
     :csend_in_lhs_of_masgn        => '&. inside multiple assignment destination',
-    :numparam_outside_block       => 'numbered parameter outside block',
+    :cant_assign_to_numparam      => 'cannot assign to numbered parameter %{name}',
     :ordinary_param_defined       => 'ordinary parameter is defined',
     :numparam_used_in_outer_scope => 'numbered parameter is already used in an outer scope',
     :circular_argument_reference  => 'circular argument reference %{var_name}',

--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -1528,7 +1528,7 @@ opt_block_args_tail:
                     }
                   lambda_body
                     {
-                      args = @max_numparam_stack.top > 0 ? @builder.numargs(@max_numparam_stack.top) : val[1]
+                      args = @max_numparam_stack.has_numparams? ? @builder.numargs(@max_numparam_stack.top) : val[1]
                       result = [ args, val[3] ]
 
                       @max_numparam_stack.pop
@@ -1684,7 +1684,7 @@ opt_block_args_tail:
                     }
                     opt_block_param compstmt
                     {
-                      args = @max_numparam_stack.top > 0 ? @builder.numargs(@max_numparam_stack.top) : val[1]
+                      args = @max_numparam_stack.has_numparams? ? @builder.numargs(@max_numparam_stack.top) : val[1]
                       result = [ args, val[2] ]
 
                       @max_numparam_stack.pop
@@ -1700,7 +1700,7 @@ opt_block_args_tail:
                     }
                     opt_block_param bodystmt
                     {
-                      args = @max_numparam_stack.top > 0 ? @builder.numargs(@max_numparam_stack.top) : val[2]
+                      args = @max_numparam_stack.has_numparams? ? @builder.numargs(@max_numparam_stack.top) : val[2]
                       result = [ args, val[3] ]
 
                       @max_numparam_stack.pop
@@ -2033,13 +2033,9 @@ keyword_variable: kNIL
                       if (node = val[0]) && node.type == :ident
                         name = node.children[0]
 
-                        if name =~ /\A_[1-9]\z/ && !static_env.declared?(name)
+                        if name =~ /\A_[1-9]\z/ && !static_env.declared?(name) && context.in_dynamic_block?
                           # definitely an implicit param
                           location = node.loc.expression
-
-                          if !context.in_block? && !context.in_lambda?
-                            diagnostic :error, :numparam_outside_block, nil, [nil, location]
-                          end
 
                           if max_numparam_stack.has_ordinary_params?
                             diagnostic :error, :ordinary_param_defined, nil, [nil, location]


### PR DESCRIPTION
This commit tracks upstream commits ruby/ruby@2fd4655 and ruby/ruby@82e840a.

Closes https://github.com/whitequark/parser/issues/626
