### PR TITLE
Fix modern documentation to mention emit_arg_inside_procarg0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ below for explanation of `emit_*` calls):
 
     require 'parser/current'
     # opt-in to most recent AST format:
-    Parser::Builders::Default.emit_lambda   = true
-    Parser::Builders::Default.emit_procarg0 = true
-    Parser::Builders::Default.emit_encoding = true
-    Parser::Builders::Default.emit_index    = true
+    Parser::Builders::Default.emit_lambda              = true
+    Parser::Builders::Default.emit_procarg0            = true
+    Parser::Builders::Default.emit_encoding            = true
+    Parser::Builders::Default.emit_index               = true
+    Parser::Builders::Default.emit_arg_inside_procarg0 = true
 
 Parse a chunk of code:
 


### PR DESCRIPTION
- Fix documentation of modern AST format to include
  emit_arg_inside_procarg0. This allows users to mirror what
  `Parser::Builders::Default.modernize` does.