### PR TITLE
+ Add Source::Range#line_span

### DIFF
--- a/lib/parser/source/comment.rb
+++ b/lib/parser/source/comment.rb
@@ -10,7 +10,7 @@ module Parser
     #  @return [String]
     #
     # @!attribute [r] location
-    #  @return [Parser::Source::Map]
+    #  @return [Parser::Source::Range]
     #
     # @api public
     #

--- a/lib/parser/source/range.rb
+++ b/lib/parser/source/range.rb
@@ -87,6 +87,27 @@ module Parser
       alias_method :first_line, :line
 
       ##
+      # The range of line numbers spanned by the range.
+      # The range will be exclusive or not depending on the keyword argument;
+      # default is inclusive.
+      #
+      # Assume that `def_node` is the Node corresponding to the following example:
+      #
+      #    def foo
+      #      do_something
+      #      42
+      #    end
+      #
+      # Then:
+      #
+      #    def_node.loc.end.line_span                           # => 4..4
+      #    def_node.loc.expression.line_span(exclude_end: true) # => 1...4
+      #
+      def line_span(exclude_end: false)
+        ::Range.new(first_line, last_line, exclude_end)
+      end
+
+      ##
       # @return [Integer] zero-based column number of the beginning of this range.
       #
       def column

--- a/test/test_source_range.rb
+++ b/test/test_source_range.rb
@@ -119,6 +119,12 @@ class TestSourceRange < Minitest::Test
     assert_equal 2, sr.line
   end
 
+  def test_line_span
+    sr = Parser::Source::Range.new(@buf, 2, 8)
+    assert_equal 1..1, @sr1_3.line_span
+    assert_equal 1...2, sr.line_span(exclude_end: true)
+  end
+
   def test_source_line
     sr = Parser::Source::Range.new(@buf, 7, 8)
     assert_equal 'baz', sr.source_line


### PR DESCRIPTION
This PR introduces a shortcut for `first_line..last_line` or `first_line...last_line`.

While the decision for `to_range` and `column_range` to be exclusive feels is always right, when mapping a range to lines I find this less clear, so I added a `exclude_end` keyword parameter.

Background: I'm still in a RuboCop refactor (definitely yak shaving, see last PR 😆 ) and noticing some occurrences of this pattern (a dozen inclusive, 3 exclusive). There's a method `line_range` for this in RuboCop, but it would be nicer as a building method and the name is unfortunate as it is easy to confuse with `SourceBuffer#line_range`.

I believe the concept is general enough to be worthwhile adding to `parser` directly, but if not this can be closed and I'll open a different PR for the doc fix I'm sneaking in the first commit 😅 