### PR TITLE
+ emit "endless method def" as `:def` node.

### DIFF
--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -829,7 +829,7 @@ Format:
 Format:
 
 ~~~
-(def_e :foo (args) (int 42))
+(def :foo (args) (int 42))
 "def foo() = 42"
  ~~~ keyword
      ~~~ name
@@ -843,7 +843,7 @@ Format:
 Format:
 
 ~~~
-(defs_e (self) :foo (args) (int 42))
+(defs (self) :foo (args) (int 42))
 "def self.foo() = 42"
  ~~~ keyword
           ~~~ name

--- a/lib/parser/ast/processor.rb
+++ b/lib/parser/ast/processor.rb
@@ -163,8 +163,6 @@ module Parser
         ])
       end
 
-      alias on_def_e on_def
-
       def on_defs(node)
         definee_node, name, args_node, body_node = *node
 
@@ -173,8 +171,6 @@ module Parser
           process(args_node), process(body_node)
         ])
       end
-
-      alias on_defs_e on_defs
 
       alias on_undef    process_regular_node
       alias on_alias    process_regular_node

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -695,7 +695,7 @@ module Parser
 
     def def_endless_method(def_t, name_t, args,
                            assignment_t, body)
-      n(:def_e, [ value(name_t).to_sym, args, body ],
+      n(:def, [ value(name_t).to_sym, args, body ],
         endless_definition_map(def_t, nil, name_t, assignment_t, body))
     end
 
@@ -713,7 +713,7 @@ module Parser
                               assignment_t, body)
       return unless validate_definee(definee)
 
-      n(:defs_e, [ definee, value(name_t).to_sym, args, body ],
+      n(:defs, [ definee, value(name_t).to_sym, args, body ],
         endless_definition_map(def_t, dot_t, name_t, assignment_t, body))
     end
 

--- a/lib/parser/meta.rb
+++ b/lib/parser/meta.rb
@@ -16,7 +16,7 @@ module Parser
         op_asgn and_asgn ensure rescue arg_expr
         or_asgn back_ref nth_ref
         match_with_lvasgn match_current_line
-        module class sclass def defs def_e defs_e undef alias args
+        module class sclass def defs undef alias args
         cbase arg optarg restarg blockarg block_pass kwarg kwoptarg
         kwrestarg kwnilarg send csend super zsuper yield block
         and not or if when case while until while_post

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -9563,7 +9563,7 @@ class TestParser < Minitest::Test
 
   def test_endless_method
     assert_parses(
-      s(:def_e, :foo,
+      s(:def, :foo,
         s(:args),
         s(:int, 42)),
       %q{def foo() = 42},
@@ -9574,7 +9574,7 @@ class TestParser < Minitest::Test
       SINCE_2_8)
 
     assert_parses(
-      s(:def_e, :inc,
+      s(:def, :inc,
         s(:args, s(:arg, :x)),
         s(:send,
           s(:lvar, :x), :+,
@@ -9587,7 +9587,7 @@ class TestParser < Minitest::Test
       SINCE_2_8)
 
     assert_parses(
-      s(:defs_e, s(:send, nil, :obj), :foo,
+      s(:defs, s(:send, nil, :obj), :foo,
         s(:args),
         s(:int, 42)),
       %q{def obj.foo() = 42},
@@ -9599,7 +9599,7 @@ class TestParser < Minitest::Test
       SINCE_2_8)
 
     assert_parses(
-      s(:defs_e, s(:send, nil, :obj), :inc,
+      s(:defs, s(:send, nil, :obj), :inc,
         s(:args, s(:arg, :x)),
         s(:send,
           s(:lvar, :x), :+,
@@ -9616,7 +9616,7 @@ class TestParser < Minitest::Test
   def test_endless_method_forwarded_args_legacy
     Parser::Builders::Default.emit_forward_arg = false
     assert_parses(
-      s(:def_e, :foo,
+      s(:def, :foo,
         s(:forward_args),
         s(:send, nil, :bar,
           s(:forwarded_args))),
@@ -9646,7 +9646,7 @@ class TestParser < Minitest::Test
 
   def test_endless_method_with_rescue_mod
     assert_parses(
-      s(:def_e, :m,
+      s(:def, :m,
         s(:args),
         s(:rescue,
           s(:int, 1),
@@ -9657,7 +9657,7 @@ class TestParser < Minitest::Test
       SINCE_2_8)
 
     assert_parses(
-      s(:defs_e,
+      s(:defs,
         s(:self), :m,
         s(:args),
         s(:rescue,


### PR DESCRIPTION
(according to https://github.com/whitequark/parser/pull/676#issuecomment-650327931)

2.8.0-dev is not released, so I think we are free to change it.