### PR TITLE
- ruby*.y: fixed context inside lambda args and module.

### DIFF
--- a/lib/parser/context.rb
+++ b/lib/parser/context.rb
@@ -5,6 +5,7 @@ module Parser
   #
   # Supported states:
   # + :class - in the class body (class A; end)
+  # + :module - in the module body (module M; end)
   # + :sclass - in the singleton class body (class << obj; end)
   # + :def - in the method body (def m; end)
   # + :defs - in the singleton method body (def self.m; end)

--- a/lib/parser/macruby.y
+++ b/lib/parser/macruby.y
@@ -1042,11 +1042,15 @@ rule
                       result      = @builder.block(val[0],
                                       begin_t, args, body, end_t)
                     }
-                | tLAMBDA lambda
+                | tLAMBDA
+                    {
+                      @context.push(:lambda)
+                    }
+                  lambda
                     {
                       lambda_call = @builder.call_lambda(val[0])
 
-                      args, (begin_t, body, end_t) = val[1]
+                      args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
                     }
@@ -1160,6 +1164,7 @@ rule
                     {
                       @static_env.extend_static
                       @lexer.push_cmdarg
+                      @context.push(:module)
                     }
                     bodystmt kEND
                     {
@@ -1172,6 +1177,7 @@ rule
 
                       @lexer.pop_cmdarg
                       @static_env.unextend
+                      @context.pop
                     }
                 | kDEF fname
                     {
@@ -1453,9 +1459,13 @@ rule
           lambda:   {
                       @static_env.extend_dynamic
                     }
-                  f_larglist lambda_body
+                  f_larglist
                     {
-                      result = [ val[1], val[2] ]
+                      @context.pop
+                    }
+                  lambda_body
+                    {
+                      result = [ val[1], val[3] ]
 
                       @static_env.unextend
                     }

--- a/lib/parser/ruby18.y
+++ b/lib/parser/ruby18.y
@@ -1156,6 +1156,7 @@ rule
                 | kMODULE cpath
                     {
                       @static_env.extend_static
+                      @context.push(:module)
                     }
                     bodystmt kEND
                     {
@@ -1167,6 +1168,7 @@ rule
                                                    val[3], val[4])
 
                       @static_env.unextend
+                      @context.pop
                     }
                 | kDEF fname
                     {

--- a/lib/parser/ruby19.y
+++ b/lib/parser/ruby19.y
@@ -1009,11 +1009,15 @@ rule
                       result      = @builder.block(val[0],
                                       begin_t, args, body, end_t)
                     }
-                | tLAMBDA lambda
+                | tLAMBDA
+                    {
+                      @context.push(:lambda)
+                    }
+                  lambda
                     {
                       lambda_call = @builder.call_lambda(val[0])
 
-                      args, (begin_t, body, end_t) = val[1]
+                      args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
                     }
@@ -1127,6 +1131,7 @@ rule
                     {
                       @static_env.extend_static
                       @lexer.push_cmdarg
+                      @context.push(:module)
                     }
                     bodystmt kEND
                     {
@@ -1139,6 +1144,7 @@ rule
 
                       @lexer.pop_cmdarg
                       @static_env.unextend
+                      @context.pop
                     }
                 | kDEF fname
                     {
@@ -1433,9 +1439,13 @@ rule
           lambda:   {
                       @static_env.extend_dynamic
                     }
-                  f_larglist lambda_body
+                  f_larglist
                     {
-                      result = [ val[1], val[2] ]
+                      @context.pop
+                    }
+                  lambda_body
+                    {
+                      result = [ val[1], val[3] ]
 
                       @static_env.unextend
                     }

--- a/lib/parser/ruby20.y
+++ b/lib/parser/ruby20.y
@@ -1039,11 +1039,15 @@ rule
                       result      = @builder.block(val[0],
                                       begin_t, args, body, end_t)
                     }
-                | tLAMBDA lambda
+                | tLAMBDA
+                    {
+                      @context.push(:lambda)
+                    }
+                  lambda
                     {
                       lambda_call = @builder.call_lambda(val[0])
 
-                      args, (begin_t, body, end_t) = val[1]
+                      args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
                     }
