### PR TITLE
+ ruby27.y: Allow trailing comma in hash pattern

### DIFF
--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -1986,6 +1986,10 @@ opt_block_args_tail:
                     {
                       result = val[0]
                     }
+                | p_kwarg tCOMMA
+                    {
+                      result = val[0]
+                    }
                 | p_kwrest
                     {
                       result = val[0]

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -8678,6 +8678,18 @@ class TestParser < Minitest::Test
     assert_parses_pattern_match(
       s(:in_pattern,
         s(:hash_pattern,
+          s(:pair, s(:sym, :a), s(:int, 1))),
+        nil,
+        s(:true)),
+      %q{in { a: 1, } then true},
+      %q{   ~~~~~~~~~ expression (in_pattern.hash_pattern)
+        |   ~ begin (in_pattern.hash_pattern)
+        |           ~ end (in_pattern.hash_pattern)}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
           s(:match_var, :a)),
         nil,
         s(:true)),


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@93aaa0b.

This is the following commit cherry picked from 2.8.0-dev to 2.7.1.
https://github.com/ruby/ruby/commit/d25a4f4

Closes #655.