### PR TITLE
- Fix locations for alias / undef nodes with internal symbols

### DIFF
--- a/lib/parser/macruby.y
+++ b/lib/parser/macruby.y
@@ -536,7 +536,7 @@ rule
 
             fsym: fname
                     {
-                      result = @builder.symbol(val[0])
+                      result = @builder.symbol_internal(val[0])
                     }
                 | symbol
 

--- a/lib/parser/ruby18.y
+++ b/lib/parser/ruby18.y
@@ -493,7 +493,7 @@ rule
 
             fsym: fname
                     {
-                      result = @builder.symbol(val[0])
+                      result = @builder.symbol_internal(val[0])
                     }
                 | symbol
 

--- a/lib/parser/ruby19.y
+++ b/lib/parser/ruby19.y
@@ -550,7 +550,7 @@ rule
 
             fsym: fname
                     {
-                      result = @builder.symbol(val[0])
+                      result = @builder.symbol_internal(val[0])
                     }
                 | symbol
 

--- a/lib/parser/ruby20.y
+++ b/lib/parser/ruby20.y
@@ -559,7 +559,7 @@ rule
 
             fsym: fname
                     {
-                      result = @builder.symbol(val[0])
+                      result = @builder.symbol_internal(val[0])
                     }
                 | symbol
 

--- a/lib/parser/ruby21.y
+++ b/lib/parser/ruby21.y
@@ -551,7 +551,7 @@ rule
 
             fsym: fname
                     {
-                      result = @builder.symbol(val[0])
+                      result = @builder.symbol_internal(val[0])
                     }
                 | symbol
 

--- a/lib/parser/ruby22.y
+++ b/lib/parser/ruby22.y
@@ -551,7 +551,7 @@ rule
 
             fsym: fname
                     {
-                      result = @builder.symbol(val[0])
+                      result = @builder.symbol_internal(val[0])
                     }
                 | symbol
 

--- a/lib/parser/ruby23.y
+++ b/lib/parser/ruby23.y
@@ -551,7 +551,7 @@ rule
 
             fsym: fname
                     {
-                      result = @builder.symbol(val[0])
+                      result = @builder.symbol_internal(val[0])
                     }
                 | symbol
 

--- a/lib/parser/ruby24.y
+++ b/lib/parser/ruby24.y
@@ -555,7 +555,7 @@ rule
 
             fsym: fname
                     {
-                      result = @builder.symbol(val[0])
+                      result = @builder.symbol_internal(val[0])
                     }
                 | symbol
 

--- a/lib/parser/ruby25.y
+++ b/lib/parser/ruby25.y
@@ -569,7 +569,7 @@ rule
 
             fsym: fname
                     {
-                      result = @builder.symbol(val[0])
+                      result = @builder.symbol_internal(val[0])
                     }
                 | symbol
 

--- a/lib/parser/ruby26.y
+++ b/lib/parser/ruby26.y
@@ -569,7 +569,7 @@ rule
 
             fsym: fname
                     {
-                      result = @builder.symbol(val[0])
+                      result = @builder.symbol_internal(val[0])
                     }
                 | symbol
 

--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -600,7 +600,7 @@ rule
 
            fitem: fname
                     {
-                      result = @builder.symbol(val[0])
+                      result = @builder.symbol_internal(val[0])
                     }
                 | symbol
 

--- a/lib/parser/ruby28.y
+++ b/lib/parser/ruby28.y
@@ -647,7 +647,7 @@ rule
 
            fitem: fname
                     {
-                      result = @builder.symbol(val[0])
+                      result = @builder.symbol_internal(val[0])
                     }
                 | symbol
 

--- a/lib/parser/rubymotion.y
+++ b/lib/parser/rubymotion.y
@@ -512,7 +512,7 @@ rule
 
             fsym: fname
                     {
-                      result = @builder.symbol(val[0])
+                      result = @builder.symbol_internal(val[0])
                     }
                 | symbol
 

--- a/test/test_parse_helper.rb
+++ b/test/test_parse_helper.rb
@@ -25,33 +25,36 @@ class TestParseHelper < Minitest::Test
   end
 
   def test_parse_mapsation_description
-    assert_equal [[0, 4, 'expr', [], '~~~~ expr']],
+    assert_equal [[0...4, 'expr', [], '~~~~ expr']],
                  parse_maps('~~~~ expr')
 
-    assert_equal [[0, 4, 'expr', [], '^~~~ expr']],
+    assert_equal [[0...4, 'expr', [], '^~~~ expr']],
                  parse_maps('^~~~ expr')
 
-    assert_equal [[0, 4, 'expr', [], '^^^^ expr']],
+    assert_equal [[0...4, 'expr', [], '^^^^ expr']],
                  parse_maps('^^^^ expr')
 
-    assert_equal [[2, 3, 'op', [], '  ^ op']],
+    assert_equal [[2...3, 'op', [], '  ^ op']],
                  parse_maps('  ^ op')
 
-    assert_equal [[2, 3, 'op', ['foo'], '  ~ op (foo)']],
+    assert_equal [[2...3, 'op', ['foo'], '  ~ op (foo)']],
                  parse_maps('  ~ op (foo)')
 
-    assert_equal [[2, 4, 'op', ['foo', 'bar'], '  ~~ op (foo.bar)']],
+    assert_equal [[2...4, 'op', ['foo', 'bar'], '  ~~ op (foo.bar)']],
                  parse_maps('  ~~ op (foo.bar)')
 
-    assert_equal [[2, 4, 'op', ['foo/2', 'bar'], '  ~~ op (foo/2.bar)']],
+    assert_equal [[2...4, 'op', ['foo/2', 'bar'], '  ~~ op (foo/2.bar)']],
                  parse_maps('  ~~ op (foo/2.bar)')
 
-    assert_equal [[0, 4, 'expr', [], '~~~~ expr'],
-                  [5, 7, 'op', ['str', 'e_h'], '     ~~ op (str.e_h)']],
+    assert_equal [[0...4, 'expr', [], '~~~~ expr'],
+                  [5...7, 'op', ['str', 'e_h'], '     ~~ op (str.e_h)']],
                  parse_maps(%{
                             |~~~~ expr
                             |     ~~ op (str.e_h)
                             })
+
+    assert_equal [[nil, 'expr', [], '! expr']],
+                 parse_maps('! expr')
   end
 
   def test_traverse_ast

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -1976,7 +1976,9 @@ class TestParser < Minitest::Test
       %q{alias :foo bar},
       %q{~~~~~ keyword
         |      ~~~~ expression (sym/1)
+        |      ^ begin (sym/1)
         |           ~~~ expression (sym/2)
+        |           ! begin (sym/2)
         |~~~~~~~~~~~~~~ expression})
   end
 


### PR DESCRIPTION
```sh
$ ruby-parse -L -e "alias foo x"
s(:alias,
  s(:sym, :foo),
  s(:sym, :x))
alias foo x
~~~~~ keyword         
~~~~~~~~~~~ expression
s(:sym, :foo)
alias foo x
      ~ begin       # <<< error
      ~~~ expression
s(:sym, :x)
alias foo x
          ~ begin     # <<< error
          ~ expression
```

I couldn't find a (simple) way to add a test, but it looks like tests aren't necessarily precise to that level. For example I temporarily changed `%i[foo]` to erroneously generate a `begin` and no test fail. Since this hasn't been noticed in so many years, clearly it's not super important. I noticed it by pure chance.

Let me know if it's necessary to add a test (which would probably involve changing `assert_parses` to accept some kind of annotation like `! begin` or accept a block to run extra checks...