### PR TITLE
- ruby27.y: reject invalid lvar in pattern matching

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1239,8 +1239,10 @@ module Parser
 
     def match_var(name_t)
       name = value(name_t).to_sym
+      name_l = loc(name_t)
 
-      check_duplicate_pattern_variable(name, loc(name_t))
+      check_lvar_name(name, name_l)
+      check_duplicate_pattern_variable(name, name_l)
       @parser.static_env.declare(name)
 
       n(:match_var, [ name ],
@@ -1253,6 +1255,7 @@ module Parser
       expr_l = loc(name_t)
       name_l = expr_l.adjust(end_pos: -1)
 
+      check_lvar_name(name, name_l)
       check_duplicate_pattern_variable(name, name_l)
       @parser.static_env.declare(name)
 

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1293,6 +1293,9 @@ module Parser
           Source::Map::Variable.new(name_l, expr_l))
       when :begin
         match_hash_var_from_str(begin_t, string.children, end_t)
+      else
+        # we only can get here if there is an interpolation, e.g., ``in "#{ a }":`
+        diagnostic :error, :pm_interp_in_var_name, nil, loc(begin_t).join(loc(end_t))
       end
     end
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -8934,6 +8934,13 @@ class TestParser < Minitest::Test
       %q{           ~~~~~~~ location},
       SINCE_2_7
     )
+
+    assert_diagnoses(
+      [:error, :pm_interp_in_var_name],
+      %q{case a; in "#{a}": 1; end},
+      %q{           ~~~~~~~ location},
+      SINCE_2_7
+    )
   end
 
   def test_pattern_matching_keyword_variable

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -8943,6 +8943,15 @@ class TestParser < Minitest::Test
     )
   end
 
+  def test_pattern_matching_invalid_lvar_name
+    assert_diagnoses(
+      [:error, :lvar_name, { name: :a? }],
+      %q{case a; in a?:; end},
+      %q{           ~~ location},
+      SINCE_2_7
+    )
+  end
+
   def test_pattern_matching_keyword_variable
     assert_parses_pattern_match(
       s(:in_pattern,


### PR DESCRIPTION
- [x] Added lvar name check for all `match_var` (https://github.com/ruby/ruby/blob/501f2c44e6ae79c02a5c4d0f872fc7fa77258fcf/test/ruby/test_pattern_matching.rb#L1032-L1036)

- [x] Fixed strings interpolation check (https://github.com/ruby/ruby/blob/501f2c44e6ae79c02a5c4d0f872fc7fa77258fcf/test/ruby/test_pattern_matching.rb#L1092-L1097)