### PR TITLE
+ ruby28.y: reject assignment to numparam.

### DIFF
--- a/lib/parser/max_numparam_stack.rb
+++ b/lib/parser/max_numparam_stack.rb
@@ -18,7 +18,7 @@ module Parser
     end
 
     def has_numparams?
-      top > 0
+      top && top > 0
     end
 
     def register(numparam)

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -65,6 +65,7 @@ module Parser
     :invalid_return               => 'Invalid return in class/module body',
     :csend_in_lhs_of_masgn        => '&. inside multiple assignment destination',
     :cant_assign_to_numparam      => 'cannot assign to numbered parameter %{name}',
+    :reserved_for_numparam        => '%{name} is reserved for numbered parameter',
     :ordinary_param_defined       => 'ordinary parameter is defined',
     :numparam_used_in_outer_scope => 'numbered parameter is already used in an outer scope',
     :circular_argument_reference  => 'circular argument reference %{var_name}',


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@d47e124.

Closes https://github.com/whitequark/parser/issues/723.