### PR TITLE
+ ruby30.y: allow endless method without arglist.

### DIFF
--- a/lib/parser/ruby30.y
+++ b/lib/parser/ruby30.y
@@ -847,7 +847,7 @@ rule
                       result = @builder.ternary(val[0], val[1],
                                                 val[2], val[4], val[5])
                     }
-                | defn_head f_paren_args tEQL arg
+                | defn_head f_opt_paren_args tEQL arg
                     {
                       _def_t, name_t = val[0]
                       endless_method_name(name_t)
@@ -861,7 +861,7 @@ rule
                       @context.pop
                       @current_arg_stack.pop
                     }
-                | defn_head f_paren_args tEQL arg kRESCUE_MOD arg
+                | defn_head f_opt_paren_args tEQL arg kRESCUE_MOD arg
                     {
                       _def_t, name_t = val[0]
                       endless_method_name(name_t)
@@ -881,7 +881,7 @@ rule
                       @context.pop
                       @current_arg_stack.pop
                     }
-                | defs_head f_paren_args tEQL arg
+                | defs_head f_opt_paren_args tEQL arg
                     {
                       _def_t, _recv, _dot_t, name_t = val[0]
                       endless_method_name(name_t)
@@ -895,7 +895,7 @@ rule
                       @context.pop
                       @current_arg_stack.pop
                     }
-                | defs_head f_paren_args tEQL arg kRESCUE_MOD arg
+                | defs_head f_opt_paren_args tEQL arg kRESCUE_MOD arg
                     {
                       _def_t, _recv, _dot_t, name_t = val[0]
                       endless_method_name(name_t)
@@ -2604,6 +2604,12 @@ keyword_variable: kNIL
                 | # nothing
                     {
                       result = nil
+                    }
+
+f_opt_paren_args: f_paren_args
+                | none
+                    {
+                      result = @builder.args(nil, [], nil)
                     }
 
    f_paren_args: tLPAREN2 f_args rparen

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -9682,21 +9682,6 @@ class TestParser < Minitest::Test
     Parser::Builders::Default.emit_forward_arg = true
   end
 
-  def test_endless_method_without_brackets
-    assert_diagnoses(
-      [:error, :unexpected_token, { :token => 'tEQL' }],
-      %Q{def foo = 42},
-      %q{        ^ location},
-      SINCE_3_0)
-
-    assert_diagnoses(
-      [:error, :unexpected_token, { :token => 'tEQL' }],
-      %Q{def obj.foo = 42},
-      %q{            ^ location},
-      SINCE_3_0
-    )
-  end
-
   def test_endless_method_with_rescue_mod
     assert_parses(
       s(:def, :m,
@@ -9994,6 +9979,48 @@ class TestParser < Minitest::Test
       [:error, :endless_setter],
       %q{def obj.foo=() = 42 rescue nil},
       %q{        ^^^^ location},
+      SINCE_3_0)
+  end
+
+  def test_endless_method_without_args
+    assert_parses(
+      s(:def, :foo,
+        s(:args),
+        s(:int, 42)),
+      %q{def foo = 42},
+      %q{},
+      SINCE_3_0)
+
+    assert_parses(
+      s(:def, :foo,
+        s(:args),
+        s(:rescue,
+          s(:int, 42),
+          s(:resbody, nil, nil,
+            s(:nil)), nil)),
+      %q{def foo = 42 rescue nil},
+      %q{},
+      SINCE_3_0)
+
+    assert_parses(
+      s(:defs,
+        s(:self), :foo,
+        s(:args),
+        s(:int, 42)),
+      %q{def self.foo = 42},
+      %q{},
+      SINCE_3_0)
+
+    assert_parses(
+      s(:defs,
+        s(:self), :foo,
+        s(:args),
+        s(:rescue,
+          s(:int, 42),
+          s(:resbody, nil, nil,
+            s(:nil)), nil)),
+      %q{def self.foo = 42 rescue nil},
+      %q{},
       SINCE_3_0)
   end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@bdd1d17.

Closes https://github.com/whitequark/parser/issues/754

I noticed that we have an exception to our rule that "all nodes have expression_l" - that's not true from the very beginning:

```sh
$ bin/ruby-parse --30 -L -e 'def m; end'
s(:def, :m,
  s(:args), nil)
def m; end
~~~ keyword
    ~ name
       ~~~ end
~~~~~~~~~~ expression
s(:args)
```

^ `args` node has absolutely no source maps. `def foo = 42` also emits a dummy `args` node.

@marcandre @mbj @palkan Side question for this PR (I'm going to merge it anyway as it doesn't break anything), but what's your hunch on how many things are going to break if we make `s(:args)` nullable?