### PR TITLE
Allow creating of Buffer with source

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ Parse a chunk of code and display all diagnostics:
       puts diag.render
     end
 
-    buffer = Parser::Source::Buffer.new('(string)')
-    buffer.source = "foo *bar"
+    buffer = Parser::Source::Buffer.new('(string)', source: "foo *bar")
 
     p parser.parse(buffer)
     # (string):1:5: warning: `*' interpreted as argument prefix

--- a/lib/parser/diagnostic/engine.rb
+++ b/lib/parser/diagnostic/engine.rb
@@ -7,8 +7,7 @@ module Parser
   # diagnostics by delegating them to registered consumers.
   #
   # @example
-  #  buffer      = Parser::Source::Buffer.new(__FILE__)
-  #  buffer.code = 'foobar'
+  #  buffer      = Parser::Source::Buffer.new(__FILE__, source: 'foobar')
   #
   #  consumer = lambda do |diagnostic|
   #    puts diagnostic.message

--- a/lib/parser/runner/ruby_rewrite.rb
+++ b/lib/parser/runner/ruby_rewrite.rb
@@ -55,8 +55,8 @@ module Parser
         new_source = rewriter.rewrite(buffer, ast)
 
         new_buffer = Source::Buffer.new(initial_buffer.name +
-                                    '|after ' + rewriter_class.name)
-        new_buffer.source = new_source
+                                    '|after ' + rewriter_class.name,
+                                    source: new_source)
 
         @parser.reset
         new_ast = @parser.parse(new_buffer)

--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -102,7 +102,7 @@ module Parser
         end
       end
 
-      def initialize(name, first_line = 1)
+      def initialize(name, first_line = 1, source: nil)
         @name        = name.to_s
         @source      = nil
         @first_line  = first_line
@@ -116,6 +116,8 @@ module Parser
         # Cache for fast lookup
         @line_for_position   = {}
         @column_for_position = {}
+
+        self.source = source if source
       end
 
       ##

--- a/lib/parser/tree_rewriter.rb
+++ b/lib/parser/tree_rewriter.rb
@@ -28,8 +28,7 @@ module Parser
   #     EOF
   #
   #     ast           = Parser::CurrentRuby.parse code
-  #     buffer        = Parser::Source::Buffer.new('(example)')
-  #     buffer.source = code
+  #     buffer        = Parser::Source::Buffer.new('(example)', source: code)
   #     rewriter      = RemoveDo.new
   #
   #     # Rewrite the AST, returns a String with the new form.

--- a/test/parse_helper.rb
+++ b/test/parse_helper.rb
@@ -85,8 +85,7 @@ module ParseHelper
   end
 
   def try_parsing(ast, code, parser, source_maps, version)
-    source_file = Parser::Source::Buffer.new('(assert_parses)')
-    source_file.source = code
+    source_file = Parser::Source::Buffer.new('(assert_parses)', source: code)
 
     begin
       parsed_ast = parser.parse(source_file)
@@ -142,8 +141,7 @@ module ParseHelper
   # ~~~
   def assert_diagnoses(diagnostic, code, source_maps='', versions=ALL_VERSIONS)
     with_versions(versions) do |version, parser|
-      source_file = Parser::Source::Buffer.new('(assert_diagnoses)')
-      source_file.source = code
+      source_file = Parser::Source::Buffer.new('(assert_diagnoses)', source: code)
 
       begin
         parser = parser.parse(source_file)
@@ -200,8 +198,7 @@ module ParseHelper
   # ~~~
   def assert_diagnoses_many(diagnostics, code, versions=ALL_VERSIONS)
     with_versions(versions) do |version, parser|
-      source_file = Parser::Source::Buffer.new('(assert_diagnoses_many)')
-      source_file.source = code
+      source_file = Parser::Source::Buffer.new('(assert_diagnoses_many)', source: code)
 
       begin
         parser = parser.parse(source_file)
@@ -226,8 +223,7 @@ module ParseHelper
 
   def refute_diagnoses(code, versions=ALL_VERSIONS)
     with_versions(versions) do |version, parser|
-      source_file = Parser::Source::Buffer.new('(refute_diagnoses)')
-      source_file.source = code
+      source_file = Parser::Source::Buffer.new('(refute_diagnoses)', source: code)
 
       begin
         parser = parser.parse(source_file)
@@ -243,8 +239,7 @@ module ParseHelper
 
   def assert_context(context, code, versions=ALL_VERSIONS)
     with_versions(versions) do |version, parser|
-      source_file = Parser::Source::Buffer.new('(assert_context)')
-      source_file.source = code
+      source_file = Parser::Source::Buffer.new('(assert_context)', source: code)
 
       begin
         parser.parse(source_file)

--- a/test/test_diagnostic.rb
+++ b/test/test_diagnostic.rb
@@ -4,8 +4,8 @@ require 'helper'
 
 class TestDiagnostic < Minitest::Test
   def setup
