### PR TITLE
+ Add `associate_by_identity` as an alternate to `associate`

### DIFF
--- a/lib/parser/source/comment.rb
+++ b/lib/parser/source/comment.rb
@@ -49,6 +49,19 @@ module Parser
       end
 
       ##
+      # Associate `comments` with `ast` nodes using identity.
+      #
+      # @param [Parser::AST::Node] ast
+      # @param [Array<Comment>]    comments
+      # @return [Hash<Parser::Source::Node, Array<Comment>>]
+      # @see Parser::Source::Comment::Associator#associate_by_identity
+      #
+      def self.associate_by_identity(ast, comments)
+        associator = Associator.new(ast, comments)
+        associator.associate_by_identity
+      end
+
+      ##
       # @param [Parser::Source::Range] range
       #
       def initialize(range)


### PR DESCRIPTION
In #184, it was noticed that `associate`'s result is unusable for separate nodes that might have identical content.

The method `associate_by_locations`, which uses locations instead of nodes as indices, was added as a workaround.

It was discussed at the time to change the definition of equality for `Node` (which was rejected) but it doesn't look like using `Hash#compare_by_identity` was discussed which surprises me. For any user of `parser` that does not play around its `Node`s and only uses those returned from parsing, this seems like the perfect solution.

This PR proposes to add `associate_by_identity` that does just that.

This would be helpful for rubocop/rubocop#9756 

If this is accepted, a release would be appreciated.