### PR TITLE
Allow running without mutable strings

### DIFF
--- a/lib/parser/lexer/literal.rb
+++ b/lib/parser/lexer/literal.rb
@@ -37,6 +37,14 @@ module Parser
     attr_reader   :heredoc_e, :str_s, :dedent_level
     attr_accessor :saved_herebody_s
 
+    class << self
+      attr_writer :buffer_prototype
+
+      def buffer_prototype
+        @buffer_prototype || ''
+      end
+    end
+
     def initialize(lexer, str_type, delimiter, str_s, heredoc_e = nil,
                    indent = false, dedent_body = false, label_allowed = false)
       @lexer       = lexer
@@ -151,7 +159,7 @@ module Parser
           emit(:tLABEL_END, @end_delim, ts, te + 1)
         elsif @monolithic
           # Emit the string as a single token.
-          emit(:tSTRING, @buffer, @str_s, te)
+          emit(:tSTRING, @buffer.to_s, @str_s, te)
         else
           # If this is a heredoc, @buffer contains the sentinel now.
           # Just throw it out. Lexer flushes the heredoc after each
@@ -206,7 +214,7 @@ module Parser
       end
 
       unless @buffer.empty?
-        emit(:tSTRING_CONTENT, @buffer, @buffer_s, @buffer_e)
+        emit(:tSTRING_CONTENT, @buffer.to_s, @buffer_s, @buffer_e)
 
         clear_buffer
         extend_content
@@ -246,7 +254,7 @@ module Parser
     end
 
     def clear_buffer
-      @buffer = ''.dup
+      @buffer = self.class.buffer_prototype.dup
 
       # Prime the buffer with lexer encoding; otherwise,
       # concatenation will produce varying results.

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -3605,4 +3605,37 @@ class TestLexer < Minitest::Test
     end
   end
 
+  class StringIOBuffer < StringIO
+    def << (s)
+      super
+
+      # Yes, we need to set the encoding here and not in
+      # `force_encoding' or some tests will break (when using this
+      # alternate buffer implementation for all tests.)
+
+      set_encoding(s.encoding)
+    end
+
+    def force_encoding(encoding)
+      # see above
+    end
+
+    def empty?
+      length == 0
+    end
+
+    def to_s
+      string + '_custom_buffer' # suffix only for testing
+    end
+  end
+
+  def test_alternate_string_buffer
+    begin
+      Parser::Lexer::Literal.buffer_prototype = StringIOBuffer.new
+
+      assert_escape "\x09_custom_buffer", 'u{9}'
+    ensure
+      Parser::Lexer::Literal.buffer_prototype = nil
+    end
+  end
 end


### PR DESCRIPTION
Hi, first off, thanks for this exceptionally well-made piece of software.

I need to run it in a project that gets converted to JavaScript via [Opal](https://github.com/opal/opal). Opal doesn't support mutable strings, which breaks here: https://github.com/whitequark/parser/blob/fad6bd2ecfb4877d52a313420a07d0fd8a36dcb7/lib/parser/lexer/literal.rb#L199

I've tried finding an alternate buffer implementation that works without mutable strings, passes all tests, and still performs reasonably well. I've succeeded in the first two points with something based on StringIO, but I couldn't get it faster than about 10% slower compared to the current implementation.

Now, this was measuring just the appending to and taking strings from the buffer, where only part of the overall runtime is spent. The total impact is probably more in the single percent digits, if that. I haven't bothered measuring it, since I'm conscious of the fact that compatibility with Opal is very much an edge case and so any significant performance impact, however small, feels wrong.

That's why I would like to propose this change instead. It would allow swapping out the buffer implementation for a custom one. The included test shows what that might look like.

There is an additional call to `to_s` every time a string is taken out of the buffer, but of course that is a no-op when called on String so the only overhead it adds is the method call itself. Do you agree it is negligible, all things considered?
