### PR TITLE
vertical bar is not a valid character in an lvar name

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1724,7 +1724,7 @@ module Parser
     end
 
     def check_lvar_name(name, loc)
-      if name =~ /\A[[[:lower:]]|_][[[:alnum:]]_]*\z/
+      if name =~ /\A[[[:lower:]]_][[[:alnum:]]_]*\z/
         # OK
       else
         diagnostic :error, :lvar_name, { name: name }, loc


### PR DESCRIPTION
I just happened to notice this via visual inspection (this regular expression happens to be problematic for Opal, see https://github.com/opal/opal/issues/2195 for workaround)