### PR TITLE
* Bump maintenance branches to 3.0.1, 2.7.3, 2.6.7, and 2.5.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.4.10", "2.5.8", "2.6.6", "2.7.2", "3.0.0", "jruby-9.2"]
+        ruby: ["2.4.10", "2.5.9", "2.6.7", "2.7.3", "3.0.1", "jruby-9.2"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"
             test_command: "bundle exec rake test || true"
           - ruby: "truffleruby"
             test_command: "bundle exec rake test || true"
-          - ruby: "3.0.0"
+          - ruby: "3.0.1"
             test_command: "./ci/run_rubocop_specs || true"
     steps:
     - uses: actions/checkout@v2

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -57,7 +57,7 @@ module Parser
     CurrentRuby = Ruby24
 
   when /^2\.5\./
-    current_version = '2.5.8'
+    current_version = '2.5.9'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby25', current_version
     end
@@ -66,7 +66,7 @@ module Parser
     CurrentRuby = Ruby25
 
   when /^2\.6\./
-    current_version = '2.6.6'
+    current_version = '2.6.7'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby26', current_version
     end
@@ -75,7 +75,7 @@ module Parser
     CurrentRuby = Ruby26
 
   when /^2\.7\./
-    current_version = '2.7.2'
+    current_version = '2.7.3'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby27', current_version
     end
@@ -84,7 +84,7 @@ module Parser
     CurrentRuby = Ruby27
 
   when /^3\.0\./
-    current_version = '3.0.0'
+    current_version = '3.0.1'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby30', current_version
     end

--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -872,6 +872,14 @@ rule
                     {
                       result = val
                     }
+                | tLPAREN2 args tCOMMA args_forward rparen
+                    {
+                      unless @static_env.declared_forward_args?
+                        diagnostic :error, :unexpected_token, { :token => 'tBDOT3' } , val[3]
+                      end
+
+                      result = [val[0], [*val[1], @builder.forwarded_args(val[3])], val[4]]
+                    }
                 | tLPAREN2 args_forward rparen
                     {
                       unless @static_env.declared_forward_args?
@@ -2545,6 +2553,12 @@ keyword_variable: kNIL
                       result = @builder.args(val[0], val[1], val[2])
 
                       @lexer.state = :expr_value
+                    }
+                | tLPAREN2 f_arg tCOMMA args_forward rparen
+                    {
+                      args = [ *val[1], @builder.forward_arg(val[3]) ]
+                      result = @builder.args(val[0], args, val[4])
+                      @static_env.declare_forward_args
                     }
                 | tLPAREN2 args_forward rparen
                     {

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7992,7 +7992,7 @@ class TestParser < Minitest::Test
       [:error, :unexpected_token, { :token => 'tBDOT3' }],
       %q{def foo(x,y,z); bar(x, y, z, ...); end},
       %q{                             ^^^ location},
-      SINCE_3_0)
+      SINCE_2_7)
 
     assert_diagnoses(
       [:error, :unexpected_token, { :token => 'tBDOT3' }],
@@ -8085,7 +8085,7 @@ class TestParser < Minitest::Test
         |       ~~~~~~~~~~~ expression (args)
         |                 ~ end (args)
         |              ~~~ expression (args.forward_arg)},
-      SINCE_3_0)
+      SINCE_2_7)
   end
 
 


### PR DESCRIPTION
These Rubies has been released.

- https://www.ruby-lang.org/ja/news/2021/04/05/ruby-3-0-1-released/
- https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-7-3-released/
- https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-6-7-released/
- https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-5-9-released/

## Ruby 3.0 branch

Bump 3.0 branch from 3.0.0 to 3.0.1
https://github.com/ruby/ruby/compare/v3_0_0...v3_0_1

There seems to be no change to the syntax.

## Ruby 2.7 branch

Bump 2.7 branch from 2.7.2 to 2.7.3
https://github.com/ruby/ruby/compare/v2_7_2...v2_7_3

There is the leading arguments support to arguments forwarding change to the syntax.
Thas PR is backport #712 to Ruby 2.7 branch.

cf. https://github.com/ruby/ruby/commit/27fca66207f2c35f2f44f6a7cbbe6fd153546082

## Ruby 2.6 branch

Bump 2.6 branch from 2.6.6 to 2.6.7
https://github.com/ruby/ruby/compare/v2_6_6...v2_6_7

There seems to be no change to the syntax.

## Ruby 2.5 branch

Bump 2.5 branch from 2.5.8 to 2.5.9
https://github.com/ruby/ruby/compare/v2_5_8...v2_5_9

There seems to be no change to the syntax.