### PR TITLE
+ ruby27.y: fix array pattern with tail source map

### DIFF
--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -2068,7 +2068,7 @@ so a single item match with comma gets interpreted as an array.
 (array-pattern-with-tail
   (match-var :foo))
 "in foo,"
-    ~~~ expression
+    ~~~~ expression
 ~~~
 
 ### Matching using hash pattern

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1318,7 +1318,7 @@ module Parser
 
       trailing_comma = false
 
-      elements = elements.map do |element|
+      node_elements = elements.map do |element|
         if element.type == :match_with_trailing_comma
           trailing_comma = true
           element.children.first
@@ -1329,12 +1329,13 @@ module Parser
       end
 
       node_type = trailing_comma ? :array_pattern_with_tail : :array_pattern
-      n(node_type, elements,
+
+      n(node_type, node_elements,
         collection_map(lbrack_t, elements, rbrack_t))
     end
 
-    def match_with_trailing_comma(match)
-      n(:match_with_trailing_comma, [ match ], nil)
+    def match_with_trailing_comma(match, comma_t)
+      n(:match_with_trailing_comma, [ match ], expr_map(match.loc.expression.join(loc(comma_t))))
     end
 
     def const_pattern(const, ldelim_t, pattern, rdelim_t)

--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -1784,7 +1784,7 @@ opt_block_args_tail:
                       # array patterns that end with comma
                       # like 1, 2,
                       # must be emitted as `array_pattern_with_tail`
-                      item = @builder.match_with_trailing_comma(val[0])
+                      item = @builder.match_with_trailing_comma(val[0], val[1])
                       result = @builder.array_pattern(nil, [ item ], nil)
                     }
                 | p_expr tCOMMA p_args
@@ -1934,7 +1934,7 @@ opt_block_args_tail:
                       # array patterns that end with comma
                       # like [1, 2,]
                       # must be emitted as `array_pattern_with_tail`
-                      item = @builder.match_with_trailing_comma(val[0])
+                      item = @builder.match_with_trailing_comma(val[0], val[1])
                       result = [ item ]
                     }
                 | p_args_head p_arg tCOMMA
@@ -1942,7 +1942,7 @@ opt_block_args_tail:
                       # array patterns that end with comma
                       # like [1, 2,]
                       # must be emitted as `array_pattern_with_tail`
-                      last_item = @builder.match_with_trailing_comma(val[1])
+                      last_item = @builder.match_with_trailing_comma(val[1], val[2])
                       result = [ *val[0], last_item ]
                     }
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -8422,7 +8422,7 @@ class TestParser < Minitest::Test
         nil,
         s(:nil)),
       %q{in x, then nil},
-      %q{   ~ expression (in_pattern.array_pattern_with_tail)}
+      %q{   ~~ expression (in_pattern.array_pattern_with_tail)}
     )
 
     assert_parses_pattern_match(
@@ -8468,7 +8468,7 @@ class TestParser < Minitest::Test
         nil,
         s(:nil)),
       %q{in x, y, then nil},
-      %q{   ~~~~ expression (in_pattern.array_pattern_with_tail)}
+      %q{   ~~~~~ expression (in_pattern.array_pattern_with_tail)}
     )
 
     assert_parses_pattern_match(


### PR DESCRIPTION
This change takes trailing comman into account for `array_pattern_with_tail` expression location:

```
# before
in foo,
   ~~~ expression

# after
in foo,
   ~~~~ expression
```

Currently, we lose comma location information, which makes it hard for rewriters to deal with this case.