### PR TITLE
* fixed all warnings. tests are running in verbose mode now.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,5 @@ matrix:
     - rvm: rbx-2
     - script: ./ci/run_rubocop_specs
 before_install:
-  - gem install bundler -v '< 2'
   - bundle --version
   - gem --version

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ task :default => [:test]
 Rake::TestTask.new do |t|
   t.libs       = %w(test/ lib/)
   t.test_files = FileList["test/**/test_*.rb"]
-  t.warning    = false
+  t.warning    = true
 end
 
 task :test_cov do

--- a/lib/parser/diagnostic.rb
+++ b/lib/parser/diagnostic.rb
@@ -67,7 +67,7 @@ module Parser
     # @return [String] the rendered message.
     #
     def message
-      Messages.format(@reason, @arguments)
+      Messages.compile(@reason, @arguments)
     end
 
     ##

--- a/lib/parser/diagnostic.rb
+++ b/lib/parser/diagnostic.rb
@@ -67,7 +67,7 @@ module Parser
     # @return [String] the rendered message.
     #
     def message
-      MESSAGES[@reason] % @arguments
+      Messages.format(@reason, @arguments)
     end
 
     ##

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -284,7 +284,7 @@ class Parser::Lexer
     # %
 
     # Ragel creates a local variable called `testEof` but it doesn't use
-    # it any assignment. This dead code is here to swallow the warning.
+    # it in any assignment. This dead code is here to swallow the warning.
     # It has no runtime cost because Ruby doesn't produce any instructions from it.
     if false
       testEof

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -283,6 +283,13 @@ class Parser::Lexer
     %% write exec;
     # %
 
+    # Ragel creates a local variable called `testEof` but it doesn't use
+    # it any assignment. This dead code is here to swallow the warning.
+    # It has no runtime cost because Ruby doesn't produce any instructions from it.
+    if false
+      testEof
+    end
+
     @p = p
 
     if @token_queue.any?

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -98,14 +98,14 @@ module Parser
   module Messages
     # Formats the message, returns a raw template if there's nothing to interpolate
     #
-    # Code like `"" % {}` gives a warning, and so this method tries interpolating
+    # Code like `format("", {})` gives a warning, and so this method tries interpolating
     # only if `arguments` hash is not empty.
     #
     # @api private
-    def self.format(reason, arguments)
+    def self.compile(reason, arguments)
       template = MESSAGES[reason]
       return template if Hash === arguments && arguments.empty?
-      template % arguments
+      format(template, arguments)
     end
   end
 end

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -93,4 +93,19 @@ module Parser
     :crossing_insertions           => 'the rewriting action on:',
     :crossing_insertions_conflict  => 'is crossing that on:',
   }.freeze
+
+  # @api private
+  module Messages
+    # Formats the message, returns a raw template if there's nothing to interpolate
+    #
+    # Code like `"" % {}` gives a warning, and so this method tries interpolating
+    # only if `arguments` hash is not empty.
+    #
+    # @api private
+    def self.format(reason, arguments)
+      template = MESSAGES[reason]
+      return template if Hash === arguments && arguments.empty?
+      template % arguments
+    end
+  end
 end

--- a/lib/parser/source/tree_rewriter.rb
+++ b/lib/parser/source/tree_rewriter.rb
@@ -221,7 +221,7 @@ module Parser
       #
       # @return [String]
       #
-     def process
+      def process
         source     = @source_buffer.source
 
         chunks = []

--- a/parser.gemspec
+++ b/parser.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency             'ast',       '~> 2.4.0'
 
   spec.add_development_dependency 'bundler',   '>= 1.15', '< 3.0.0'
-  spec.add_development_dependency 'rake',      '~> 10.0'
+  spec.add_development_dependency 'rake',      '~> 13.0.1'
   spec.add_development_dependency 'racc',      '= 1.4.15'
   spec.add_development_dependency 'cliver',    '~> 0.3.2'
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'tempfile'
-require 'minitest/test'
-
 require 'simplecov'
 
 if ENV.include?('COVERAGE') && SimpleCov.usable?
@@ -28,9 +26,9 @@ if ENV.include?('COVERAGE') && SimpleCov.usable?
   at_exit { RaccCoverage.stop }
 
   SimpleCov.start do
-    self.formatter = SimpleCov::Formatter::MultiFormatter[
-      SimpleCov::Formatter::HTMLFormatter,
-    ]
+    self.formatter = SimpleCov::Formatter::MultiFormatter.new(
+      SimpleCov::Formatter::HTMLFormatter
+    )
 
     add_group 'Grammars' do |source_file|
       source_file.filename =~ %r{\.y$}

--- a/test/parse_helper.rb
+++ b/test/parse_helper.rb
@@ -159,7 +159,7 @@ module ParseHelper
 
       level, reason, arguments = diagnostic
       arguments ||= {}
