### PR TITLE
+ lexer.rl: warn on `...` at EOL.

### DIFF
--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -36,6 +36,7 @@ module Parser
     :invalid_escape_use      => 'invalid character syntax; use ?%{escape}',
     :ambiguous_literal       => 'ambiguous first argument; put parentheses or a space even after the operator',
     :ambiguous_prefix        => "`%{prefix}' interpreted as argument prefix",
+    :triple_dot_at_eol       => '... at EOL, should be parenthesized',
 
     # Parser errors
     :nth_ref_alias                => 'cannot define an alias for a back-reference variable',

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7852,4 +7852,17 @@ class TestParser < Minitest::Test
       %q{        ^^^ location},
       SINCE_2_7)
   end
+
+  def test_erange_without_parentheses_at_eol
+    assert_diagnoses(
+      [:warning, :triple_dot_at_eol],
+      %Q{1...\n2},
+      %q{ ^^^ location},
+      SINCE_2_7)
+
+    refute_diagnoses('(1...)', SINCE_2_7)
+    refute_diagnoses("(1...\n)", SINCE_2_7)
+    refute_diagnoses("[1...\n]", SINCE_2_7)
+    refute_diagnoses("{a: 1...\n2}", SINCE_2_7)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@a58b4ee.

We used `@paren_nest` only for parentheses, but MRI uses them also for brackets and curly braces. Previously it was ok, but now they use it to generate this warning.

Closes https://github.com/whitequark/parser/issues/631