### PR TITLE
Improve pattern matching compatibility

### DIFF
--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -1870,6 +1870,27 @@ Format:
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ expression
 ~~~
 
+#### With empty else
+
+Empty `else` differs from the missing (or _implicit_) `else` for pattern matching, since
+the latter one raises a `NoMatchingPattern` exception. Thus, we need a way to distinguish this
+two cases in the resulting AST.
+
+Format:
+
+~~~
+(case-match,
+  (str "str")
+  (in-pattern
+    (match-var :foo)
+    (lvar :bar))
+  (empty-else))
+"case "str"; in foo; bar; else; end"
+ ~~~~ keyword             ~~~~ else
+                                ~~~ end
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ expression
+~~~
+
 ### In clause
 
 Format:

--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -2140,3 +2140,20 @@ Format:
     ~ name (const-pattern.const)
     ~ expression (const-pattern.const)
 ~~~
+
+#### With array pattern without elements
+
+Format:
+
+~~~
+(const-pattern
+  (const nil :X)
+  (array-pattern))
+"in X[]"
+     ~ begin (const-pattern)
+      ~ end (const-pattern)
+     ~~ expression (const-pattern)
+    ~ name (const-pattern.const)
+    ~ expression (const-pattern.const)
+     ~~ expression (const-pattern.array_pattern)
+~~~

--- a/lib/parser/ast/processor.rb
+++ b/lib/parser/ast/processor.rb
@@ -274,6 +274,10 @@ module Parser
           'Parser::AST::Processor#on_argument instead.'
         on_argument(node)
       end
+
+      def on_empty_else(node)
+        node
+      end
     end
   end
 end

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1371,11 +1371,13 @@ module Parser
         pair_keyword(label, value)
       else
         begin_t, parts, end_t = label
+        label_loc = loc(begin_t).join(loc(end_t))
 
         # quoted label like "label": value
         if (var_name = static_string(parts))
-          loc = loc(begin_t).join(loc(end_t))
-          check_duplicate_pattern_key(var_name, loc)
+          check_duplicate_pattern_key(var_name, label_loc)
+        else
+          diagnostic :error, :pm_interp_in_var_name, nil, label_loc
         end
 
         pair_quoted(begin_t, parts, end_t, value)

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1213,6 +1213,7 @@ module Parser
     #
 
     def case_match(case_t, expr, in_bodies, else_t, else_body, end_t)
+      else_body = n(:empty_else, nil, token_map(else_t)) if else_t && !else_body
       n(:case_match, [ expr, *(in_bodies << else_body)],
         condition_map(case_t, expr, nil, nil, else_t, else_body, end_t))
     end

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1313,6 +1313,8 @@ module Parser
     end
 
     def array_pattern(lbrack_t, elements, rbrack_t)
+      return n(:array_pattern, nil, collection_map(lbrack_t, [], rbrack_t)) if elements.nil?
+
       trailing_comma = false
 
       elements = elements.map do |element|

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -70,6 +70,7 @@ module Parser
     :circular_argument_reference  => 'circular argument reference %{var_name}',
     :pm_interp_in_var_name        => 'symbol literal with interpolation is not allowed',
     :lvar_name                    => "`%{name}' is not allowed as a local variable name",
+    :undefined_lvar               => "no such local variable: `%{name}'",
     :duplicate_variable_name      => 'duplicate variable name %{name}',
     :duplicate_pattern_key        => 'duplicate hash pattern key %{name}',
 

--- a/lib/parser/meta.rb
+++ b/lib/parser/meta.rb
@@ -31,6 +31,7 @@ module Parser
         match_var pin match_alt match_as match_rest
         array_pattern match_with_trailing_comma array_pattern_with_tail
         hash_pattern const_pattern if_guard unless_guard match_nil_pattern
+        empty_else
       ).map(&:to_sym).to_set.freeze
 
   end # Meta

--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -2096,6 +2096,11 @@ opt_block_args_tail:
 
        p_var_ref: tCARET tIDENTIFIER
                     {
+                      name = val[1][0]
+                      unless static_env.declared?(name)
+                        diagnostic :error, :undefined_lvar, { :name => name }, val[1]
+                      end
+
                       lvar = @builder.accessible(@builder.ident(val[1]))
                       result = @builder.pin(val[0], lvar)
                     }

