### PR TITLE
* do not emit truncated parts of squiggly heredoc

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -359,18 +359,23 @@ module Parser
       if !dedent_level.nil?
         dedenter = Lexer::Dedenter.new(dedent_level)
 
-        if node.type == :str
+        case node.type
+        when :str
           str = node.children.first
           dedenter.dedent(str)
-        elsif node.type == :dstr || node.type == :xstr
-          node.children.each do |str_node|
+        when :dstr, :xstr
+          children = node.children.map do |str_node|
             if str_node.type == :str
               str = str_node.children.first
               dedenter.dedent(str)
+              next nil if str.empty?
             else
               dedenter.interrupt
             end
+            str_node
           end
+
+          node = node.updated(nil, children.compact)
         end
       end
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -400,7 +400,6 @@ class TestParser < Minitest::Test
       s(:send, nil, :p,
         s(:dstr,
           s(:str, "  x\n"),
-          s(:str, ""),
           s(:begin,
             s(:lvar, :foo)),
           s(:str, "\n"))),
@@ -412,7 +411,6 @@ class TestParser < Minitest::Test
       s(:send, nil, :p,
         s(:xstr,
           s(:str, "  x\n"),
-          s(:str, ""),
           s(:begin,
             s(:lvar, :foo)),
           s(:str, "\n"))),
@@ -424,7 +422,6 @@ class TestParser < Minitest::Test
       s(:send, nil, :p,
         s(:dstr,
           s(:str, "  x\n"),
-          s(:str, ""),
           s(:begin,
             s(:str, "  y")),
           s(:str, "\n"))),
@@ -10120,5 +10117,15 @@ class TestParser < Minitest::Test
       %q{def self.foo = 42 rescue nil},
       %q{},
       SINCE_3_0)
+  end
+
+  def test_parser_drops_truncated_parts_of_squiggly_heredoc
+    assert_parses(
+      s(:dstr,
+        s(:begin),
+        s(:str, "\n")),
+      %q{<<~HERE!  #{}!HERE}.gsub('!', "\n"),
+      %q{},
+      SINCE_2_3)
   end
 end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/772

So now
```
$ /bin/cat test.rb
<<~HEREDOC
  #{}
  #{}
HEREDOC

"#{}
#{}
"

"" ""
```

is parsed as
```
$ bin/ruby-parse --30 test.rb
(begin
  (dstr
    (begin)
    (str "\n")
    (begin)
    (str "\n"))
  (dstr
    (begin)
    (str "\n")
    (begin)
    (str "\n"))
  (dstr
    (str "")
    (str "")))
```

(two first cases are equivalent, the third case is not affected, we still emit all empty strings)