### PR TITLE
- lexer.rl: don't perform lookahead after tASSOC.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -2384,7 +2384,7 @@ class Parser::Lexer
       '*' | '=>'
       => {
         emit_table(PUNCTUATION)
-        fgoto expr_value;
+        fnext expr_value; fbreak;
       };
 
       # When '|', '~', '!', '=>' are used as operators

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -9587,9 +9587,9 @@ class TestParser < Minitest::Test
       %w(2.7))
 
     assert_diagnoses(
-      [:error, :unexpected_token, { :token => 'tCOLON' }],
+      [:error, :unexpected_token, { :token => 'tLABEL' }],
       %{1 => a:},
-      %{      ^ location},
+      %{     ^^ location},
       SINCE_3_0)
   end
 


### PR DESCRIPTION
It fixes parsing of
```ruby
1 => foo
bar
```

```ruby
1 => A(foo)
```

and basically all single line patterns that consist of multiple tokens.
The second token of expr` in `pattern => expr` was interpreted in EXPR_BEG state instead of EXPR_ARG.

Closes #763