### PR TITLE
- dedenter.rb: fixed over-dedenting of squiggly heredocs

### DIFF
--- a/lib/parser/lexer/dedenter.rb
+++ b/lib/parser/lexer/dedenter.rb
@@ -3,72 +3,71 @@
 module Parser
 
   class Lexer::Dedenter
+    # Tab (\t) counts as 8 spaces
+    TAB_WIDTH = 8
+
     def initialize(dedent_level)
       @dedent_level = dedent_level
       @at_line_begin = true
       @indent_level  = 0
     end
 
+    # For a heredoc like
+    #   <<-HERE
+    #     a
+    #     b
+    #   HERE
+    # this method gets called with "  a\n" and "  b\n"
+    #
+    # However, the following heredoc:
+    #
+    #   <<-HERE
+    #     a\
+    #     b
+    #   HERE
+    # calls this method only once with a string "  a\\\n  b\n"
+    #
+    # This is important because technically it's a single line,
+    # but it has to be concatenated __after__ dedenting.
+    #
+    # It has no effect for non-squiggly heredocs, i.e. it simply removes "\\\n"
+    # Of course, lexer could do it but once again: it's all because of dedenting.
+    #
     def dedent(string)
-      space_begin = space_end = offset = 0
-      last_index  = string.length - 1
-      escape = false
-      _at_line_begin = nil
-
-      string.chars.each_with_index do |char, index|
-        if char == '\\'
-          # entering escape mode
-          escape = true
-          string.slice!(index - offset)
-          offset += 1
-          _at_line_begin = @at_line_begin
-          @at_line_begin = false
-        elsif escape
-          if char == ?\n
-            # trimming \n, starting a new line
-            string.slice!(index - offset)
-            offset += 1
-            @at_line_begin = true
-            space_begin = space_end = index - offset
-            @indent_level = 0
-          elsif char == ?n
-            # replacing \\n to \n
-            string.slice!(index - offset)
-            string.insert(index - offset, ?\n)
-          else
-            # exiting escape mode as it's not an escape sequence
-            @at_line_begin = _at_line_begin
-            escape = false
-            redo
-          end
-          escape = false
-        elsif @at_line_begin
-          if char == ?\n || @indent_level >= @dedent_level
-            string.slice!(space_begin...space_end)
-            offset += space_end - space_begin
-            @at_line_begin = false
-          end
-
-          case char
-          when ?\s
-            @indent_level += 1
-            space_end += 1
-          when ?\t
-            @indent_level += 8 - @indent_level % 8
-            space_end += 1
-          end
-        elsif char == ?\n && index == last_index
-          @at_line_begin = true
-          @indent_level  = 0
-          space_begin = space_end = index - offset + 1
-        end
-      end
+      lines = string.split("\\\n")
 
       if @at_line_begin
-        string.slice!(space_begin..space_end)
+        lines_to_dedent = lines
+      else
+        _first, *lines_to_dedent = lines
       end
 
-      nil
+      lines_to_dedent.each do |line|
+        left_to_remove = @dedent_level
+        remove = 0
+
+        line.each_char do |char|
+          break if left_to_remove <= 0
+          case char
+          when ?\s
+            remove += 1
+            left_to_remove -= 1
+          when ?\t
+            break if TAB_WIDTH * (remove / TAB_WIDTH + 1) > @dedent_level
+            remove += 1
+            left_to_remove -= TAB_WIDTH
+          else
+            # no more spaces or tabs
+            break
+          end
+        end
+
+        line.slice!(0, remove)
+      end
+
+      string.replace(lines.join)
+
+      @at_line_begin = string.end_with?("\n")
     end
 
     def interrupt

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -324,7 +324,7 @@ class TestParser < Minitest::Test
     assert_parses(
       s(:send, nil, :p,
         s(:dstr,
-          s(:str, "x\n"),
+          s(:str, "\tx\n"),
           s(:str, "y\n"))),
       %Q{p <<~E\n\tx\n    y\nE},
       %q{},
@@ -428,6 +428,14 @@ class TestParser < Minitest::Test
             s(:str, "  y")),
           s(:str, "\n"))),
       %Q{p <<~"E"\n    x\n  \#{"  y"}\nE},
+      %q{},
+      SINCE_2_3)
+  end
+
+  def test_parser_bug_640
+    assert_parses(
+      s(:str, "bazqux\n"),
+      %Q{<<~FOO\n  baz\\\n  qux\nFOO},
       %q{},
       SINCE_2_3)
   end


### PR DESCRIPTION
Closes #640 

I'm not sure what exactly caused this bug, but `Dedenter` removed non-whitespace character because of wrong values in `space_begin`/`space_end`.

Instead of debugging it I decided to rewrite it into a less efficient, but way more readable implementation.

I manually checked all test cases in `test_dedenting_heredoc` and found one more bug related to tabs (that is fixed now).