### PR TITLE
+ lexer.rl: reject `->...` and `->(...)` with the same error.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -2030,7 +2030,14 @@ class Parser::Lexer
 
       '...'
       => {
-        if @version >= 27
+        if @version >= 28
+          if @lambda_stack.any? && @lambda_stack.last + 1 == @paren_nest
+            # To reject `->(...)` like `->...`
+            emit(:tDOT3)
+          else
+            emit(:tBDOT3)
+          end
+        elsif @version >= 27
           emit(:tBDOT3)
         else
           emit(:tDOT3)

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7912,7 +7912,13 @@ class TestParser < Minitest::Test
       [:error, :unexpected_token, { :token => 'tBDOT3' }],
       %q{->(...) {}},
       %q{   ^^^ location},
-      SINCE_2_7)
+      ['2.7'])
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tDOT3' }],
+      %q{->(...) {}},
+      %q{   ^^^ location},
+      SINCE_2_8)
 
     # Here and below the parser asssumes that
     # it can be a beginningless range, so the error comes after reducing right paren


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@c0ba35f.

Closes https://github.com/whitequark/parser/issues/704