### PR TITLE
meta: root is no longer used

### DIFF
--- a/lib/parser/meta.rb
+++ b/lib/parser/meta.rb
@@ -23,7 +23,7 @@ module Parser
         until_post for break next redo return resbody
         kwbegin begin retry preexe postexe iflipflop eflipflop
         shadowarg complex rational __FILE__ __LINE__ __ENCODING__
-        ident root lambda indexasgn index procarg0
+        ident lambda indexasgn index procarg0
         restarg_expr blockarg_expr
         objc_kwarg objc_restarg objc_varargs
         numargs numblock forward_args forwarded_args forward_arg


### PR DESCRIPTION
Last use was replaced by zsuper in cbbb6bbd28cac20dc1a618c7d4779dce12f5f749.

meta also mentions 'ident'.  I think it is used only temporarily by the parser and never shows in final ASTs.  Is that right?