### PR TITLE
rectify multiple assignment example

### DIFF
--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -637,7 +637,7 @@ Format:
 (masgn (mlhs (ivasgn :@a) (cvasgn :@@b)) (array (splat (lvar :c))))
 "@a, @@b = *c"
 
-(masgn (mlhs (mlhs (lvasgn :a) (lvasgn :b)) (lvasgn :c)) (lvar :d))
+(masgn (mlhs (lvasgn :a) (mlhs (lvasgn :b)) (lvasgn :c)) (lvar :d))
 "a, (b, c) = d"
 
 (masgn (mlhs (send (self) :a=) (send (self) :[]= (int 1))) (lvar :a))


### PR DESCRIPTION
The commit corrects an example in [AST format document](https://github.com/whitequark/parser/blob/master/doc/AST_FORMAT.md) in the "Multiple Assignment" section.