### PR TITLE
- ruby27.y: accept const names as hash keys for pattern matching

### DIFF
--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -2031,7 +2031,6 @@ opt_block_args_tail:
 
       p_kw_label: tLABEL
                   {
-                    check_kwarg_name(val[0])
                     result = [:label, val[0]]
                   }
                 | tSTRING_BEG string_contents tLABEL_END

--- a/lib/parser/ruby28.y
+++ b/lib/parser/ruby28.y
@@ -2127,7 +2127,6 @@ opt_block_args_tail:
 
       p_kw_label: tLABEL
                   {
-                    check_kwarg_name(val[0])
                     result = [:label, val[0]]
                   }
                 | tSTRING_BEG string_contents tLABEL_END

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -8912,6 +8912,21 @@ class TestParser < Minitest::Test
       s(:in_pattern,
         s(:hash_pattern,
           s(:pair,
+             s(:sym, :Foo),
+             s(:int, 42))), nil,
+        s(:false)),
+      %q{
+        in {Foo: 42
+        }
+          false
+      },
+      %q{}
+    )
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:hash_pattern,
+          s(:pair,
             s(:sym, :a),
             s(:hash_pattern,
               s(:match_var, :b))),


### PR DESCRIPTION
Resolves: https://github.com/rubocop-hq/rubocop/issues/8165

This PR fixes the following error for pattern matching.

```console
% ruby -v
ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-darwin17]

% ruby-parse -e 'pattern in { Foo: foo }'
(fragment:0):1:14: error: formal argument cannot be a constant
(fragment:0):1: pattern in { Foo: foo }
(fragment:0):1:              ^~~~
```

Because of that, this PR removes the check for kwarg name to a hash object, and accepts the same case as Ruby:

```console
% ruby -ce 'pattern in { Foo: foo }'
-e:1: warning: Pattern matching is experimental, and the behavior may
change in future versions of Ruby!
Syntax OK
```

It makes the same changes for ruby28.y (experimental).