### PR TITLE
+ lexer.rl: reject `\u` after control/meta escape chars.

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -705,6 +705,11 @@ class Parser::Lexer
 
   action unescape_char {
     codepoint = @source_pts[p - 1]
+
+    if @version >= 30 && (codepoint == 117 || codepoint == 85) # 'u' or 'U'
+      diagnostic :fatal, :invalid_escape
+    end
+
     if (@escape = ESCAPES[codepoint]).nil?
       @escape = encode_escape(@source_buffer.slice(p - 1))
     end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@110f242.

Partially fixes https://github.com/whitequark/parser/issues/800