### PR TITLE
- fix a false positive for endless method definition

### DIFF
--- a/lib/parser/ruby30.y
+++ b/lib/parser/ruby30.y
@@ -3071,7 +3071,7 @@ require 'parser'
   end
 
   def endless_method_name(name_t)
-    if name_t[0].end_with?('=')
+    if !%w[=== == != <= >=].include?(name_t[0]) && name_t[0].end_with?('=')
       diagnostic :error, :endless_setter, nil, name_t
     end
   end

--- a/lib/parser/ruby31.y
+++ b/lib/parser/ruby31.y
@@ -3071,7 +3071,7 @@ require 'parser'
   end
 
   def endless_method_name(name_t)
-    if name_t[0].end_with?('=')
+    if !%w[=== == != <= >=].include?(name_t[0]) && name_t[0].end_with?('=')
       diagnostic :error, :endless_setter, nil, name_t
     end
   end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -10107,6 +10107,19 @@ class TestParser < Minitest::Test
       SINCE_3_0)
   end
 
+  def test_endless_comparison_method
+    %i[=== == != <= >= !=].each do |method_name|
+      assert_parses(
+        s(:def, method_name,
+          s(:args,
+            s(:arg, :other)),
+          s(:send, nil, :do_something)),
+        %Q{def #{method_name}(other) = do_something},
+        %q{},
+        SINCE_3_0)
+    end
+  end
+
   def test_endless_method_without_args
     assert_parses(
       s(:def, :foo,


### PR DESCRIPTION
Fixes: #795.

This PR fixes false positives that comparison methods recognizes as a setter method.