### PR TITLE
Exclude .gitignore from the package to support vendoring.

### DIFF
--- a/parser.gemspec
+++ b/parser.gemspec
@@ -35,7 +35,10 @@ Gem::Specification.new do |spec|
                           lib/parser/ruby30.rb
                           lib/parser/macruby.rb
                           lib/parser/rubymotion.rb
+                       ) - %w(
+                          .gitignore
                        )
+
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^test/})
   spec.require_paths = ['lib']


### PR DESCRIPTION
If .gitignore is a part of the .gem it's impossible to include source of
the locally installed parser (using bundle install --path ./vendor) because git
automatically excludes all gitignore-d files (including all parsers and lexer).