### PR TITLE
* Bump ruby versions to 2.4.10, 2.5.8, 2.6.6, 2.7.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ dist: trusty
 language: ruby
 matrix:
   include:
-    - name: 2.4.10 / Parser tests
-      rvm: 2.4.10
+    - name: 2.4.9 / Parser tests
+      rvm: 2.4.9
       script: bundle exec rake test_cov
     - name: 2.5.8 / Parser tests
       rvm: 2.5.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,17 @@ dist: trusty
 language: ruby
 matrix:
   include:
-    - name: 2.0.0 / Parser tests
-      rvm: 2.0.0
+    - name: 2.4.10 / Parser tests
+      rvm: 2.4.10
       script: bundle exec rake test_cov
-    - name: 2.2.10 / Parser tests
-      rvm: 2.2.10
+    - name: 2.5.8 / Parser tests
+      rvm: 2.5.8
       script: bundle exec rake test_cov
-    - name: 2.3.8 / Parser tests
-      rvm: 2.3.8
+    - name: 2.6.6 / Parser tests
+      rvm: 2.6.6
       script: bundle exec rake test_cov
-    - name: 2.4.9 / Parser tests
-      rvm: 2.4.9
-      script: bundle exec rake test_cov
-    - name: 2.5.7 / Parser tests
-      rvm: 2.5.7
-      script: bundle exec rake test_cov
-    - name: 2.6.5 / Parser tests
-      rvm: 2.6.5
-      script: bundle exec rake test_cov
-    - name: 2.7.0 / Parser tests
-      rvm: 2.7.0
+    - name: 2.7.1 / Parser tests
+      rvm: 2.7.1
       script: bundle exec rake test_cov
     - name: ruby-head / Parser tests
       rvm: ruby-head
@@ -32,14 +23,14 @@ matrix:
     - name: rbx-2 / Parser tests
       rvm: rbx-2
       script: bundle exec rake test_cov
-    - name: 2.5.7 / Rubocop tests
-      rvm: 2.5.7
+    - name: 2.5.8 / Rubocop tests
+      rvm: 2.5.8
       script: ./ci/run_rubocop_specs
-    - name: 2.6.5 / Rubocop tests
-      rvm: 2.6.5
+    - name: 2.6.6 / Rubocop tests
+      rvm: 2.6.6
       script: ./ci/run_rubocop_specs
-    - name: 2.7.0 / Rubocop tests
-      rvm: 2.7.0
+    - name: 2.7.1 / Rubocop tests
+      rvm: 2.7.1
       script: ./ci/run_rubocop_specs
   allow_failures:
     - rvm: ruby-head

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -48,7 +48,7 @@ module Parser
     CurrentRuby = Ruby23
 
   when /^2\.4\./
-    current_version = '2.4.9'
+    current_version = '2.4.10'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby24', current_version
     end
@@ -57,7 +57,7 @@ module Parser
     CurrentRuby = Ruby24
 
   when /^2\.5\./
-    current_version = '2.5.7'
+    current_version = '2.5.8'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby25', current_version
     end
@@ -66,7 +66,7 @@ module Parser
     CurrentRuby = Ruby25
 
   when /^2\.6\./
-    current_version = '2.6.5'
+    current_version = '2.6.6'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby26', current_version
     end
@@ -75,7 +75,7 @@ module Parser
     CurrentRuby = Ruby26
 
   when /^2\.7\./
-    current_version = '2.7.0'
+    current_version = '2.7.1'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby27', current_version
     end


### PR DESCRIPTION
Not sure if travis support them.

Also removed all versions that are not longer maintained from the travis matrix.

Closes https://github.com/whitequark/parser/issues/663