### PR TITLE
+ ruby28.y: extracted excessed_comma rule.

### DIFF
--- a/lib/parser/ruby28.y
+++ b/lib/parser/ruby28.y
@@ -1483,6 +1483,8 @@ opt_block_args_tail:
                       result = []
                     }
 
+  excessed_comma: tCOMMA
+
      block_param: f_arg tCOMMA f_block_optarg tCOMMA f_rest_arg              opt_block_args_tail
                     {
                       result = val[0].
@@ -1517,7 +1519,7 @@ opt_block_args_tail:
                                   concat(val[2]).
                                   concat(val[3])
                     }
-                | f_arg tCOMMA
+                | f_arg excessed_comma
                 | f_arg tCOMMA                       f_rest_arg tCOMMA f_arg opt_block_args_tail
                     {
                       result = val[0].


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@cadd224.

Closes #700

Travis is lagging - https://travis-ci.org/github/whitequark/parser/builds/696873904, the build is green