### PR TITLE
+ ruby30.y: reject endless setter.

### DIFF
--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -74,6 +74,7 @@ module Parser
     :undefined_lvar               => "no such local variable: `%{name}'",
     :duplicate_variable_name      => 'duplicate variable name %{name}',
     :duplicate_pattern_key        => 'duplicate hash pattern key %{name}',
+    :endless_setter               => 'setter method cannot be defined in an endless method definition',
 
     # Parser warnings
     :useless_else            => 'else without rescue is useless',

--- a/lib/parser/ruby30.y
+++ b/lib/parser/ruby30.y
@@ -866,6 +866,12 @@ rule
                     }
                 | defn_head f_paren_args tEQL arg
                     {
+                      _def_t, name_t = val[0]
+
+                      if name_t[0].end_with?('=')
+                        diagnostic :error, :endless_setter, nil, name_t
+                      end
+
                       result = @builder.def_endless_method(*val[0],
                                  val[1], val[2], val[3])
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -9975,4 +9975,12 @@ class TestParser < Minitest::Test
         SINCE_3_0)
     end
   end
+
+  def test_endless_setter
+    assert_diagnoses(
+      [:error, :endless_setter],
+      %q{def foo=() = 42},
+      %q{    ^^^^ location},
+      SINCE_3_0)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@53ba9fb.

Closes #730

What's interesting, the following syntax is still allowed:
```ruby
def foo=() = 42 rescue nil
def self.foo=() = 42

def self.foo=() = 42 rescue nil
```