-      message     = Parser::Messages.format(reason, arguments)
+      message     = Parser::Messages.compile(reason, arguments)
 
       assert_equal level, emitted_diagnostic.level
       assert_equal reason, emitted_diagnostic.reason
@@ -214,7 +214,7 @@ module ParseHelper
       diagnostics.zip(@diagnostics) do |expected_diagnostic, actual_diagnostic|
         level, reason, arguments = expected_diagnostic
         arguments ||= {}
-        message     = Parser::Messages.format(reason, arguments)
+        message     = Parser::Messages.compile(reason, arguments)
 
         assert_equal level, actual_diagnostic.level
         assert_equal reason, actual_diagnostic.reason

--- a/test/parse_helper.rb
+++ b/test/parse_helper.rb
@@ -106,8 +106,7 @@ module ParseHelper
     assert_equal ast, parsed_ast,
                  "(#{version}) AST equality"
 
-    parse_source_map_descriptions(source_maps) \
-        do |begin_pos, end_pos, map_field, ast_path, line|
+    parse_source_map_descriptions(source_maps) do |begin_pos, end_pos, map_field, ast_path, line|
 
       astlet = traverse_ast(parsed_ast, ast_path)
 
@@ -160,15 +159,14 @@ module ParseHelper
 
       level, reason, arguments = diagnostic
       arguments ||= {}
-      message     = Parser::MESSAGES[reason] % arguments
+      message     = Parser::Messages.format(reason, arguments)
 
       assert_equal level, emitted_diagnostic.level
       assert_equal reason, emitted_diagnostic.reason
       assert_equal arguments, emitted_diagnostic.arguments
       assert_equal message, emitted_diagnostic.message
 
-      parse_source_map_descriptions(source_maps) \
-          do |begin_pos, end_pos, map_field, ast_path, line|
+      parse_source_map_descriptions(source_maps) do |begin_pos, end_pos, map_field, ast_path, line|
 
         case map_field
         when 'location'
@@ -216,7 +214,7 @@ module ParseHelper
       diagnostics.zip(@diagnostics) do |expected_diagnostic, actual_diagnostic|
         level, reason, arguments = expected_diagnostic
         arguments ||= {}
-        message     = Parser::MESSAGES[reason] % arguments
+        message     = Parser::Messages.format(reason, arguments)
 
         assert_equal level, actual_diagnostic.level
         assert_equal reason, actual_diagnostic.reason

--- a/test/test_diagnostic.rb
+++ b/test/test_diagnostic.rb
@@ -16,7 +16,7 @@ class TestDiagnostic < Minitest::Test
       Parser::Diagnostic.new(:foobar, :escape_eof, {}, @range1)
     end
 
-    assert_match /level/, error.message
+    assert_match(/level/, error.message)
   end
 
   def test_freezes

--- a/test/test_diagnostic_engine.rb
+++ b/test/test_diagnostic_engine.rb
@@ -4,9 +4,6 @@ require 'helper'
 
 class TestDiagnosticEngine < Minitest::Test
   def setup
-    @buffer  = Parser::Source::Buffer.new('(source)')
-    @buffer.source = 'foobar'
-
     @engine = Parser::Diagnostic::Engine.new
 
     @queue  = []
@@ -14,7 +11,7 @@ class TestDiagnosticEngine < Minitest::Test
   end
 
   def test_process_warnings
-    warn = Parser::Diagnostic.new(:warning, :invalid_escape, @buffer, 1..2)
+    warn = Parser::Diagnostic.new(:warning, :invalid_escape, {}, 1..2)
     @engine.process(warn)
 
     assert_equal [warn], @queue
@@ -23,7 +20,7 @@ class TestDiagnosticEngine < Minitest::Test
   def test_ignore_warnings
     @engine.ignore_warnings = true
 
-    warn = Parser::Diagnostic.new(:warning, :invalid_escape, @buffer, 1..2)
+    warn = Parser::Diagnostic.new(:warning, :invalid_escape, {}, 1..2)
     @engine.process(warn)
 
     assert_equal [], @queue
@@ -32,7 +29,7 @@ class TestDiagnosticEngine < Minitest::Test
   def test_all_errors_are_fatal
     @engine.all_errors_are_fatal = true
 
-    error = Parser::Diagnostic.new(:error, :invalid_escape, @buffer, 1..2)
+    error = Parser::Diagnostic.new(:error, :invalid_escape, {}, 1..2)
 
     err = assert_raises Parser::SyntaxError do
       @engine.process(error)
@@ -44,14 +41,14 @@ class TestDiagnosticEngine < Minitest::Test
   end
 
   def test_all_errors_are_collected
