### PR TITLE
+ ruby27.y: allow newlines inside braced pattern.

### DIFF
--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -1877,13 +1877,16 @@ opt_block_args_tail:
                 | tLBRACE
                     {
                       @pattern_hash_keys.push
+                      result = @lexer.in_kwarg
+                      @lexer.in_kwarg = false
                     }
-                  p_kwargs tRCURLY
+                  p_kwargs rbrace
                     {
                       @pattern_hash_keys.pop
+                      @lexer.in_kwarg = val[1]
                       result = @builder.hash_pattern(val[0], val[2], val[3])
                     }
-                | tLBRACE tRCURLY
+                | tLBRACE rbrace
                     {
                       result = @builder.hash_pattern(val[0], [], val[1])
                     }
@@ -2899,6 +2902,10 @@ keyword_variable: kNIL
                       result = val[1]
                     }
         rbracket: opt_nl tRBRACK
+                    {
+                      result = val[1]
+                    }
+          rbrace: opt_nl tRCURLY
                     {
                       result = val[1]
                     }

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -8758,6 +8758,67 @@ class TestParser < Minitest::Test
       %q{in a: 1, _a:, ** then true},
       %q{   ~~~~~~~~~~~~~ expression (in_pattern.hash_pattern)}
     )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:pair,
+            s(:sym, :a),
+            s(:int, 1))), nil,
+        s(:false)),
+      %q{
+        in {a: 1
+        }
+          false
+      },
+      %q{}
+    )
+
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:pair,
+            s(:sym, :a),
+            s(:int, 2))), nil,
+        s(:false)),
+      %q{
+        in {a:
+              2}
+          false
+      },
+      %q{}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:pair,
+            s(:sym, :a),
+            s(:hash_pattern,
+              s(:match_var, :b))),
+          s(:match_var, :c)), nil,
+        s(:send, nil, :p,
+          s(:lvar, :c))),
+      %q{
+        in a: {b:}, c:
+          p c
+      },
+      %q{}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:match_var, :a)), nil,
+        s(:true)),
+      %q{
+        in {a:
+        }
+          true
+      },
+      %q{}
+    )
   end
 
   def test_pattern_matching_hash_with_string_keys


### PR DESCRIPTION
This commit tracks upstream commits ruby/ruby@f5c904c and ruby/ruby@c8d0bf0
that have been cherry-picked in 2.7.1 (ruby/ruby@004c298 and ruby/ruby@44f7e38)

Closes https://github.com/whitequark/parser/issues/656