### PR TITLE
- fix Comment.associate for postfix conditions/loops

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -51,9 +51,29 @@ require 'minitest/autorun'
 $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 require 'parser'
 
+module NodeCollector
+  extend self
+  attr_accessor :callbacks, :nodes
+  self.callbacks = []
+  self.nodes = []
+
+  def check
+    @callbacks.each do |callback|
+      @nodes.each { |node| callback.call(node) }
+    end
+    puts "#{callbacks.size} additional tests on #{nodes.size} nodes ran successfully"
+  end
+
+  Minitest.after_run { check }
+end
+
+def for_each_node(&block)
+  NodeCollector.callbacks << block
+end
+
 class Parser::AST::Node
   def initialize(type, *)
-    raise "Type #{type} missing from Parser::Meta::NODE_TYPES" unless Parser::Meta::NODE_TYPES.include?(type)
+    NodeCollector.nodes << self
     super
   end
 end

--- a/test/test_meta.rb
+++ b/test/test_meta.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'helper'
+
+class TestMeta < Minitest::Test
+  def test_NODE_TYPES
+    for_each_node do |node|
+      assert Parser::Meta::NODE_TYPES.include?(node.type),
+            "Type #{node.type} missing from Parser::Meta::NODE_TYPES"
+    end
+  end
+end


### PR DESCRIPTION
and also any node with children in inverted order.

See test file for example.

An faster alternative solution would be to instead figure out which nodes might have such a situation and visit them accordingly (are there any other than postfix `if/unless/while`?), but this slower solution seemed the most robust.