### PR TITLE
Rewriter optimizations

### DIFF
--- a/lib/parser/source/tree_rewriter.rb
+++ b/lib/parser/source/tree_rewriter.rb
@@ -221,20 +221,17 @@ module Parser
       #
       # @return [String]
       #
-      def process
-        source     = @source_buffer.source.dup
-        adjustment = 0
+     def process
+        source     = @source_buffer.source
 
+        chunks = []
+        last_end = 0
         @action_root.ordered_replacements.each do |range, replacement|
-          begin_pos = range.begin_pos + adjustment
-          end_pos   = begin_pos + range.length
-
-          source[begin_pos...end_pos] = replacement
-
-          adjustment += replacement.length - range.length
+          chunks << source[last_end...range.begin_pos] << replacement
+          last_end = range.end_pos
         end
-
-        source
+        chunks << source[last_end...source.length]
+        chunks.join
       end
 
       ##

--- a/test/test_source_tree_rewriter.rb
+++ b/test/test_source_tree_rewriter.rb
@@ -151,6 +151,16 @@ DIAGNOSTIC
                             [:wrap, @hello, '[', ']']]
   end
 
+  def test_inserts_on_empty_ranges
+    assert_actions_result 'puts({x}:hello[y], :world)',
+      [:insert_before, @hello.begin, '{'],
+      [:replace, @hello.begin, 'x'],
+      [:insert_after, @hello.begin, '}'],
+      [:insert_before, @hello.end, '['],
+      [:replace, @hello.end, 'y'],
+      [:insert_after, @hello.end, ']']
+  end
+
   def test_replace_same_range
     assert_actions_result 'puts(:hey, :world)',
                            [[:replace, @hello, ':hi'],


### PR DESCRIPTION
This PR contains two independent optimizations for the `Source::TreeRewriter`.

The first one changes building the tree from `O(n^2)` to `O(n log(n))` where `n` is the number of rewriting actions.

The second one is of lesser importance and changes applying the tree from `O(n * s)` to `O(n + s)`, where `s` is the length of the source.

While I doubt users of `RuboCop` will notice the speedup but this will make a big difference for the conversion and annotation of source files into HTML by `DeepCover` which was ridiculously slow for long source files.