### PR TITLE
+ Added `emit_forward_arg` compatibility flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ below for explanation of `emit_*` calls):
     Parser::Builders::Default.emit_encoding            = true
     Parser::Builders::Default.emit_index               = true
     Parser::Builders::Default.emit_arg_inside_procarg0 = true
+    Parser::Builders::Default.emit_forward_arg         = true
 
 Parse a chunk of code:
 

--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -1164,13 +1164,13 @@ s(:numblock,
 
 ## Forward arguments
 
-### Method definition accepting forwarding arguments
+### Method definition accepting only forwarding arguments
 
 Ruby 2.7 introduced a feature called "arguments forwarding".
 When a method takes any arguments for forwarding them in the future
 the whole `args` node gets replaced with `forward-args` node.
 
-Format:
+Format if `emit_forward_arg` compatibility flag is disabled:
 
 ~~~
 (def :foo
@@ -1180,6 +1180,25 @@ Format:
         ~ begin
         ~~~~~ expression
 ~~~
+
+However, Ruby 2.8 added support for leading arguments before `...`, and so
+it can't be used as a replacement of the `(args)` node anymore. To solve it
+`emit_forward_arg` should be enabled.
+
+Format if `emit_forward_arg` compatibility flag is enabled:
+
+~~~
+(def :foo
+  (args
+    (forward-arg)) nil)
+"def foo(...); end"
+        ~ begin (args)
+            ~ end (args)
+        ~~~~~ expression (args)
+         ~~~ expression (forward_arg)
+~~~
+
+Note that the node is called `forward_arg` when emitted separately.
 
 ### Method call taking arguments of the currently forwarding method
 

--- a/lib/parser/ast/processor.rb
+++ b/lib/parser/ast/processor.rb
@@ -127,6 +127,7 @@ module Parser
       alias on_kwarg          process_argument_node
       alias on_kwoptarg       process_argument_node
       alias on_kwrestarg      process_argument_node
+      alias on_forward_arg    process_argument_node
 
       def on_procarg0(node)
         if node.children[0].is_a?(Symbol)

--- a/lib/parser/meta.rb
+++ b/lib/parser/meta.rb
@@ -26,7 +26,7 @@ module Parser
         ident root lambda indexasgn index procarg0
         restarg_expr blockarg_expr
         objc_kwarg objc_restarg objc_varargs
-        numargs numblock forward_args forwarded_args
+        numargs numblock forward_args forwarded_args forward_arg
         case_match in_match in_pattern
         match_var pin match_alt match_as match_rest
         array_pattern match_with_trailing_comma array_pattern_with_tail

--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -2532,7 +2532,7 @@ keyword_variable: kNIL
                     }
                 | tLPAREN2 args_forward rparen
                     {
-                      result = @builder.forward_args(val[0], val[1], val[2])
+                      result = @builder.forward_only_args(val[0], val[1], val[2])
                       @static_env.declare_forward_args
 
                       @lexer.state = :expr_value

--- a/lib/parser/ruby28.y
+++ b/lib/parser/ruby28.y
@@ -2595,7 +2595,7 @@ keyword_variable: kNIL
                     }
                 | tLPAREN2 args_forward rparen
                     {
-                      result = @builder.forward_args(val[0], val[1], val[2])
+                      result = @builder.forward_only_args(val[0], val[1], val[2])
                       @static_env.declare_forward_args
 
                       @lexer.state = :expr_value

--- a/lib/parser/runner.rb
+++ b/lib/parser/runner.rb
@@ -37,7 +37,7 @@ module Parser
 
     private
 
-    LEGACY_MODES = %i[lambda procarg0 encoding index arg_inside_procarg0].freeze
+    LEGACY_MODES = %i[lambda procarg0 encoding index arg_inside_procarg0 forward_arg].freeze
 
     def runner_name
       raise NotImplementedError, "implement #{self.class}##{__callee__}"


### PR DESCRIPTION
The reason is that Ruby 2.8 supports the following code:
  `def m(a, b, ...); end`

If set to false (the default):
  1. `def m(...) end` is emitted as
     ```
     s(:def, :m, s(:forward_args), nil)
     ```

  2. `def m(a, b, ...) end` is emitted as
     ```
     s(:def, :m,
       s(:args, s(:arg, :a), s(:arg, :b), s(:forward_arg)))
     ```

If set to true it uses a single format:
  1. `def m(...) end` is emitted as
     ```
     s(:def, :m, s(:args, s(:forward_arg)))
     ```

  2. `def m(a, b, ...) end` is emitted as
     ```
     s(:def, :m, s(:args, s(:arg, :a), s(:arg, :b), s(:forward_arg)))
     ```

This is necessary to backport https://github.com/ruby/ruby/commit/f8b4340fa2c254cd093ebc3bc70d2d0c46ea9997

I'll keep it open for a few days, feel free to leave comments/suggestions.