### PR TITLE
Add LICENSE.txt to the gem

### DIFF
--- a/parser.gemspec
+++ b/parser.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     'source_code_uri' => "https://github.com/whitequark/parser/tree/v#{spec.version}"
   }
 
-  spec.files         = Dir['bin/*', 'lib/**/*.rb', 'parser.gemspec']
+  spec.files         = Dir['bin/*', 'lib/**/*.rb', 'parser.gemspec', 'LICENSE.txt']
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
It was removed while dropping git in gemspec (a70ed2ade8f6d4c12d0d30069a3bde0d447fb7b9).