### PR TITLE
+ ruby27.y: reverted method reference operator (added in #634)

### DIFF
--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -602,18 +602,6 @@ Format:
  ~~~~~~~~~~~~~ expression
 ~~~
 
-### Method reference operator
-
-Format:
-
-~~~
-(meth-ref (self) :foo)
-"self.:foo"
-     ^^ dot
-       ^^^ selector
- ^^^^^^^^^ expression
-~~~
-
 ### Multiple assignment
 
 #### Multiple left hand side

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1016,11 +1016,6 @@ module Parser
       end
     end
 
-    def method_ref(receiver, dot_t, selector_t)
-      n(:meth_ref, [ receiver, value(selector_t).to_sym ],
-          send_map(receiver, dot_t, selector_t, nil, [], nil))
-    end
-
     #
     # Control flow
     #

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -447,7 +447,7 @@ class Parser::Lexer
     '=>'  => :tASSOC,   '::'  => :tCOLON2,  '===' => :tEQQ,
     '<=>' => :tCMP,     '[]'  => :tAREF,    '[]=' => :tASET,
     '{'   => :tLCURLY,  '}'   => :tRCURLY,  '`'   => :tBACK_REF2,
-    '!@'  => :tBANG,    '&.'  => :tANDDOT,  '.:'  => :tMETHREF
+    '!@'  => :tBANG,    '&.'  => :tANDDOT,
   }
 
   PUNCTUATION_BEGIN = {
@@ -2292,24 +2292,6 @@ class Parser::Lexer
       #
       # METHOD CALLS
       #
-
-      '.:' w_space+
-      => { emit(:tDOT, '.', @ts, @ts + 1)
-           emit(:tCOLON, ':', @ts + 1, @ts + 2)
-           p = p - tok.length + 2
-           fnext expr_dot; fbreak; };
-
-      '.:'
-      => {
-        if @version >= 27
-          emit_table(PUNCTUATION)
-        else
-          emit(:tDOT, tok(@ts, @ts + 1), @ts, @ts + 1)
-          fhold;
-        end
-
-        fnext expr_dot; fbreak;
-      };
 
       '.' | '&.' | '::'
       => { emit_table(PUNCTUATION)

--- a/lib/parser/meta.rb
+++ b/lib/parser/meta.rb
@@ -24,7 +24,7 @@ module Parser
         kwbegin begin retry preexe postexe iflipflop eflipflop
         shadowarg complex rational __FILE__ __LINE__ __ENCODING__
         ident root lambda indexasgn index procarg0
-        meth_ref restarg_expr blockarg_expr
+        restarg_expr blockarg_expr
         objc_kwarg objc_restarg objc_varargs
         numargs numblock forward_args forwarded_args
       ).map(&:to_sym).to_set.freeze

--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -17,7 +17,7 @@ token kCLASS kMODULE kDEF kUNDEF kBEGIN kRESCUE kENSURE kEND kIF kUNLESS
       tWORDS_BEG tQWORDS_BEG tSYMBOLS_BEG tQSYMBOLS_BEG tSTRING_DBEG
       tSTRING_DVAR tSTRING_END tSTRING_DEND tSTRING tSYMBOL
       tNL tEH tCOLON tCOMMA tSPACE tSEMI tLAMBDA tLAMBEG tCHARACTER
-      tRATIONAL tIMAGINARY tLABEL_END tANDDOT tMETHREF tBDOT2 tBDOT3
+      tRATIONAL tIMAGINARY tLABEL_END tANDDOT tBDOT2 tBDOT3
 
 prechigh
   right    tBANG tTILDE tUPLUS
@@ -1259,10 +1259,6 @@ rule
                 | kRETRY
                     {
                       result = @builder.keyword_cmd(:retry, val[0])
-                    }
-                | primary_value tMETHREF operation2
-                    {
-                      result = @builder.method_ref(val[0], val[1], val[2])
                     }
 
    primary_value: primary

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -3562,51 +3562,6 @@ class TestLexer < Minitest::Test
                    :tIDENTIFIER, 're', [1, 3])
   end
 