-    error = Parser::Diagnostic.new(:error, :invalid_escape, @buffer, 1..2)
+    error = Parser::Diagnostic.new(:error, :invalid_escape, {}, 1..2)
     @engine.process(error)
 
     assert_equal [error], @queue
   end
 
   def test_fatal_error
-    fatal = Parser::Diagnostic.new(:fatal, :invalid_escape, @buffer, 1..2)
+    fatal = Parser::Diagnostic.new(:fatal, :invalid_escape, {}, 1..2)
 
     assert_raises Parser::SyntaxError do
       @engine.process(fatal)

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -3606,7 +3606,7 @@ class TestLexer < Minitest::Test
 
   def refute_scanned_numbered_parameter(input, message = nil)
     err = assert_raises Parser::SyntaxError do
-      lex_token, (lex_value, lex_range) = lex_numbered_parameter(input)
+      _lex_token, (_lex_value, _lex_range) = lex_numbered_parameter(input)
     end
 
     if message

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -9238,7 +9238,7 @@ class TestParser < Minitest::Test
       before = parser.static_env.instance_variable_get(:@variables).to_a
 
       begin
-        parsed_ast = parser.parse(source_file)
+        _parsed_ast = parser.parse(source_file)
       rescue Parser::SyntaxError => exc
         backtrace = exc.backtrace
         Exception.instance_method(:initialize).bind(exc).

--- a/test/test_runner_parse.rb
+++ b/test/test_runner_parse.rb
@@ -7,7 +7,7 @@ class TestRunnerParse < Minitest::Test
   PATH_TO_RUBY_PARSE = File.expand_path('../bin/ruby-parse', __dir__).freeze
 
   def assert_prints(argv, expected_output)
-    stdout, stderr, status = Open3.capture3(PATH_TO_RUBY_PARSE, *argv)
+    stdout, _stderr, status = Open3.capture3(PATH_TO_RUBY_PARSE, *argv)
 
     assert_equal 0, status.to_i
     assert_includes(stdout, expected_output)

--- a/test/test_runner_rewrite.rb
+++ b/test/test_runner_rewrite.rb
@@ -21,7 +21,7 @@ class TestRunnerRewrite < Minitest::Test
       expected_file = @fixtures_dir + output
 
       FileUtils.cp(@fixtures_dir + input, sample_file_expanded)
-      stdout, stderr, exit_code = Dir.chdir @test_dir do
+      stdout, stderr, _exit_code = Dir.chdir @test_dir do
         Open3.capture3 %Q{
           #{Shellwords.escape(@ruby_rewrite.to_s)} #{args} \
           #{Shellwords.escape(sample_file_expanded.to_s)}

--- a/test/test_source_buffer.rb
+++ b/test/test_source_buffer.rb
@@ -45,7 +45,7 @@ class TestSourceBuffer < Minitest::Test
       ].join("\n")
     end
 
-    assert_match /invalid byte sequence in UTF\-8/, error.message
+    assert_match(/invalid byte sequence in UTF\-8/, error.message)
   end
 
   def test_read

--- a/test/test_source_comment_associator.rb
+++ b/test/test_source_comment_associator.rb
@@ -95,7 +95,7 @@ class Foo
 end
     END
 
-    klass_node         = ast
+    _klass_node        = ast
     method_node        = ast.children[2]
     body               = method_node.children[2]
     f1_1_node          = body.children[0]
@@ -175,7 +175,7 @@ class Foo
 end
     END
 
-    klass_node         = ast
+    _klass_node        = ast
     method_node        = ast.children[2]
     body               = method_node.children[2]
     f1_1_node          = body.children[0]
@@ -201,12 +201,12 @@ end
   end
 
   def test_associate_empty_tree
-    ast, associations = associate("")
+    _ast, associations = associate("")
     assert_equal 0, associations.size
   end
 
   def test_associate_shebang_only
-    ast, associations = associate(<<-END)
+    _ast, associations = associate(<<-END)
 #!ruby
 class Foo
 end
@@ -216,7 +216,7 @@ end
   end
 
   def test_associate_frozen_string_literal
-    ast, associations = associate(<<-END)
+    _ast, associations = associate(<<-END)
 # frozen_string_literal: true
 class Foo
 end
@@ -226,7 +226,7 @@ end
   end
 
   def test_associate_frozen_string_literal_dash_star_dash
-    ast, associations = associate(<<-END)
+    _ast, associations = associate(<<-END)
 # -*- frozen_string_literal: true -*-
 class Foo
 end
@@ -236,7 +236,7 @@ end
   end
 
   def test_associate_frozen_string_literal_no_space_after_colon
-    ast, associations = associate(<<-END)
+    _ast, associations = associate(<<-END)
 # frozen_string_literal:true
 class Foo
 end
@@ -246,7 +246,7 @@ end
   end
 
   def test_associate_warn_indent
-    ast, associations = associate(<<-END)
+    _ast, associations = associate(<<-END)
 # warn_indent: true
 class Foo
 end
