### PR TITLE
+ Source::TreeRewriter: Improved merging and representations

### DIFF
--- a/lib/parser/source/range.rb
+++ b/lib/parser/source/range.rb
@@ -13,7 +13,7 @@ module Parser
     #        ^^
     #
     # @!attribute [r] source_buffer
-    #  @return [Parser::Diagnostic::Engine]
+    #  @return [Parser::Source::Buffer]
     #
     # @!attribute [r] begin_pos
     #  @return [Integer] index of the first character in the range

--- a/lib/parser/source/tree_rewriter.rb
+++ b/lib/parser/source/tree_rewriter.rb
@@ -261,6 +261,44 @@ module Parser
       end
 
       ##
+      # Returns a representation of the rewriter as an ordered list of replacements.
+      #
+      #     rewriter.as_replacements # => [ [1...1, '('],
+      #                                     [2...4, 'foo'],
+      #                                     [5...6, ''],
+      #                                     [6...6, '!'],
+      #                                     [10...10, ')'],
+      #                                   ]
+      #
+      # This representation is sufficient to recreate the result of `process` but it is
+      # not sufficient to recreate completely the rewriter for further merging/actions.
+      # See `as_nested_actions`
+      #
+      # @return [Array<Range, String>] an ordered list of pairs of range & replacement
+      #
+      def as_replacements
+        @action_root.ordered_replacements
+      end
+
+      ##
+      # Returns a representation of the rewriter as nested insertions (:wrap) and replacements.
+      #
+      #     rewriter.as_actions # =>[ [:wrap, 1...10, '(', ')'],
+      #                               [:wrap, 2...6, '', '!'],  # aka "insert_after"
+      #                               [:replace, 2...4, 'foo'],
+      #                               [:replace, 5...6, ''],  # aka "removal"
+      #                             ],
+      #
+      # Contrary to `as_replacements`, this representation is sufficient to recreate exactly
+      # the rewriter.
+      #
+      # @return [Array<(Symbol, Range, String{, String})>]
+      #
+      def as_nested_actions
+        @action_root.nested_actions
+      end
+
+      ##
       # Provides a protected block where a sequence of multiple rewrite actions
       # are handled atomically. If any of the actions failed by clobbering,
       # all the actions are rolled back. Transactions can be nested.

--- a/lib/parser/source/tree_rewriter.rb
+++ b/lib/parser/source/tree_rewriter.rb
@@ -129,6 +129,8 @@ module Parser
       ##
       # Merges the updates of argument with the receiver.
       # Policies of the receiver are used.
+      # This action is atomic in that it won't change the receiver
+      # unless it succeeds.
       #
       # @param [Rewriter] with
       # @return [Rewriter] self

--- a/lib/parser/source/tree_rewriter.rb
+++ b/lib/parser/source/tree_rewriter.rb
@@ -310,7 +310,7 @@ module Parser
 
       def check_range_validity(range)
         if range.begin_pos < 0 || range.end_pos > @source_buffer.source.size
-          raise IndexError, "The range #{range} is outside the bounds of the source"
+          raise IndexError, "The range #{range.to_range} is outside the bounds of the source"
         end
         range
       end

--- a/lib/parser/source/tree_rewriter/action.rb
+++ b/lib/parser/source/tree_rewriter/action.rb
@@ -50,6 +50,37 @@ module Parser
         !insert_before.empty? || !insert_after.empty? || (replacement && !replacement.empty?)
       end
 
+      ##
+      # A root action has its range set to the whole source range, even
+      # though it typically do not act on that range.
+      # This method returns the action as if it was a child action with
+      # its range contracted.
+      # @return [Action]
+      def contract
+        raise 'Empty actions can not be contracted' if empty?
+        return self if insertion?
+        range = @range.with(
+          begin_pos: children.first.range.begin_pos,
+          end_pos: children.last.range.end_pos,
+        )
+        with(range: range)
+      end
+
+      ##
+      # @return [Action] that has been moved to the given source_buffer and with the given offset
+      # No check is done on validity of resulting range.
+      def moved(source_buffer, offset)
+        moved_range = ::Parser::Source::Range.new(
+          source_buffer,
+          @range.begin_pos + offset,
+          @range.end_pos + offset
+        )
+        with(
+          range: moved_range,
+          children: children.map { |child| child.moved(source_buffer, offset) }
+        )
+      end
+
       protected
 
       attr_reader :children

--- a/lib/parser/source/tree_rewriter/action.rb
+++ b/lib/parser/source/tree_rewriter/action.rb
@@ -46,6 +46,14 @@ module Parser
         reps
       end
 
+      def nested_actions
+        actions = []
+        actions << [:wrap, @range, @insert_before, @insert_after] if !@insert_before.empty? ||
+                                                                     !@insert_after.empty?
+        actions << [:replace, @range, @replacement] if @replacement
+        actions.concat(@children.flat_map(&:nested_actions))
+      end
+
       def insertion?
         !insert_before.empty? || !insert_after.empty? || (replacement && !replacement.empty?)
       end


### PR DESCRIPTION
This PR provides `TreeRewriter` with:
* improved merging (allowing different ProcessedSource or offsetting)
* two representations of the rewriter (a basic one and a complete one)

*Background*:
I was looking at [erb-lint](https://github.com/Shopify/erb-lint) and they do some processing on some excerpts of erb files. Later, they want to combine the rewriting actions on the original erb (with an offset).
With the upcoming RuboCop 1.0 this would be tricky, and this made me realize that the two avenues I was thinking about were not available (transferring a `TreeRewriter` with an offset, or at least having a representation of the TreeRewriter so we could recreate the actions on a different source and with an offset). This PR allows both avenues.

I added a minor doc change too. Let me know if I should split this into different PRs