@@ -1157,6 +1161,7 @@ rule
                     {
                       @static_env.extend_static
                       @lexer.push_cmdarg
+                      @context.push(:module)
                     }
                     bodystmt kEND
                     {
@@ -1169,6 +1174,7 @@ rule
 
                       @lexer.pop_cmdarg
                       @static_env.unextend
+                      @context.pop
                     }
                 | kDEF fname
                     {
@@ -1487,9 +1493,13 @@ opt_block_args_tail:
           lambda:   {
                       @static_env.extend_dynamic
                     }
-                  f_larglist lambda_body
+                  f_larglist
                     {
-                      result = [ val[1], val[2] ]
+                      @context.pop
+                    }
+                  lambda_body
+                    {
+                      result = [ val[1], val[3] ]
 
                       @static_env.unextend
                     }

--- a/lib/parser/ruby21.y
+++ b/lib/parser/ruby21.y
@@ -1029,11 +1029,15 @@ rule
                       result      = @builder.block(val[0],
                                       begin_t, args, body, end_t)
                     }
-                | tLAMBDA lambda
+                | tLAMBDA
+                    {
+                      @context.push(:lambda)
+                    }
+                  lambda
                     {
                       lambda_call = @builder.call_lambda(val[0])
 
-                      args, (begin_t, body, end_t) = val[1]
+                      args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
                     }
