### PR TITLE
CI against Ruby 2.4.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ dist: trusty
 language: ruby
 matrix:
   include:
-    - name: 2.4.9 / Parser tests
-      rvm: 2.4.9
+    - name: 2.4.10 / Parser tests
+      rvm: 2.4.10
       script: bundle exec rake test_cov
     - name: 2.5.8 / Parser tests
       rvm: 2.5.8


### PR DESCRIPTION
Follow https://github.com/whitequark/parser/pull/665/commits/3274464.

Currently, Ruby 2.4.10 is available on Travis CI.
https://travis-ci.community/t/cannot-find-ruby-2-4-10-and-2-6-6-using-rvm-ubuntu-16-04-xenial/7962