### PR TITLE
+ builder: emit implicit hash passed to a method call as kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ below for explanation of `emit_*` calls):
     Parser::Builders::Default.emit_index               = true
     Parser::Builders::Default.emit_arg_inside_procarg0 = true
     Parser::Builders::Default.emit_forward_arg         = true
+    Parser::Builders::Default.emit_kwargs              = true
 
 Parse a chunk of code:
 

--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -277,6 +277,23 @@ Format:
  ~~~~~~~~~~~~~~~~ expression
 ~~~
 
+### Kwargs
+
+Starting from Ruby 2.7 only implicit hash literals (that are not wrapped into `{ .. }`) are passed as keyword arguments.
+Explicit hash literals are passed as positional arguments.
+This is reflected in AST as `kwargs` node that is emitted only for implicit
+hash literals and only if `emit_kwargs` compatibility flag is enabled.
+
+Note that it can be a part of `send`, `csend`, `index` and `yield` nodes.
+
+Format:
+
+~~~
+(kwargs (pair (int 1) (int 2)) (kwsplat (lvar :bar)) (pair (sym :baz) (int 3)))
+"foo(1 => 2, **bar, baz: 3)"
+     ~~~~~~~~~~~~~~~~~~~~~ expression
+~~~
+
 #### Keyword splat (2.0)
 
 Can also be used in argument lists: `foo(bar, **baz)`

--- a/lib/parser/ast/processor.rb
+++ b/lib/parser/ast/processor.rb
@@ -20,6 +20,7 @@ module Parser
       alias on_array    process_regular_node
       alias on_pair     process_regular_node
       alias on_hash     process_regular_node
+      alias on_kwargs   process_regular_node
       alias on_irange   process_regular_node
       alias on_erange   process_regular_node
 

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -130,6 +130,54 @@ module Parser
 
     class << self
       ##
+      # AST compatibility attribute; Starting from Ruby 2.7 keyword arguments
+      # of method calls that are passed explicitly as a hash (i.e. with curly braces)
+      # are treated as positional arguments and Ruby 2.7 emits a warning on such method
+      # call. Ruby 3.0 given an ArgumentError.
+      #
+      # If set to false (the default) the last hash argument is emitted as `hash`:
+      #
+      # ```
+      # (send nil :foo
+      #   (hash
+      #     (pair
+      #       (sym :bar)
+      #       (int 42))))
+      # ```
+      #
+      # If set to true it is emitted as `kwargs`:
+      #
+      # ```
+      # (send nil :foo
+      #   (kwargs
+      #     (pair
+      #       (sym :bar)
+      #       (int 42))))
+      # ```
+      #
+      # Note that `kwargs` node is just a replacement for `hash` argument,
+      # so if there's are multiple arguments (or a `kwsplat`) all of them
+      # are wrapped into `kwargs` instead of `hash`:
+      #
+      # ```
+      # (send nil :foo
+      #   (hash
+      #     (pair
+      #       (sym :a)
+      #       (int 42))
+      #     (kwsplat
+      #       (send nil :b))
+      #     (pair
+      #       (sym :c)
+      #       (int 10))))
+      # ```
+      attr_accessor :emit_kwargs
+    end
+
+    @emit_kwargs = false
+
+    class << self
+      ##
       # @api private
       def modernize
         @emit_lambda = true
@@ -138,6 +186,7 @@ module Parser
         @emit_index = true
         @emit_arg_inside_procarg0 = true
         @emit_forward_arg = true
+        @emit_kwargs = true
       end
     end
 
@@ -927,6 +976,11 @@ module Parser
     def call_method(receiver, dot_t, selector_t,
                     lparen_t=nil, args=[], rparen_t=nil)
       type = call_type_for_dot(dot_t)
+
+      if self.class.emit_kwargs
+        rewrite_hash_args_to_kwargs(args)
+      end
+
       if selector_t.nil?
         n(type, [ receiver, :call, *args ],
           send_map(receiver, dot_t, nil, lparen_t, args, rparen_t))