@@ -256,7 +256,7 @@ end
   end
 
   def test_associate_warn_indent_dash_star_dash
-    ast, associations = associate(<<-END)
+    _ast, associations = associate(<<-END)
 # -*- warn_indent: true -*-
 class Foo
 end
@@ -266,7 +266,7 @@ end
   end
 
   def test_associate_warn_past_scope
-    ast, associations = associate(<<-END)
+    _ast, associations = associate(<<-END)
 # warn_past_scope: true
 class Foo
 end
@@ -276,7 +276,7 @@ end
   end
 
   def test_associate_warn_past_scope_dash_star_dash
-    ast, associations = associate(<<-END)
+    _ast, associations = associate(<<-END)
 # -*- warn_past_scope: true -*-
 class Foo
 end
@@ -286,7 +286,7 @@ end
   end
 
   def test_associate_multiple
-    ast, associations = associate(<<-END)
+    _ast, associations = associate(<<-END)
 # frozen_string_literal: true; warn_indent: true
 class Foo
 end
@@ -296,7 +296,7 @@ end
   end
 
   def test_associate_multiple_dash_star_dash
-    ast, associations = associate(<<-END)
+    _ast, associations = associate(<<-END)
 # -*- frozen_string_literal: true; warn_indent: true -*-
 class Foo
 end
@@ -306,7 +306,7 @@ end
   end
 
   def test_associate_no_comments
-    ast, associations = associate(<<-END)
+    _ast, associations = associate(<<-END)
 class Foo
 end
     END
@@ -315,7 +315,7 @@ end
   end
 
   def test_associate_comments_after_root_node
-    ast, associations = associate(<<-END)
+    _ast, associations = associate(<<-END)
 class Foo
 end
 # not associated

--- a/test/test_source_range.rb
+++ b/test/test_source_range.rb
@@ -95,15 +95,15 @@ class TestSourceRange < Minitest::Test
 
   def test_order
     assert_equal  0, @sr1_3 <=> @sr1_3
-    assert_equal -1, @sr1_3 <=> @sr5_8
-    assert_equal -1, @sr2_2 <=> @sr2_6
-    assert_equal +1, @sr2_6 <=> @sr2_2
+    assert_equal(-1, @sr1_3 <=> @sr5_8)
+    assert_equal(-1, @sr2_2 <=> @sr2_6)
+    assert_equal(+1, @sr2_6 <=> @sr2_2)
 
-    assert_equal -1, @sr1_3 <=> @sr2_6
+    assert_equal(-1, @sr1_3 <=> @sr2_6)
 
-    assert_equal +1, @sr2_2 <=> @sr1_3
-    assert_equal -1, @sr1_3 <=> @sr2_2
-    assert_equal -1, @sr5_7 <=> @sr5_8
+    assert_equal(+1, @sr2_2 <=> @sr1_3)
+    assert_equal(-1, @sr1_3 <=> @sr2_2)
+    assert_equal(-1, @sr5_7 <=> @sr5_8)
 
     assert_nil @sr1_3 <=> Parser::Source::Range.new(@buf.dup, 1, 3)
     assert_nil @sr1_3 <=> 4

--- a/test/test_source_rewriter.rb
+++ b/test/test_source_rewriter.rb
@@ -522,7 +522,7 @@ class TestSourceRewriter < Minitest::Test
       end
     end
 
-    assert_match /nested/i, error.message
+    assert_match(/nested/i, error.message)
   end
 
   def test_process_in_transaction_raises_error
@@ -532,7 +532,7 @@ class TestSourceRewriter < Minitest::Test
       end
     end
 
-    assert_match /transaction/, error.message
+    assert_match(/transaction/, error.message)
   end
 
   def silence_diagnostics

--- a/test/test_source_tree_rewriter.rb
+++ b/test/test_source_tree_rewriter.rb
@@ -36,7 +36,7 @@ class TestSourceTreeRewriter < Minitest::Test
     else
       diags.call
     end
-  rescue ::Parser::ClobberingError => e
+  rescue ::Parser::ClobberingError => _e
     [::Parser::ClobberingError, diags.call]
   end
 


### PR DESCRIPTION
1. added `if false; testEof; end` at the bottom of `Lexer#advance` to prevent warnings about unused variable `testEof`. It has 0 runtime cost.
2. fixed formatting in a few places
3. changed test task definition to run tests in verbose mode (like `ruby -w` would do)
4. For some reason `"" % {}` gives a warning (same with `Kernel#sprintf`, no idea why). Added a utility method to perform interpolation on messages only if there's something to interpolate.
5. added parentheses to all `m /regex/` calls
6. added `_` prefix to unused variables.

I'm getting 0 warnings locally when running `rake test`/`rake test_cov`

Closes https://github.com/whitequark/parser/issues/684