-    @buffer = Parser::Source::Buffer.new('(string)')
-    @buffer.source = 'if (this is some bad code + bugs)'
+    @buffer = Parser::Source::Buffer.new('(string)',
+      source: 'if (this is some bad code + bugs)')
 
     @range1 = Parser::Source::Range.new(@buffer, 0, 2) # if
     @range2 = Parser::Source::Range.new(@buffer, 4, 8) # this
@@ -50,8 +50,8 @@ class TestDiagnostic < Minitest::Test
   end
 
   def test_multiline_render
-    @buffer = Parser::Source::Buffer.new('(string)')
-    @buffer.source = "abc abc abc\ndef def def\nghi ghi ghi\n"
+    @buffer = Parser::Source::Buffer.new('(string)',
+      source: "abc abc abc\ndef def def\nghi ghi ghi\n")
 
     location = Parser::Source::Range.new(@buffer, 4, 27)
 
@@ -80,8 +80,7 @@ class TestDiagnostic < Minitest::Test
   }
 }
     CODE
-    @buffer = Parser::Source::Buffer.new('(string)')
-    @buffer.source = source
+    @buffer = Parser::Source::Buffer.new('(string)', source: source)
 
     location = Parser::Source::Range.new(@buffer, 33, 34)
     diag = Parser::Diagnostic.new(:error, :unexpected_token, { :token => 'tNL' },

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -37,9 +37,8 @@ class TestLexer < Minitest::Test
   end
 
   def assert_escape(expected, input)
-    source_buffer = Parser::Source::Buffer.new('(assert_escape)')
-
-    source_buffer.source = "\"\\#{input}\"".encode(input.encoding)
+    source_buffer = Parser::Source::Buffer.new('(assert_escape)',
+      source: "\"\\#{input}\"".encode(input.encoding))
 
     @lex.reset
     @lex.source_buffer = source_buffer
@@ -71,8 +70,7 @@ class TestLexer < Minitest::Test
   end
 
   def assert_scanned(input, *args)
-    source_buffer = Parser::Source::Buffer.new('(assert_scanned)')
-    source_buffer.source = input
+    source_buffer = Parser::Source::Buffer.new('(assert_scanned)', source: input)
 
     @lex.reset(false)
     @lex.source_buffer = source_buffer
@@ -3587,8 +3585,7 @@ class TestLexer < Minitest::Test
     @lex.context = Parser::Context.new
     @lex.context.push(:block)
 
-    source_buffer = Parser::Source::Buffer.new('(assert_lex_numbered_parameter)')
-    source_buffer.source = input
+    source_buffer = Parser::Source::Buffer.new('(assert_lex_numbered_parameter)', source: input)
 
     @lex.source_buffer = source_buffer
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -5360,8 +5360,7 @@ class TestParser < Minitest::Test
 
   def test_crlf_line_endings
     with_versions(ALL_VERSIONS) do |_ver, parser|
-      source_file = Parser::Source::Buffer.new('(comments)')
-      source_file.source = "\r\nfoo"
+      source_file = Parser::Source::Buffer.new('(comments)', source: "\r\nfoo")
 
       range = lambda do |from, to|
         Parser::Source::Range.new(source_file, from, to)
@@ -5434,8 +5433,7 @@ class TestParser < Minitest::Test
     with_versions(ALL_VERSIONS) do |_ver, parser|
       parser.builder.emit_file_line_as_literals = false
 
-      source_file = Parser::Source::Buffer.new('(comments)')
-      source_file.source = "[__FILE__, __LINE__]"
+      source_file = Parser::Source::Buffer.new('(comments)', source: "[__FILE__, __LINE__]")
 
       ast = parser.parse(source_file)
 
@@ -5519,8 +5517,7 @@ class TestParser < Minitest::Test
 
   def assert_parses_with_comments(ast_pattern, source, comments_pattern)
     with_versions(ALL_VERSIONS) do |_ver, parser|
-      source_file = Parser::Source::Buffer.new('(comments)')
-      source_file.source = source
+      source_file = Parser::Source::Buffer.new('(comments)', source: source)
 
       comments_pattern_here = comments_pattern.map do |(from, to)|
         range = Parser::Source::Range.new(source_file, from, to)
@@ -5551,8 +5548,8 @@ class TestParser < Minitest::Test
 
   def test_tokenize
     with_versions(ALL_VERSIONS) do |_ver, parser|
-      source_file = Parser::Source::Buffer.new('(tokenize)')
-      source_file.source = "1 + # foo\n 2"
+      source_file = Parser::Source::Buffer.new('(tokenize)',
+        source: "1 + # foo\n 2")
 
       range = lambda do |from, to|
         Parser::Source::Range.new(source_file, from, to)
@@ -5578,8 +5575,8 @@ class TestParser < Minitest::Test
 
   def test_tokenize_recover
     with_versions(ALL_VERSIONS) do |_ver, parser|
-      source_file = Parser::Source::Buffer.new('(tokenize)')
-      source_file.source = "1 + # foo\n "
+      source_file = Parser::Source::Buffer.new('(tokenize)',
+        source: "1 + # foo\n ")
 
       range = lambda do |from, to|
         Parser::Source::Range.new(source_file, from, to)
@@ -9227,8 +9224,7 @@ class TestParser < Minitest::Test
     code = "case 1; #{match_code}; then [#{lvar_names.join(', ')}]; end"
 
     with_versions(versions) do |version, parser|
-      source_file = Parser::Source::Buffer.new('(assert_context)')
-      source_file.source = code
+      source_file = Parser::Source::Buffer.new('(assert_context)', source: code)
 
       lvar_names.each do |lvar_name|
         refute parser.static_env.declared?(lvar_name),

--- a/test/test_source_buffer.rb
+++ b/test/test_source_buffer.rb
@@ -20,6 +20,9 @@ class TestSourceBuffer < Minitest::Test
 
     buffer = Parser::Source::Buffer.new('(string)', 5)
     assert_equal 5, buffer.first_line
+
+    buffer = Parser::Source::Buffer.new('(string)', source: '2+2')
+    assert_equal '2+2', buffer.source
   end
 
   def test_source_setter

--- a/test/test_source_comment.rb
+++ b/test/test_source_comment.rb
@@ -4,8 +4,8 @@ require 'helper'
 
 class TestSourceComment < Minitest::Test
   def setup
-    @buf = Parser::Source::Buffer.new('(string)')
-    @buf.source = "# foo\n=begin foo\nbar\n=end baz\n"
+    @buf = Parser::Source::Buffer.new('(string)',
+      source: "# foo\n=begin foo\nbar\n=end baz\n")
   end
 
   def range(s, e)

--- a/test/test_source_map.rb
+++ b/test/test_source_map.rb
@@ -7,8 +7,7 @@ class TestSourceMap < Minitest::Test
   include ParseHelper
 
   def test_to_hash
-    buf = Parser::Source::Buffer.new("<input>")
-    buf.source = "1"
+    buf = Parser::Source::Buffer.new("<input>", source: "1")
     ast = parser_for_ruby_version('1.8').parse(buf)
     assert_equal [:expression, :operator], ast.loc.to_hash.keys.sort_by(&:to_s)
   end

--- a/test/test_source_range.rb
+++ b/test/test_source_range.rb
@@ -4,8 +4,8 @@ require 'helper'
 
 class TestSourceRange < Minitest::Test
   def setup
-    @buf = Parser::Source::Buffer.new('(string)')
-    @buf.source = "foobar\nbaz"
+    @buf = Parser::Source::Buffer.new('(string)',
+      source: "foobar\nbaz")
     @sr1_3 = Parser::Source::Range.new(@buf, 1, 3)
     @sr2_2 = Parser::Source::Range.new(@buf, 2, 2)
     @sr3_3 = Parser::Source::Range.new(@buf, 3, 3)
@@ -178,8 +178,8 @@ class TestSourceRange < Minitest::Test
     assert_equal true, @sr1_3.eql?(also_1_3)
     assert_equal @sr1_3.hash, also_1_3.hash
 
-    buf2 = Parser::Source::Buffer.new('(string)')
-    buf2.source = "foobar\nbaz"
+    buf2 = Parser::Source::Buffer.new('(string)',
+      source: "foobar\nbaz")
     from_other_buf = Parser::Source::Range.new(buf2, 1, 3)
     assert_equal false, @sr1_3.eql?(from_other_buf)
     assert @sr1_3.hash != from_other_buf.hash

--- a/test/test_source_rewriter.rb
+++ b/test/test_source_rewriter.rb
@@ -4,8 +4,8 @@ require 'helper'
 
 class TestSourceRewriter < Minitest::Test
   def setup
-    @buf = Parser::Source::Buffer.new('(rewriter)')
-    @buf.source = 'foo bar baz'
+    @buf = Parser::Source::Buffer.new('(rewriter)',
+      source: 'foo bar baz')
     Parser::Source::Rewriter.warned_of_deprecation = true
     @rewriter = Parser::Source::Rewriter.new(@buf)
   end

--- a/test/test_source_rewriter_action.rb
+++ b/test/test_source_rewriter_action.rb
@@ -4,8 +4,8 @@ require 'helper'
 
 class TestSourceRewriterAction < Minitest::Test
   def setup
-    @buf = Parser::Source::Buffer.new('(rewriter_action)')
-    @buf.source = 'foo bar baz'
+    @buf = Parser::Source::Buffer.new('(rewriter_action)',
+      source: 'foo bar baz')
   end
 
   def range(from, len)

--- a/test/test_source_tree_rewriter.rb
+++ b/test/test_source_tree_rewriter.rb
@@ -4,8 +4,8 @@ require 'helper'
 
 class TestSourceTreeRewriter < Minitest::Test
   def setup
-    @buf = Parser::Source::Buffer.new('(rewriter)')
-    @buf.source = 'puts(:hello, :world)'
+    @buf = Parser::Source::Buffer.new('(rewriter)',
+      source: 'puts(:hello, :world)')
 
     @hello = range(5, 6)
     @ll = range(7, 2)


### PR DESCRIPTION
I find it inconvenient that a `Source::Buffer` can not be created in one go. I feel that creation of mostly immutable objects should be, if possible, atomic.

Could we add a `source:` named parameter to the constructor of `Buffer`?