### PR TITLE
- lexer.rl: allow spaces before comments-before-leading-dot.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -2473,7 +2473,7 @@ class Parser::Lexer
 
       # Here we use '\n' instead of w_newline to not modify @newline_s
       # and eventually properly emit tNL
-      (w_space_comment '\n')+
+      (c_space* w_space_comment '\n')+
       => {
         if @version < 27
           # Ruby before 2.7 doesn't support comments before leading dot.

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7645,9 +7645,23 @@ class TestParser < Minitest::Test
       SINCE_2_7)
 
     assert_parses(
+      s(:send,
+        s(:send, nil, :a), :foo),
+      %Q{a #\n  #\n.foo\n},
+      %q{},
+      SINCE_2_7)
+
+    assert_parses(
       s(:csend,
         s(:send, nil, :a), :foo),
       %Q{a #\n#\n&.foo\n},
+      %q{},
+      SINCE_2_7)
+
+    assert_parses(
+      s(:csend,
+        s(:send, nil, :a), :foo),
+      %Q{a #\n  #\n&.foo\n},
       %q{},
       SINCE_2_7)
   end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/653

`\s*` was missing and so
```ruby
m
#
  .n
```

was valid, but not

```ruby
m
  #
  .n
```