### PR TITLE
Make `SourceBuffer` Ractor-shareable. Basic test for `Node`.

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -323,7 +323,11 @@ module Parser
 
       # @returns 0-based line index of position
       def line_index_for_position(position)
-        @line_index_for_position[position] ||= bsearch(line_begins, position) - 1
+        @line_index_for_position[position] || begin
+          index = bsearch(line_begins, position) - 1
+          @line_index_for_position[position] = index unless @line_index_for_position.frozen?
+          index
+        end
       end
 
       if Array.method_defined?(:bsearch_index) # RUBY_VERSION >= 2.3

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -28,4 +28,11 @@ class TestBase < Minitest::Test
     assert_nil ast.loc.dup.node
     Parser::AST::Node.new(:zsuper, [], :location => ast.loc)
   end
+
+  def test_node_ractor
+    ast = Parser::CurrentRuby.parse('1')
+    ::Ractor.make_shareable(ast)
+    assert ::Ractor.shareable?(ast)
+    assert_equal '1', ast.loc.expression.source
+  end if defined?(::Ractor)
 end

--- a/test/test_source_buffer.rb
+++ b/test/test_source_buffer.rb
@@ -172,4 +172,11 @@ class TestSourceBuffer < Minitest::Test
     @buffer.source_range
     assert_equal 'foo', @buffer.line_range(2).source
   end
+
+  def test_ractor
+    @buffer.source = "hello\n:world\nstrange\nodd"
+    ::Ractor.make_shareable(@buffer)
+    assert ::Ractor.shareable?(@buffer)
+    assert_equal ':world', @buffer.line_range(2).source
+  end if defined?(::Ractor)
 end


### PR DESCRIPTION
Build on #756 so that `SourceBuffer` is `Ractor`-shareable.

Since `Node`, `Range` and `Map` are typically frozen, there's probably no issue with them.
`SourceBuffer` is the only non-frozen element in the chain.

`Ractor` is still evolving, maybe you'll want to wait until X-mas to merge this...