### PR TITLE
* Bump 2.7 branch to 2.7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ jobs:
     - name: 2.6.6 / Parser tests
       rvm: 2.6.6
       script: bundle exec rake test_cov
-    - name: 2.7.1 / Parser tests
-      rvm: 2.7.1
+    - name: 2.7.2 / Parser tests
+      rvm: 2.7.2
       script: bundle exec rake test_cov
     - name: ruby-head / Parser tests
       rvm: ruby-head
@@ -29,8 +29,8 @@ jobs:
     - name: 2.6.6 / Rubocop tests
       rvm: 2.6.6
       script: ./ci/run_rubocop_specs
-    - name: 2.7.1 / Rubocop tests
-      rvm: 2.7.1
+    - name: 2.7.2 / Rubocop tests
+      rvm: 2.7.2
       script: ./ci/run_rubocop_specs
   allow_failures:
     - rvm: ruby-head

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -75,7 +75,7 @@ module Parser
     CurrentRuby = Ruby26
 
   when /^2\.7\./
-    current_version = '2.7.1'
+    current_version = '2.7.2'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby27', current_version
     end


### PR DESCRIPTION
Ruby 2.7.2 has been released.
https://www.ruby-lang.org/en/news/2020/10/02/ruby-2-7-2-released/

It seems like no changes have been made to ruby27.y where Parser gem should be changed (backported).
https://github.com/ruby/ruby/compare/v2_7_1...v2_7_2