### PR TITLE
* README.md: documented compatibility issue with EOF chars after embedded documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,13 @@ follows 2.1 behavior.
 
 No known code is affected by this issue.
 
+### EOF characters after embedded documents before 2.7
+
+Code like `"=begin\n""=end\0"` is invalid for all versions of Ruby before 2.7. Ruby 2.7 and later parses it
+normally. Parser follows 2.7 behavior.
+
+It is unknown whether any gems are affected by this issue.
+
 ## Contributors
 
 * [whitequark][]

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7865,4 +7865,23 @@ class TestParser < Minitest::Test
     refute_diagnoses("[1...\n]", SINCE_2_7)
     refute_diagnoses("{a: 1...\n2}", SINCE_2_7)
   end
+
+  def test_embedded_document_with_eof
+    refute_diagnoses("=begin\n""=end", SINCE_2_7)
+    refute_diagnoses("=begin\n""=end\0", SINCE_2_7)
+    refute_diagnoses("=begin\n""=end\C-d", SINCE_2_7)
+    refute_diagnoses("=begin\n""=end\C-z", SINCE_2_7)
+
+    assert_diagnoses(
+      [:fatal, :embedded_document],
+      "=begin\n",
+      %q{},
+      SINCE_2_7)
+
+    assert_diagnoses(
+      [:fatal, :embedded_document],
+      "=begin",
+      %q{},
+      SINCE_2_7)
+  end
 end


### PR DESCRIPTION
Added tests from ruby/ruby@ade0388.

Closes https://github.com/whitequark/parser/issues/627.

If anyone wants to implement it you are welcome. I'm pretty sure nobody cares about it.