### PR TITLE
* Optimize `SourceBuffer` line and column handling

### DIFF
--- a/test/test_source_buffer.rb
+++ b/test/test_source_buffer.rb
@@ -76,6 +76,8 @@ class TestSourceBuffer < Minitest::Test
     assert_equal [1, 1], @buffer.decompose_position(1)
     assert_equal [2, 0], @buffer.decompose_position(2)
     assert_equal [3, 1], @buffer.decompose_position(7)
+    assert_equal [3, 71], @buffer.decompose_position(42)
+    assert_raises { @buffer.decompose_position(-42) }
   end
 
   def test_decompose_position_mapped

--- a/test/test_source_buffer.rb
+++ b/test/test_source_buffer.rb
@@ -76,8 +76,8 @@ class TestSourceBuffer < Minitest::Test
     assert_equal [1, 1], @buffer.decompose_position(1)
     assert_equal [2, 0], @buffer.decompose_position(2)
     assert_equal [3, 1], @buffer.decompose_position(7)
-    assert_equal [3, 71], @buffer.decompose_position(42)
-    assert_raises { @buffer.decompose_position(-42) }
+    assert_equal [3, 36], @buffer.decompose_position(42)
+    assert_equal [0, -52], @buffer.decompose_position(-42)
   end
 
   def test_decompose_position_mapped


### PR DESCRIPTION
`#line_begins`:
- store `line_begin` instead of `[line_begin, index]`
- simplify code by storing an additional "virtual" line_begin at the end

caches for `position` => line / column: Use same cache instead of two.

`#decompose_position`: use cache there too

I added tests for behavior of some methods with out-of-range arguments.
Behavior arguably less bad after this PR.