--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -1841,7 +1841,8 @@ opt_block_args_tail:
                     }
                 | p_const tLPAREN2 rparen
                     {
-                      result = @builder.const_pattern(val[0], val[1], nil, val[2])
+                      pattern = @builder.array_pattern(val[1], nil, val[2])
+                      result = @builder.const_pattern(val[0], val[1], pattern, val[2])
                     }
                 | p_const p_lbracket p_args rbracket
                     {
@@ -1857,7 +1858,8 @@ opt_block_args_tail:
                     }
                 | p_const tLBRACK2 rbracket
                     {
-                      result = @builder.const_pattern(val[0], val[1], nil, val[2])
+                      pattern = @builder.array_pattern(val[1], nil, val[2])
+                      result = @builder.const_pattern(val[0], val[1], pattern, val[2])
                     }
                 | tLBRACK
                     {

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -8997,13 +8997,15 @@ class TestParser < Minitest::Test
       s(:in_pattern,
         s(:const_pattern,
           s(:const, nil, :A),
-          nil),
+          s(:array_pattern)),
         nil,
         s(:true)),
       %q{in A() then true},
       %q{    ~~ expression (in_pattern.const_pattern)
         |    ~ begin (in_pattern.const_pattern)
-        |     ~ end (in_pattern.const_pattern)}
+        |     ~ end (in_pattern.const_pattern)
+        |   ~ expression (in_pattern.const_pattern.const)
+        |    ~~ expression (in_pattern.const_pattern.array_pattern)}
     )
 
     assert_parses_pattern_match(
@@ -9043,13 +9045,14 @@ class TestParser < Minitest::Test
       s(:in_pattern,
         s(:const_pattern,
           s(:const, nil, :A),
-          nil),
+          s(:array_pattern)),
         nil,
         s(:true)),
       %q{in A[] then true},
       %q{    ~~ expression (in_pattern.const_pattern)
         |    ~ begin (in_pattern.const_pattern)
-        |     ~ end (in_pattern.const_pattern)}
+        |     ~ end (in_pattern.const_pattern)
+        |    ~~ expression (in_pattern.const_pattern.array_pattern)}
     )
   end
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -8839,6 +8839,15 @@ class TestParser < Minitest::Test
     )
   end
 
+  def test_pattern_matching_hash_with_string_interpolation_keys
+    assert_diagnoses(
+      [:error, :pm_interp_in_var_name],
+      %q{case a; in "#{a}": 1; end},
+      %q{           ~~~~~~~ location},
+      SINCE_2_7
+    )
+  end
+
   def test_pattern_matching_keyword_variable
     assert_parses_pattern_match(
       s(:in_pattern,

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -9105,6 +9105,20 @@ class TestParser < Minitest::Test
     )
   end
 
+  def test_pattern_matching_blank_else
+    assert_parses(
+      s(:case_match,
+        s(:int, 1),
+        s(:in_pattern,
+          s(:int, 2), nil,
+          s(:int, 3)),
+        s(:empty_else)),
+      %q{case 1; in 2; 3; else; end},
+      %q{                 ~~~~ else},
+      SINCE_2_7
+    )
+  end
+
   def assert_pattern_matching_defines_local_variables(match_code, lvar_names, versions = SINCE_2_7)
     code = "case 1; #{match_code}; then [#{lvar_names.join(', ')}]; end"
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -9295,6 +9295,14 @@ class TestParser < Minitest::Test
       SINCE_2_7)
   end
 
+  def test_pattern_matching_required_bound_variable_before_pin
+    assert_diagnoses(
+      [:error, :undefined_lvar, { :name => 'a' }],
+      %{case 0; in ^a; true; end},
+      %{            ^ location},
+      SINCE_2_7)
+  end
+
   def test_parser_bug_645
     assert_parses(
       s(:block,


### PR DESCRIPTION
This PR aims to fix a few incompatibilities with MRI (based on the recently published [ruby/spec](https://github.com/ruby/spec/blob/master/language/pattern_matching_spec.rb) tests for pattern matching).

- [x] Raise syntax error if pin points to unknown local variable (see https://github.com/ruby/spec/blob/10fe05ce8f82eae325a6f259f67a054b9f58fb58/language/pattern_matching_spec.rb#L372-L384)

- [x] [**WONTFIX**](https://github.com/whitequark/parser/pull/652#issuecomment-590318925) ~~Disallow variable binding in alternation (see https://github.com/ruby/spec/blob/10fe05ce8f82eae325a6f259f67a054b9f58fb58/language/pattern_matching_spec.rb#L396-L405)~~

- [x] Empty array should return array-pattern anyway (see https://github.com/ruby/spec/blob/10fe05ce8f82eae325a6f259f67a054b9f58fb58/language/pattern_matching_spec.rb#L501-L512) (right now `Object[]` behaves the same as `Object`).

- [x] Disallow string interpolation in keys (see https://github.com/ruby/spec/blob/10fe05ce8f82eae325a6f259f67a054b9f58fb58/language/pattern_matching_spec.rb#L739-L749)

```ruby
case {a: 1}
  # this should raise syntax error
  in {"#{x}": 1}
end
```

- [x] Respect `else; end`.
For `case ... in` the empty else clause has a different meaning than no else clause (the first one returns `nil`, the second raises NoMatchingPattern); thus, we need to make them distinguishable in the resulting AST.


