### PR TITLE
- unify locations for normal and endless method definition

### DIFF
--- a/lib/parser.rb
+++ b/lib/parser.rb
@@ -46,7 +46,7 @@ module Parser
     require 'parser/source/map/variable'
     require 'parser/source/map/keyword'
     require 'parser/source/map/definition'
-    require 'parser/source/map/endless_definition'
+    require 'parser/source/map/method_definition'
     require 'parser/source/map/send'
     require 'parser/source/map/index'
     require 'parser/source/map/condition'

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1803,17 +1803,17 @@ module Parser
     end
 
     def definition_map(keyword_t, operator_t, name_t, end_t)
-      Source::Map::Definition.new(loc(keyword_t),
-                                  loc(operator_t), loc(name_t),
-                                  loc(end_t))
+      Source::Map::MethodDefinition.new(loc(keyword_t),
+                                        loc(operator_t), loc(name_t),
+                                        loc(end_t), nil, nil)
     end
 
     def endless_definition_map(keyword_t, operator_t, name_t, assignment_t, body_e)
       body_l = body_e.loc.expression
 
-      Source::Map::EndlessDefinition.new(loc(keyword_t),
-                                         loc(operator_t), loc(name_t),
-                                         loc(assignment_t), body_l)
+      Source::Map::MethodDefinition.new(loc(keyword_t),
+                                        loc(operator_t), loc(name_t), nil,
+                                        loc(assignment_t), body_l)
     end
 
     def send_map(receiver_e, dot_t, selector_t, begin_t=nil, args=[], end_t=nil)

--- a/lib/parser/source/map/method_definition.rb
+++ b/lib/parser/source/map/method_definition.rb
@@ -3,19 +3,21 @@
 module Parser
   module Source
 
-    class Map::EndlessDefinition < Map
+    class Map::MethodDefinition < Map
       attr_reader :keyword
       attr_reader :operator
       attr_reader :name
+      attr_reader :end
       attr_reader :assignment
 
-      def initialize(keyword_l, operator_l, name_l, assignment_l, body_l)
+      def initialize(keyword_l, operator_l, name_l, end_l, assignment_l, body_l)
         @keyword  = keyword_l
         @operator = operator_l
         @name     = name_l
+        @end      = end_l
         @assignment = assignment_l
 
-        super(@keyword.join(body_l))
+        super(@keyword.join(end_l || body_l))
       end
     end
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -1856,6 +1856,7 @@ class TestParser < Minitest::Test
       %q{def foo; end},
       %q{~~~ keyword
         |    ~~~ name
+        |! assignment
         |         ~~~ end})
 
     assert_parses(
@@ -9585,6 +9586,7 @@ class TestParser < Minitest::Test
       %q{~~~ keyword
         |    ~~~ name
         |          ^ assignment
+        |! end
         |~~~~~~~~~~~~~~ expression},
       SINCE_2_8)
 


### PR DESCRIPTION
This way one can ask `loc.end` or `loc.assignment` of all method definitions