### PR TITLE
+ ruby-[parse, rewrite]: add legacy switches

### DIFF
--- a/test/test_runner_parse.rb
+++ b/test/test_runner_parse.rb
@@ -18,6 +18,27 @@ class TestRunnerParse < Minitest::Test
                   's(:int, 123)'
   end
 
+  def test_emit_modern_ruby
+    assert_prints ['-e', '->{}'],
+                  '(lambda)'
+    assert_prints ['-e', 'self[1] = 2'],
+                  'indexasgn'
+  end
+
+  def test_emit_legacy
+    assert_prints ['--legacy', '-e', '->{}'],
+                  '(send nil :lambda)'
+    assert_prints ['--legacy', '-e', 'self[1] = 2'],
+                  ':[]='
+  end
+
+  def test_emit_legacy_lambda
+    assert_prints ['--legacy-lambda', '-e', '->{}'],
+                  '(send nil :lambda)'
+    assert_prints ['--legacy-lambda', '-e', 'self[1] = 2'],
+                  'indexasgn'
+  end
+
   def test_emit_json
     assert_prints ['--emit-json', '-e', '123'],
                   '["int",123]'


### PR DESCRIPTION
This PR adds switches to `ruby-parse` and `ruby-rewrite` to turn off `emit_lambda`, etc.

I thought that `--legacy` would be an easy to remember switch and also added `--legacy-lambda`, etc. just because.

Usecase: The actual AST printed / passed on to rewriter is quite important, so these switches should be available. In particular, `rubocop` [currently does not turn them on](https://github.com/rubocop-hq/rubocop-ast/issues/10), so writing/debugging cops using `ruby-parse` is much more error prone.

New help look like:
```
$ ruby-parse -h
Usage: ruby-parse [options] FILE|DIRECTORY...
        --18                         Parse as Ruby 1.8.7 would
        --19                         Parse as Ruby 1.9.3 would
        --20                         Parse as Ruby 2.0 would
        --21                         Parse as Ruby 2.1 would
        --22                         Parse as Ruby 2.2 would
        --23                         Parse as Ruby 2.3 would
        --24                         Parse as Ruby 2.4 would
        --25                         Parse as Ruby 2.5 would
        --26                         Parse as Ruby 2.6 would
        --27                         Parse as Ruby 2.7 would
        --28                         Parse as Ruby 2.8 would
        --mac                        Parse as MacRuby 0.12 would
        --ios                        Parse as mid-2015 RubyMotion would
        --legacy                     Parse with all legacy modes
        --legacy-lambda              Parse with legacy mode for emit_lambda
        --legacy-procarg0            Parse with legacy mode for emit_procarg0
        --legacy-encoding            Parse with legacy mode for emit_encoding
        --legacy-index               Parse with legacy mode for emit_index
        --legacy-arg-inside-procarg0 Parse with legacy mode for emit_arg_inside_procarg0
    -w, --warnings                   Enable warnings
    -B, --benchmark                  Benchmark the processor
    -e fragment                      Process a fragment of Ruby code
    -L, --locate                     Explain how source maps for AST nodes are laid out
    -E, --explain                    Explain how the source is tokenized
        --emit-ruby                  Emit S-expressions as valid Ruby code
        --emit-json                  Emit S-expressions as valid JSON
    -h, --help                       Display this help message and exit
    -V, --version                    Output version information and exit

  If you specify a DIRECTORY, then all *.rb files are fetched
  from it recursively and appended to the file list.

  The default parsing mode is for current Ruby (2.7.1).
```