### PR TITLE
+ ruby30.y: reintroduce `expr in pat`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ below for explanation of `emit_*` calls):
     Parser::Builders::Default.emit_arg_inside_procarg0 = true
     Parser::Builders::Default.emit_forward_arg         = true
     Parser::Builders::Default.emit_kwargs              = true
+    Parser::Builders::Default.emit_match_pattern       = true
 
 Parse a chunk of code:
 

--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -1910,15 +1910,56 @@ Format:
 
 ## Pattern matching
 
-### Using `in` modifier
+### Using `in` operator
 
-Format:
+Ruby 2.7 throws a `NoMatchingPatternError` for `foo in bar` if given value doesn't match pattern.
+
+Format when `emit_match_pattern` compatibility attribute is disabled (the default):
 
 ~~~
 (in-match
   (int 1)
   (match-var :a))
 "1 in a"
+   ~~ operator
+ ~~~~~~ expression
+~~~
+
+Format when `emit_match_pattern` is enabled:
+
+~~~
+(match-pattern
+  (int 1)
+  (match-var :a))
+"1 in a"
+   ~~ operator
+ ~~~~~~ expression
+~~~
+
+Starting from 3.0 Ruby returns `true`/`false` for the same code construction.
+
+Ruby 3.0 format (compatibility attribute has no effect):
+
+~~~
+(match-pattern-p
+  (int 1)
+  (match-var :a))
+"1 in a"
+   ~~ operator
+ ~~~~~~ expression
+~~~
+
+### Using `=>` operator
+
+This node appears in AST only starting from Ruby 3.0.
+
+Format:
+
+~~~
+(match-pattern
+  (int 1)
+  (match-var :a))
+"1 => a"
    ~~ operator
  ~~~~~~ expression
 ~~~

--- a/lib/parser/ast/processor.rb
+++ b/lib/parser/ast/processor.rb
@@ -240,6 +240,8 @@ module Parser
 
       alias on_case_match              process_regular_node
       alias on_in_match                process_regular_node
+      alias on_match_pattern           process_regular_node
+      alias on_match_pattern_p         process_regular_node
       alias on_in_pattern              process_regular_node
       alias on_if_guard                process_regular_node
       alias on_unless_guard            process_regular_node

--- a/lib/parser/meta.rb
+++ b/lib/parser/meta.rb
@@ -32,6 +32,7 @@ module Parser
         array_pattern match_with_trailing_comma array_pattern_with_tail
         hash_pattern const_pattern if_guard unless_guard match_nil_pattern
         empty_else find_pattern kwargs
+        match_pattern_p match_pattern
       ).to_set.freeze
 
   end # Meta

--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -295,7 +295,11 @@ rule
                   p_expr
                     {
                       @lexer.in_kwarg = val[2]
-                      result = @builder.in_match(val[0], val[1], val[3])
+                      if @builder.class.emit_match_pattern
+                        result = @builder.match_pattern(val[0], val[1], val[3])
+                      else
+                        result = @builder.in_match(val[0], val[1], val[3])
+                      end
                     }
                 | arg =tLBRACE_ARG
 

--- a/lib/parser/ruby30.y
+++ b/lib/parser/ruby30.y
@@ -296,7 +296,21 @@ rule
                   p_expr
                     {
                       @lexer.in_kwarg = val[2]
-                      result = @builder.in_match(val[0], val[1], val[3])
+                      result = @builder.match_pattern(val[0], val[1], val[3])
+                    }
+                | arg kIN
+                    {
+                      @lexer.state = :expr_beg
+                      @lexer.command_start = false
+                      pattern_variables.push
+
+                      result = @lexer.in_kwarg
+                      @lexer.in_kwarg = true
+                    }
+                  p_expr
+                    {
+                      @lexer.in_kwarg = val[2]
+                      result = @builder.match_pattern_p(val[0], val[1], val[3])
                     }
                 | arg =tLBRACE_ARG
 

--- a/lib/parser/runner.rb
+++ b/lib/parser/runner.rb
@@ -37,7 +37,7 @@ module Parser
 
     private
 
-    LEGACY_MODES = %i[lambda procarg0 encoding index arg_inside_procarg0 forward_arg kwargs].freeze
+    LEGACY_MODES = %i[lambda procarg0 encoding index arg_inside_procarg0 forward_arg kwargs match_pattern].freeze
 
     def runner_name
       raise NotImplementedError, "implement #{self.class}##{__callee__}"

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -9556,7 +9556,8 @@ class TestParser < Minitest::Test
     )
   end
 
-  def test_pattern_matching_single_line__27
+  def test_pattern_matching_single_line__27__legacy
+    Parser::Builders::Default.emit_match_pattern = false
     assert_parses(
       s(:begin,
         s(:in_match,
@@ -9568,19 +9569,47 @@ class TestParser < Minitest::Test
       %q{~~~~~~~~ expression (in_match)
         |  ~~ operator (in_match)},
       %w(2.7))
+  ensure
+    Parser::Builders::Default.emit_match_pattern = true
+  end
+
+  def test_pattern_matching_single_line__27
+    assert_parses(
+      s(:begin,
+        s(:match_pattern,
+          s(:int, 1),
+          s(:array_pattern,
+            s(:match_var, :a))),
+        s(:lvar, :a)),
+      %q{1 in [a]; a},
+      %q{~~~~~~~~ expression (match_pattern)
+        |  ~~ operator (match_pattern)},
+      %w(2.7))
   end
 
   def test_pattern_matching_single_line
     assert_parses(
       s(:begin,
-        s(:in_match,
+        s(:match_pattern,
           s(:int, 1),
           s(:array_pattern,
             s(:match_var, :a))),
         s(:lvar, :a)),
       %q{1 => [a]; a},
-      %q{~~~~~~~~ expression (in_match)
-        |  ~~ operator (in_match)},
+      %q{~~~~~~~~ expression (match_pattern)
+        |  ~~ operator (match_pattern)},
+      SINCE_3_0)
+
+    assert_parses(
+      s(:begin,
+        s(:match_pattern_p,
+          s(:int, 1),
+          s(:array_pattern,
+            s(:match_var, :a))),
+        s(:lvar, :a)),
+      %q{1 in [a]; a},
+      %q{~~~~~~~~ expression (match_pattern_p)
+        |  ~~ operator (match_pattern_p)},
       SINCE_3_0)
   end
 


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@88f3ce1.

Closes https://github.com/whitequark/parser/issues/775

So, if compatibility flag is disabled:

+ 2.7 emits `foo in bar` as `in_match`
+ 3.0.. emits `foo in bar` as `match_pattern_p`, `foo => bar` as `match_pattern`

If enabled:

+ 2.7 emits `foo in bar` as `match_pattern` (because it throws)
+ 3.0.. emits `foo in bar` as `match_pattern_p`, `foo => bar` as `match_pattern`

This flag doesn't affect 3.0 at all. I think it's incorrect to emit `foo in bar` as `in_match` on 3.0. On 2.7 this node has a different meaning (throw vs true/false), and so it must be a different node.

It's a bit chaotic with the flag being disabled, but
1. There's no way to misinterpret throwing and bool versions (even when multiple grammars are used).
2. It doesn't break 2.7 when disabled
3. Just enable the flag to have `match_pattern` vs `match_pattern_p` on all versions