### PR TITLE
Source buffer freeze

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -299,6 +299,12 @@ module Parser
         line_begins.size + @first_line - 2
       end
 
+      # :nodoc:
+      def freeze
+        source_lines; line_begins; source_range # build cache
+        super
+      end
+
       private
 
       # @returns [0, line_begin_of_line_1, ..., source.size + 1]

--- a/test/test_source_buffer.rb
+++ b/test/test_source_buffer.rb
@@ -164,4 +164,12 @@ class TestSourceBuffer < Minitest::Test
     @buffer.source = "foo\nbar"
     assert_equal ['foo', 'bar'], @buffer.source_lines
   end
+
+  def test_freeze
+    @buffer.source = "1\nfoo\nbar\n"
+    @buffer.freeze
+    @buffer.source_lines
+    @buffer.source_range
+    assert_equal 'foo', @buffer.line_range(2).source
+  end
 end


### PR DESCRIPTION
Builds on #755 and makes `SourceBuffer` freezable. Currently attempting to freeze before caches are build will crash.