### PR TITLE
+ lexer.rl: use more specific warning for ambiguous slash.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -1544,7 +1544,11 @@ class Parser::Lexer
       => {
         if tok(tm, tm + 1) == '/'.freeze
           # Ambiguous regexp literal.
-          diagnostic :warning, :ambiguous_literal, nil, range(tm, tm + 1)
+          if @version < 30
+            diagnostic :warning, :ambiguous_literal, nil, range(tm, tm + 1)
+          else
+            diagnostic :warning, :ambiguous_regexp, nil, range(tm, tm + 1)
+          end
         end
 
         p = tm - 1

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -35,6 +35,7 @@ module Parser
     # Lexer warnings
     :invalid_escape_use      => 'invalid character syntax; use ?%{escape}',
     :ambiguous_literal       => 'ambiguous first argument; put parentheses or a space even after the operator',
+    :ambiguous_regexp        => "ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator",
     :ambiguous_prefix        => "`%{prefix}' interpreted as argument prefix",
     :triple_dot_at_eol       => '... at EOL, should be parenthesized',
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -3106,7 +3106,19 @@ class TestParser < Minitest::Test
     assert_diagnoses(
       [:warning, :ambiguous_literal],
       %q{m /foo/},
-      %q{  ^ location})
+      %q{  ^ location},
+      ALL_VERSIONS - SINCE_3_0)
+
+    refute_diagnoses(
+      %q{m %[1]})
+  end
+
+  def test_send_plain_cmd_ambiguous_regexp
+    assert_diagnoses(
+      [:warning, :ambiguous_regexp],
+      %q{m /foo/},
+      %q{  ^ location},
+      SINCE_3_0)
 
     refute_diagnoses(
       %q{m %[1]})
@@ -6987,7 +6999,7 @@ class TestParser < Minitest::Test
         [:error, :unexpected_token, { :token => 'tLCURLY' }]
       ],
       %q{m /foo/ {}},
-      SINCE_2_4)
+      %w(2.4 2.5 2.6 2.7))
 
     assert_diagnoses_many(
       [
@@ -6995,7 +7007,7 @@ class TestParser < Minitest::Test
         [:error, :unexpected_token, { :token => 'tLCURLY' }]
       ],
       %q{m /foo/x {}},
-      SINCE_2_4)
+      %w(2.4 2.5 2.6 2.7))
   end
 
   def test_bug_447


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@f5bb911.

Closes https://github.com/whitequark/parser/issues/762