### PR TITLE
+ `Source::TreeRewriter#inspect` [#728]

### DIFF
--- a/lib/parser/source/tree_rewriter.rb
+++ b/lib/parser/source/tree_rewriter.rb
@@ -330,6 +330,11 @@ module Parser
         @in_transaction
       end
 
+      # :nodoc:
+      def inspect
+        "#<#{self.class} #{source_buffer.name}: #{action_summary}>"
+      end
+
       ##
       # @api private
       # @deprecated Use insert_after or wrap
@@ -360,6 +365,28 @@ module Parser
       attr_reader :action_root
 
       private
+
+      def action_summary
+        replacements = as_replacements
+        case replacements.size
+        when 0 then return 'empty'
+        when 1..3 then #ok
+        else
+          replacements = replacements.first(3)
+          suffix = '…'
+        end
+        parts = replacements.map do |(range, str)|
+          if str.empty? # is this a deletion?
+            "-#{range.to_range}"
+          elsif range.size == 0 # is this an insertion?
+            "+#{str.inspect}@#{range.begin_pos}"
+          else # it is a replacement
+            "^#{str.inspect}@#{range.to_range}"
+          end
+        end
+        parts << suffix if suffix
+        parts.join(', ')
+      end
 
       ACTIONS = %i[accept warn raise].freeze
       def check_policy_validity

--- a/test/test_source_tree_rewriter.rb
+++ b/test/test_source_tree_rewriter.rb
@@ -358,4 +358,15 @@ class TestSourceTreeRewriterImport < Minitest::Test
     assert_equal @rewriter, @rewriter.import!(@rewriter2)
     assert_equal @rewriter, @rewriter.import!(@rewriter, offset: 42)
   end
+
+  def test_inspect
+    assert_equal '#<Parser::Source::TreeRewriter (rewriter): empty>', @rewriter.inspect
+    @rewriter.insert_before(@hello, '[')
+    @rewriter.replace(@ll, 'xxx')
+    @rewriter.remove(@comma_space)
+    assert_equal '#<Parser::Source::TreeRewriter (rewriter): +"["@5, ^"xxx"@8...10, -11...13>', @rewriter.inspect
+    @rewriter.insert_before(@hello, '{')
+    @rewriter.remove(@world)
+    assert_equal '#<Parser::Source::TreeRewriter (rewriter): +"{["@5, ^"xxx"@8...10, -11...13, …>', @rewriter.inspect
+  end
 end


### PR DESCRIPTION
This provide a short `inspect` for TreeRewriter. I thought it might be useful to add a summarized summary of the actions of the rewriter, either "empty", or a mix of additions (`+"insert me"@42`), deletions (`-55...60`) and replacements (`^"replacement"@77...88), but I can change of remove if that's too cryptic. The main goal was to avoid an `inspect` that was really very long.