### PR TITLE
+ ruby27.y: removed opt_block_args_tail: tOROP rule.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -1888,6 +1888,24 @@ class Parser::Lexer
       };
 
       #
+      # AMBIGUOUS EMPTY BLOCK ARGUMENTS
+      #
+
+      # Ruby >= 2.7 emits it as two tPIPE terminals
+      # while Ruby < 2.7 as a single tOROP (like in `a || b`)
+      '||'
+      => {
+        if @version >= 27
+          emit(:tPIPE, tok(@ts, @ts + 1), @ts, @ts + 1)
+          fhold;
+          fnext expr_beg; fbreak;
+        else
+          p -= 2
+          fgoto expr_end;
+        end
+      };
+
+      #
       # KEYWORDS AND PUNCTUATION
       #
 

--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -1481,11 +1481,6 @@ opt_block_args_tail:
                       @current_arg_stack.set(nil)
                       result = @builder.args(val[0], val[1], val[2])
                     }
-                | tOROP
-                    {
-                      @max_numparam_stack.has_ordinary_params!
-                      result = @builder.args(val[0], [], val[0])
-                    }
                 | tPIPE block_param opt_bv_decl tPIPE
                     {
                       @max_numparam_stack.has_ordinary_params!

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -1507,6 +1507,13 @@ class TestLexer < Minitest::Test
     assert_scanned "||", :tOROP, "||", [0, 2]
   end
 
+  def test_or2__after_27
+    setup_lexer(27)
+    assert_scanned("||",
+                   :tPIPE, "|", [0, 1],
+                   :tPIPE, "|", [1, 2])
+  end
+
   def test_or2_equals
     assert_scanned "||=", :tOP_ASGN, "||", [0, 3]
   end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -2477,7 +2477,7 @@ class TestParser < Minitest::Test
       %Q{|;\na\n|},
       SINCE_2_0)
 
-    # tOROP
+    # tOROP before 2.7 / tPIPE+tPIPE after
     assert_parses_blockargs(
       s(:args),
       %q{||})
@@ -7689,12 +7689,6 @@ class TestParser < Minitest::Test
       %q{          ^^^ location},
       SINCE_2_7)
 
-    assert_diagnoses(
-      [:error, :circular_argument_reference, { :var_name => 'foo' }],
-      %q{m { |foo = proc { || 1 + foo }| }},
-      %q{                         ^^^ location},
-      SINCE_2_7)
-
     # Traversing
 
     assert_diagnoses(
@@ -7725,7 +7719,8 @@ class TestParser < Minitest::Test
       'm { |foo = def self.m(bar = foo); foo; end| }',
       'def m(foo = def m; foo; end) end',
       'def m(foo = def self.m; foo; end) end',
-      'm { |foo = proc { |bar| 1 + foo }| }'
+      'm { |foo = proc { |bar| 1 + foo }| }',
+      'm { |foo = proc { || 1 + foo }| }'
     ].each do |code|
       refute_diagnoses(code, SINCE_2_7)
     end


### PR DESCRIPTION
This rule was the only one that didn't unset current_arg.
Thus, `def foo(var: bar { || var }) var end` is now a valid syntax.

This commit tracks upstream commits ruby/ruby@7c22898 and ruby/ruby@ed90ec3.

Closes https://github.com/whitequark/parser/issues/629 (that allows this syntax by fixing this rule)
Closes https://github.com/whitequark/parser/issues/630 (that removes the rule and changes lexer to emit a different sequence of terminals and use a different rule that allows new syntax).
It's easier to apply them both.