@@ -1147,6 +1151,7 @@ rule
                     {
                       @static_env.extend_static
                       @lexer.push_cmdarg
+                      @context.push(:module)
                     }
                     bodystmt kEND
                     {
@@ -1159,6 +1164,7 @@ rule
 
                       @lexer.pop_cmdarg
                       @static_env.unextend
+                      @context.pop
                     }
                 | kDEF fname
                     {
@@ -1471,6 +1477,7 @@ opt_block_args_tail:
                     {
                       result = @lexer.cmdarg.dup
                       @lexer.cmdarg.clear
+                      @context.pop
                     }
                   lambda_body
                     {

--- a/lib/parser/ruby22.y
+++ b/lib/parser/ruby22.y
@@ -1028,11 +1028,15 @@ rule
                       result      = @builder.block(val[0],
                                       begin_t, args, body, end_t)
                     }
-                | tLAMBDA lambda
+                | tLAMBDA
+                    {
+                      @context.push(:lambda)
+                    }
+                  lambda
                     {
                       lambda_call = @builder.call_lambda(val[0])
 
-                      args, (begin_t, body, end_t) = val[1]
+                      args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
                     }
@@ -1146,6 +1150,7 @@ rule
                     {
                       @static_env.extend_static
                       @lexer.push_cmdarg
+                      @context.push(:module)
                     }
                     bodystmt kEND
                     {
@@ -1158,6 +1163,7 @@ rule
 
                       @lexer.pop_cmdarg
                       @static_env.unextend
+                      @context.pop
                     }
                 | kDEF fname
                     {
@@ -1470,6 +1476,7 @@ opt_block_args_tail:
                     {
                       result = @lexer.cmdarg.dup
                       @lexer.cmdarg.clear
+                      @context.pop
                     }
                   lambda_body
                     {

--- a/lib/parser/ruby23.y
+++ b/lib/parser/ruby23.y
@@ -1028,11 +1028,15 @@ rule
                       result      = @builder.block(val[0],
                                       begin_t, args, body, end_t)
                     }
-                | tLAMBDA lambda
+                | tLAMBDA
+                    {
+                      @context.push(:lambda)
+                    }
+                  lambda
                     {
                       lambda_call = @builder.call_lambda(val[0])
 
-                      args, (begin_t, body, end_t) = val[1]
+                      args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
                     }
@@ -1146,6 +1150,7 @@ rule
                     {
                       @static_env.extend_static
                       @lexer.push_cmdarg
+                      @context.push(:module)
                     }
                     bodystmt kEND
                     {
@@ -1158,6 +1163,7 @@ rule
 
                       @lexer.pop_cmdarg
                       @static_env.unextend
+                      @context.pop
                     }
                 | kDEF fname
                     {
@@ -1470,6 +1476,7 @@ opt_block_args_tail:
                     {
                       result = @lexer.cmdarg.dup
                       @lexer.cmdarg.clear
+                      @context.pop
                     }
                   lambda_body
                     {

--- a/lib/parser/ruby24.y
+++ b/lib/parser/ruby24.y
@@ -1047,11 +1047,15 @@ rule
                       result      = @builder.block(val[0],
                                       begin_t, args, body, end_t)
                     }
-                | tLAMBDA lambda
+                | tLAMBDA
+                    {
+                      @context.push(:lambda)
+                    }
+                  lambda
                     {
                       lambda_call = @builder.call_lambda(val[0])
 
-                      args, (begin_t, body, end_t) = val[1]
+                      args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
                     }
@@ -1165,6 +1169,7 @@ rule
                     {
                       @static_env.extend_static
                       @lexer.cmdarg.push(false)
+                      @context.push(:module)
                     }
                     bodystmt kEND
                     {
@@ -1177,6 +1182,7 @@ rule
 
                       @lexer.cmdarg.pop
                       @static_env.unextend
+                      @context.pop
                     }
                 | kDEF fname
                     {
@@ -1487,6 +1493,7 @@ opt_block_args_tail:
                     }
                   f_larglist
                     {
+                      @context.pop
                       @lexer.cmdarg.push(false)
                     }
                   lambda_body

--- a/lib/parser/ruby25.y
+++ b/lib/parser/ruby25.y
@@ -1057,11 +1057,15 @@ rule
                       result      = @builder.block(val[0],
                                       begin_t, args, body, end_t)
                     }
-                | tLAMBDA lambda
+                | tLAMBDA
+                    {
+                      @context.push(:lambda)
+                    }
+                  lambda
                     {
                       lambda_call = @builder.call_lambda(val[0])
 
-                      args, (begin_t, body, end_t) = val[1]
+                      args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
                     }
@@ -1151,6 +1155,7 @@ rule
                     {
                       @static_env.extend_static
                       @lexer.cmdarg.push(false)
+                      @context.push(:module)
                     }
                     bodystmt kEND
                     {
@@ -1163,6 +1168,7 @@ rule
 
                       @lexer.cmdarg.pop
                       @static_env.unextend
+                      @context.pop
                     }
                 | kDEF fname
                     {
@@ -1484,6 +1490,7 @@ opt_block_args_tail:
                     }
                   f_larglist
                     {
+                      @context.pop
                       @lexer.cmdarg.push(false)
                     }
                   lambda_body

--- a/lib/parser/ruby26.y
+++ b/lib/parser/ruby26.y
@@ -1065,11 +1065,15 @@ rule
                       result      = @builder.block(val[0],
                                       begin_t, args, body, end_t)
                     }
-                | tLAMBDA lambda
+                | tLAMBDA
+                    {
+                      @context.push(:lambda)
+                    }
+                  lambda
                     {
                       lambda_call = @builder.call_lambda(val[0])
 
-                      args, (begin_t, body, end_t) = val[1]
+                      args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
                     }
@@ -1159,6 +1163,7 @@ rule
                     {
                       @static_env.extend_static
                       @lexer.cmdarg.push(false)
+                      @context.push(:module)
                     }
                     bodystmt kEND
                     {
@@ -1171,6 +1176,7 @@ rule
 
                       @lexer.cmdarg.pop
                       @static_env.unextend
+                      @context.pop
                     }
                 | kDEF fname
                     {
@@ -1492,6 +1498,7 @@ opt_block_args_tail:
                     }
                   f_larglist
                     {
+                      @context.pop
                       @lexer.cmdarg.push(false)
                     }
                   lambda_body

--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -1109,11 +1109,15 @@ rule
                       result      = @builder.block(val[0],
                                       begin_t, args, body, end_t)
                     }
-                | tLAMBDA lambda
+                | tLAMBDA
+                    {
+                      @context.push(:lambda)
+                    }
+                  lambda
                     {
                       lambda_call = @builder.call_lambda(val[0])
 
-                      args, (begin_t, body, end_t) = val[1]
+                      args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
                     }
