### PR TITLE
Add argument_error to parser messages hash

### DIFF
--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -45,6 +45,7 @@ module Parser
     :invalid_assignment           => 'cannot assign to a keyword',
     :module_name_const            => 'class or module name must be a constant literal',
     :unexpected_token             => 'unexpected token %{token}',
+    :argument_error               => '%{message}',
     :argument_const               => 'formal argument cannot be a constant',
     :argument_ivar                => 'formal argument cannot be an instance variable',
     :argument_gvar                => 'formal argument cannot be a global variable',


### PR DESCRIPTION
Essentially a duplicate of the `:invalid_regexp` message, yielding the raw message text with no accompanying text. Allows to creating a Diagnostic for an ArgumentError.

```
ArgumentError: wrong number of arguments (given 0, expected 1)
```

```ruby
begin
  # ...
rescue ArgumentError => e
  Parser::Diagnostic.new(
    :error,
    :argument_error,
    {
      message: e.message,
    },
    node.location.expression,
  )
end
```