### PR TITLE
- Parser#parse returns nil instead of false if error is thrown

### DIFF
--- a/lib/parser/base.rb
+++ b/lib/parser/base.rb
@@ -177,16 +177,16 @@ module Parser
     end
 
     ##
-    # Parses a source buffer and returns the AST.
+    # Parses a source buffer and returns the AST, or `nil` in case of a non fatal error.
     #
     # @param [Parser::Source::Buffer] source_buffer The source buffer to parse.
-    # @return [Parser::AST::Node]
+    # @return [Parser::AST::Node, nil]
     #
     def parse(source_buffer)
       @lexer.source_buffer = source_buffer
       @source_buffer       = source_buffer
 
-      do_parse
+      do_parse || nil # Force `false` to `nil`, see https://github.com/ruby/racc/pull/136
     ensure
       # Don't keep references to the source file.
       @source_buffer       = nil
@@ -210,8 +210,9 @@ module Parser
 
     ##
     # Parses a source buffer and returns the AST, the source code comments,
-    # and the tokens emitted by the lexer. If `recover` is true and a fatal
-    # {SyntaxError} is encountered, `nil` is returned instead of the AST, and
+    # and the tokens emitted by the lexer. In case of a fatal error, a {SyntaxError}
+    # is raised, unless `recover` is true. In case of an error
+    # (non-fatal or recovered), `nil` is returned instead of the AST, and
     # comments as well as tokens are only returned up to the location of
     # the error.
     #

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -9796,4 +9796,14 @@ class TestParser < Minitest::Test
       %q{   ~~~~~~~~ expression (in_pattern.find_pattern)},
       SINCE_2_8)
   end
+
+  def test_invalid_source
+    with_versions(ALL_VERSIONS) do |_ver, parser|
+      source_file = Parser::Source::Buffer.new('(comments)', source: "def foo; en")
+
+      parser.diagnostics.all_errors_are_fatal = false
+      ast = parser.parse(source_file)
+      assert_nil(ast)
+    end
+  end
 end


### PR DESCRIPTION
In some circumstances (when reaching the EOF too early), [`racc` erroneously returns `false` instead of `nil`](https://github.com/ruby/racc/pull/136).

Even though it's an upstream issue, the fix is so simple that I thought it was worthwhile to circumvent it.

This PR also improves the documentation for non-fatal cases. There are no other tests with `all_errors_are_fatal` set to `false`.