@@ -1004,6 +1058,10 @@ module Parser
     end
 
     def index(receiver, lbrack_t, indexes, rbrack_t)
+      if self.class.emit_kwargs
+        rewrite_hash_args_to_kwargs(indexes)
+      end
+
       if self.class.emit_index
         n(:index, [ receiver, *indexes ],
           index_map(receiver, lbrack_t, rbrack_t))
@@ -1163,6 +1221,10 @@ module Parser
         last_arg = args.last
         if last_arg.type == :block_pass
           diagnostic :error, :block_given_to_yield, nil, loc(keyword_t), [last_arg.loc.expression]
+        end
+
+        if self.class.emit_kwargs
+          rewrite_hash_args_to_kwargs(args)
         end
       end
 
@@ -2097,6 +2159,20 @@ module Parser
       else
         true
       end
+    end
+
+    def rewrite_hash_args_to_kwargs(args)
+      if args.any? && kwargs?(args.last)
+        # foo(..., bar: baz)
+        args[args.length - 1] = args[args.length - 1].updated(:kwargs)
+      elsif args.length > 1 && args.last.type == :block_pass && kwargs?(args[args.length - 2])
+        # foo(..., bar: baz, &blk)
+        args[args.length - 2] = args[args.length - 2].updated(:kwargs)
+      end
+    end
+
+    def kwargs?(node)
+      node.type == :hash && node.loc.begin.nil? && node.loc.end.nil?
     end
   end
 

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1222,10 +1222,10 @@ module Parser
         if last_arg.type == :block_pass
           diagnostic :error, :block_given_to_yield, nil, loc(keyword_t), [last_arg.loc.expression]
         end
+      end
 
-        if self.class.emit_kwargs
-          rewrite_hash_args_to_kwargs(args)
-        end
+      if %i[yield super].include?(type) && self.class.emit_kwargs
+        rewrite_hash_args_to_kwargs(args)
       end
 
       n(type, args,

--- a/lib/parser/meta.rb
+++ b/lib/parser/meta.rb
@@ -31,7 +31,7 @@ module Parser
         match_var pin match_alt match_as match_rest
         array_pattern match_with_trailing_comma array_pattern_with_tail
         hash_pattern const_pattern if_guard unless_guard match_nil_pattern
-        empty_else find_pattern
+        empty_else find_pattern kwargs
       ).to_set.freeze
 
   end # Meta

--- a/lib/parser/ruby18.y
+++ b/lib/parser/ruby18.y
@@ -729,6 +729,9 @@ rule
        arg_value: arg
 
        aref_args: none
+                    {
+                      result = []
+                    }
                 | command opt_nl
                     {
                       result = [ val[0] ]

--- a/lib/parser/runner.rb
+++ b/lib/parser/runner.rb
@@ -37,7 +37,7 @@ module Parser
 
     private
 
-    LEGACY_MODES = %i[lambda procarg0 encoding index arg_inside_procarg0 forward_arg].freeze
+    LEGACY_MODES = %i[lambda procarg0 encoding index arg_inside_procarg0 forward_arg kwargs].freeze
 
     def runner_name
       raise NotImplementedError, "implement #{self.class}##{__callee__}"

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -3940,6 +3940,14 @@ class TestParser < Minitest::Test
             s(:sym, :foo),
             s(:int, 42)))),
       %q{yield(:foo => 42)})
+
+    assert_parses(
+      s(:super,
+        s(:hash,
+          s(:pair,
+            s(:sym, :foo),
+            s(:int, 42)))),
+      %q{super(:foo => 42)})
   ensure
     Parser::Builders::Default.emit_kwargs = true
   end
@@ -3982,6 +3990,14 @@ class TestParser < Minitest::Test
             s(:sym, :foo),
             s(:int, 42)))),
       %q{yield(:foo => 42)})
+
+    assert_parses(
+      s(:super,
+        s(:kwargs,
+          s(:pair,
+            s(:sym, :foo),
+            s(:int, 42)))),
+      %q{super(:foo => 42)})
   end
 
   def test_args_assocs_star


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/761.