-  def test_meth_ref
-    setup_lexer(27)
-
-    assert_scanned('foo.:bar',
-                  :tIDENTIFIER, 'foo', [0, 3],
-                  :tMETHREF,   '.:',   [3, 5],
-                  :tIDENTIFIER, 'bar', [5, 8])
-
-    assert_scanned('foo .:bar',
-                   :tIDENTIFIER, 'foo', [0, 3],
-                   :tMETHREF,   '.:',   [4, 6],
-                   :tIDENTIFIER, 'bar', [6, 9])
-  end
-
-  def test_meth_ref_unary_op
-    setup_lexer(27)
-
-    assert_scanned('foo.:+',
-                  :tIDENTIFIER, 'foo', [0, 3],
-                  :tMETHREF,    '.:',  [3, 5],
-                  :tPLUS,       '+',   [5, 6])
-
-    assert_scanned('foo.:-@',
-                  :tIDENTIFIER, 'foo', [0, 3],
-                  :tMETHREF,    '.:',  [3, 5],
-                  :tUMINUS,     '-@',  [5, 7])
-  end
-
-  def test_meth_ref_unsupported_newlines
-    # MRI emits exactly the same sequence of tokens,
-    # the error happens later in the parser
-
-    assert_scanned('foo. :+',
-                  :tIDENTIFIER, 'foo', [0, 3],
-                  :tDOT,        '.',   [3, 4],
-                  :tCOLON,      ':',   [5, 6],
-                  :tUPLUS,       '+',  [6, 7])
-
-    assert_scanned('foo.: +',
-                  :tIDENTIFIER, 'foo', [0, 3],
-                  :tDOT,        '.',   [3, 4],
-                  :tCOLON,      ':',   [4, 5],
-                  :tPLUS,       '+',   [6, 7])
-  end
-
   def lex_numbered_parameter(input)
     @lex.max_numparam_stack.push
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7214,52 +7214,6 @@ class TestParser < Minitest::Test
     end
   end
 
-  def test_meth_ref__27
-    assert_parses(
-      s(:meth_ref, s(:lvar, :foo), :bar),
-      %q{foo.:bar},
-      %q{   ^^ dot
-        |     ~~~ selector
-        |~~~~~~~~ expression},
-      SINCE_2_7)
-
-    assert_parses(
-      s(:meth_ref, s(:lvar, :foo), :+@),
-      %q{foo.:+@},
-      %q{   ^^ dot
-        |     ~~ selector
-        |~~~~~~~ expression},
-      SINCE_2_7)
-  end
-
-  def test_meth_ref__before_27
-    assert_diagnoses(
-      [:error, :unexpected_token, { :token => 'tCOLON' }],
-      %q{foo.:bar},
-      %q{    ^ location },
-      ALL_VERSIONS - SINCE_2_7)
-
-    assert_diagnoses(
-      [:error, :unexpected_token, { :token => 'tCOLON' }],
-      %q{foo.:+@},
-      %q{    ^ location },
-      ALL_VERSIONS - SINCE_2_7)
-  end
-
-  def test_meth_ref_unsupported_newlines
-    assert_diagnoses(
-      [:error, :unexpected_token, { :token => 'tCOLON' }],
-      %Q{foo. :+},
-      %q{     ^ location},
-      SINCE_2_7)
-
-    assert_diagnoses(
-      [:error, :unexpected_token, { :token => 'tCOLON' }],
-      %Q{foo.: +},
-      %q{    ^ location},
-      SINCE_2_7)
-  end
-
   def test_unterimated_heredoc_id__27
     assert_diagnoses(
       [:error, :unterminated_heredoc_id],
@@ -7686,13 +7640,6 @@ class TestParser < Minitest::Test
       s(:csend,
         s(:send, nil, :a), :foo),
       %Q{a #\n#\n&.foo\n},
-      %q{},
-      SINCE_2_7)
-
-    assert_parses(
-      s(:meth_ref,
-        s(:send, nil, :a), :foo),
-      %Q{a #\n#\n.:foo\n},
       %q{},
       SINCE_2_7)
   end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@fb6a489.

Closes https://github.com/whitequark/parser/issues/632