### PR TITLE
+ ruby28.y: support rescue modifier in endless method definition.

### DIFF
--- a/lib/parser/ruby28.y
+++ b/lib/parser/ruby28.y
@@ -875,10 +875,44 @@ rule
                       @context.pop
                       @current_arg_stack.pop
                     }
+                | defn_head f_paren_args tEQL arg kRESCUE_MOD arg
+                    {
+                      rescue_body = @builder.rescue_body(val[4],
+                                        nil, nil, nil,
+                                        nil, val[5])
+
+                      method_body = @builder.begin_body(val[3], [ rescue_body ])
+
+                      result = @builder.def_endless_method(*val[0],
+                                 val[1], val[2], method_body)
+
+                      @lexer.cmdarg.pop
+                      @lexer.cond.pop
+                      @static_env.unextend
+                      @context.pop
+                      @current_arg_stack.pop
+                    }
                 | defs_head f_paren_args tEQL arg
                     {
                       result = @builder.def_endless_singleton(*val[0],
                                  val[1], val[2], val[3])
+
+                      @lexer.cmdarg.pop
+                      @lexer.cond.pop
+                      @static_env.unextend
+                      @context.pop
+                      @current_arg_stack.pop
+                    }
+                | defs_head f_paren_args tEQL arg kRESCUE_MOD arg
+                    {
+                      rescue_body = @builder.rescue_body(val[4],
+                                        nil, nil, nil,
+                                        nil, val[5])
+
+                      method_body = @builder.begin_body(val[3], [ rescue_body ])
+
+                      result = @builder.def_endless_singleton(*val[0],
+                                 val[1], val[2], method_body)
 
                       @lexer.cmdarg.pop
                       @lexer.cond.pop

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -9520,6 +9520,31 @@ class TestParser < Minitest::Test
     )
   end
 
+  def test_endless_method_with_rescue_mod
+    assert_parses(
+      s(:def_e, :m,
+        s(:args),
+        s(:rescue,
+          s(:int, 1),
+          s(:resbody, nil, nil,
+            s(:int, 2)), nil)),
+      %q{def m() = 1 rescue 2},
+      %q{},
+      SINCE_2_8)
+
+    assert_parses(
+      s(:defs_e,
+        s(:self), :m,
+        s(:args),
+        s(:rescue,
+          s(:int, 1),
+          s(:resbody, nil, nil,
+            s(:int, 2)), nil)),
+      %q{def self.m() = 1 rescue 2},
+      %q{},
+      SINCE_2_8)
+  end
+
   def test_rasgn
     assert_parses(
       s(:rasgn,


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@d7d0d01.

Closes https://github.com/whitequark/parser/issues/687