@@ -1211,6 +1215,7 @@ rule
                     {
                       @static_env.extend_static
                       @lexer.cmdarg.push(false)
+                      @context.push(:module)
                     }
                     bodystmt kEND
                     {
@@ -1223,6 +1228,7 @@ rule
 
                       @lexer.cmdarg.pop
                       @static_env.unextend
+                      @context.pop
                     }
                 | kDEF fname
                     {
@@ -1538,7 +1544,6 @@ opt_block_args_tail:
           lambda:   {
                       @static_env.extend_dynamic
                       @max_numparam_stack.push
-                      @context.push(:lambda)
                     }
                   f_larglist
                     {
@@ -2089,11 +2094,15 @@ opt_block_args_tail:
                     {
                       result = @builder.accessible(val[0])
                     }
-                | tLAMBDA lambda
+                | tLAMBDA
+                    {
+                      @context.push(:lambda)
+                    }
+                  lambda
                     {
                       lambda_call = @builder.call_lambda(val[0])
 
-                      args, (begin_t, body, end_t) = val[1]
+                      args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
                     }

--- a/lib/parser/ruby28.y
+++ b/lib/parser/ruby28.y
@@ -1307,6 +1307,7 @@ rule
                     {
                       @static_env.extend_static
                       @lexer.cmdarg.push(false)
+                      @context.push(:module)
                     }
                     bodystmt kEND
                     {
@@ -1319,6 +1320,7 @@ rule
 
                       @lexer.cmdarg.pop
                       @static_env.unextend
+                      @context.pop
                     }
                 | defn_head f_arglist bodystmt kEND
                     {

--- a/lib/parser/rubymotion.y
+++ b/lib/parser/rubymotion.y
@@ -1018,11 +1018,15 @@ rule
                       result      = @builder.block(val[0],
                                       begin_t, args, body, end_t)
                     }
-                | tLAMBDA lambda
+                | tLAMBDA
+                    {
+                      @context.push(:lambda)
+                    }
+                  lambda
                     {
                       lambda_call = @builder.call_lambda(val[0])
 
-                      args, (begin_t, body, end_t) = val[1]
+                      args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
                     }
@@ -1136,6 +1140,7 @@ rule
                     {
                       @static_env.extend_static
                       @lexer.push_cmdarg
+                      @context.push(:module)
                     }
                     bodystmt kEND
                     {
@@ -1148,6 +1153,7 @@ rule
 
                       @lexer.pop_cmdarg
                       @static_env.unextend
+                      @context.pop
                     }
                 | kDEF fname
                     {
@@ -1429,9 +1435,13 @@ rule
           lambda:   {
                       @static_env.extend_dynamic
                     }
-                  f_larglist lambda_body
+                  f_larglist
                     {
-                      result = [ val[1], val[2] ]
+                      @context.pop
+                    }
+                  lambda_body
+                    {
+                      result = [ val[1], val[3] ]
 
                       @static_env.unextend
                     }

--- a/parser.gemspec
+++ b/parser.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency             'ast',       '~> 2.4.0'
+  spec.add_dependency             'ast',       '~> 2.4.1'
 
   spec.add_development_dependency 'bundler',   '>= 1.15', '< 3.0.0'
   spec.add_development_dependency 'rake',      '~> 13.0.1'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -77,3 +77,27 @@ class Parser::AST::Node
     super
   end
 end
+
+# Special test extension that records a context of the parser
+# for any node that is created
+module NodeContextExt
+  module NodeExt
+    attr_reader :context
+
+    def assign_properties(properties)
+      super
+
+      if (context = properties[:context])
+        @context = context
+      end
+    end
+  end
+  Parser::AST::Node.prepend(NodeExt)
+
+  module BuilderExt
+    def n(type, children, source_map)
+      super.updated(nil, nil, context: @parser.context.stack.dup)
+    end
+  end
+  Parser::Builders::Default.prepend(BuilderExt)
+end


### PR DESCRIPTION
Previously we didn't push context for module and lambda arguments and so we didn't reject some code (or we rejected what's allowed).
However, examples that should've raised errors are complicated and it's very unlikely that any code was affected. At least no related issues were reported.

Examples of code that is accepted/rejected differently after this change:
1. `->(a) { module M; _1; end }`
We didn't push context for module M, and so argument `a` conflicted with implicit parameter `_1`. In Ruby module opens a new scope and so `_1` is just a regular local variable.

2. `class A; ->(a = (return; 1)) {}; end`
This code is valid, because `return` is a part of the lambda. But we didn't store this fact internally, and so it was rejected before.

Both examples described above (and all similar variations) are fixed in this commit.

Also, I've slightly improved assertions related to context (`assert_context`). Instead of checking state of the half-reduced AST (which is impossible for lambda args for example) we use a special `get_context` macro-like node that grabs snapshot of the `parser.context`.