### PR TITLE
+ ruby28.y: add find pattern.

### DIFF
--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -2191,6 +2191,24 @@ Format:
       ~~~ name (match-nil-pattern)
 ~~~
 
+### Matching using find pattern
+
+Format:
+
+~~~
+(find-pattern
+  (match-rest
+    (match-var :a))
+  (int 42)
+  (match-rest))
+"in [*, 42, *]"
+    ~ begin
+             ~ end
+    ~~~~~~~~~~ expression
+~~~
+
+Note that it can be used as a top-level pattern only when used in a `case` statement. In that case `begin` and `end` are empty.
+
 ### Matching using const pattern
 
 #### With array pattern
@@ -2245,4 +2263,21 @@ Format:
     ~ name (const-pattern.const)
     ~ expression (const-pattern.const)
      ~~ expression (const-pattern.array_pattern)
+~~~
+
+#### With find pattern
+
+Format:
+
+~~~
+(const-pattern
+  (const nil :X)
+  (find-pattern
+    (match-rest)
+    (int 42)
+    (match-rest)))
+"in X[*, 42, *]"
+     ~ begin
+              ~ end
+    ~~~~~~~~~~~ expression
 ~~~

--- a/lib/parser/ast/processor.rb
+++ b/lib/parser/ast/processor.rb
@@ -258,6 +258,7 @@ module Parser
       alias on_array_pattern_with_tail process_regular_node
       alias on_hash_pattern            process_regular_node
       alias on_const_pattern           process_regular_node
+      alias on_find_pattern            process_regular_node
 
       # @private
       def process_variable_node(node)

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1400,6 +1400,11 @@ module Parser
         collection_map(lbrack_t, elements, rbrack_t))
     end
 
+    def find_pattern(lbrack_t, elements, rbrack_t)
+      n(:find_pattern, elements,
+        collection_map(lbrack_t, elements, rbrack_t))
+    end
+
     def match_with_trailing_comma(match, comma_t)
       n(:match_with_trailing_comma, [ match ], expr_map(match.loc.expression.join(loc(comma_t))))
     end

--- a/lib/parser/meta.rb
+++ b/lib/parser/meta.rb
@@ -31,7 +31,7 @@ module Parser
         match_var pin match_alt match_as match_rest
         array_pattern match_with_trailing_comma array_pattern_with_tail
         hash_pattern const_pattern if_guard unless_guard match_nil_pattern
-        empty_else
+        empty_else find_pattern
       ).map(&:to_sym).to_set.freeze
 
   end # Meta

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -8460,7 +8460,7 @@ class TestParser < Minitest::Test
         nil),
       "#{case_pre}#{code}; end",
       source_maps,
-      SINCE_2_7
+      versions
     )
   end
 
@@ -9713,6 +9713,68 @@ class TestParser < Minitest::Test
       [:error, :unexpected_token, { :token => 'tASSOC' }],
       %Q{13.divmod(5)\n=> a,b; [a, b]},
       %{             ^^ location},
+      SINCE_2_8)
+  end
+
+  def test_find_pattern
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:find_pattern,
+          s(:match_rest,
+            s(:match_var, :x)),
+          s(:match_as,
+            s(:int, 1),
+            s(:match_var, :a)),
+          s(:match_rest,
+            s(:match_var, :y))),
+        nil,
+        s(:true)),
+      %q{in [*x, 1 => a, *y] then true},
+      %q{   ~~~~~~~~~~~~~~~~ expression (in_pattern.find_pattern)
+        |   ~ begin (in_pattern.find_pattern)
+        |                  ~ end (in_pattern.find_pattern)
+        |    ~~ expression (in_pattern.find_pattern.match_rest/1)
+        |                ~~ expression (in_pattern.find_pattern.match_rest/2)},
+      SINCE_2_8)
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:const_pattern,
+          s(:const, nil, :String),
+          s(:find_pattern,
+            s(:match_rest),
+            s(:int, 1),
+            s(:match_rest))),
+        nil,
+        s(:true)),
+      %q{in String(*, 1, *) then true},
+      %q{          ~~~~~~~ expression (in_pattern.const_pattern.find_pattern)},
+      SINCE_2_8)
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:const_pattern,
+          s(:const, nil, :Array),
+          s(:find_pattern,
+            s(:match_rest),
+            s(:int, 1),
+            s(:match_rest))),
+        nil,
+        s(:true)),
+      %q{in Array[*, 1, *] then true},
+      %q{         ~~~~~~~ expression (in_pattern.const_pattern.find_pattern)},
+      SINCE_2_8)
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:find_pattern,
+          s(:match_rest),
+          s(:int, 42),
+          s(:match_rest)),
+        nil,
+        s(:true)),
+      %q{in *, 42, * then true},
+      %q{   ~~~~~~~~ expression (in_pattern.find_pattern)},
       SINCE_2_8)
   end
 end


### PR DESCRIPTION
This commit tracks upstream commits ruby/ruby@ddded11 and ruby/ruby@f7906a7.

Closes https://github.com/whitequark/parser/issues/711