### PR TITLE
- lexer.rl: fix incompatible delimiters on percent literal

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -518,7 +518,8 @@ class Parser::Lexer
   c_nl_zlen  = c_nl | zlen;
   c_line     = any - c_nl_zlen;
 
-  c_unicode  = c_any - 0x00..0x7f;
+  c_ascii    = 0x00..0x7f;
+  c_unicode  = c_any - c_ascii;
   c_upper    = [A-Z];
   c_lower    = [a-z_]  | c_unicode;
   c_alpha    = c_lower | c_upper;
@@ -1406,7 +1407,7 @@ class Parser::Lexer
       ':'
       => { fhold; fgoto expr_beg; };
 
-      '%s' c_any
+      '%s' (c_ascii - [A-Za-z0-9])
       => {
         if version?(23)
           type, delimiter = tok[0..-2], tok[-1].chr
@@ -1758,14 +1759,14 @@ class Parser::Lexer
       };
 
       # %<string>
-      '%' ( any - [A-Za-z] )
+      '%' ( c_ascii - [A-Za-z0-9] )
       => {
         type, delimiter = @source_buffer.slice(@ts).chr, tok[-1].chr
         fgoto *push_literal(type, delimiter, @ts);
       };
 
       # %w(we are the people)
-      '%' [A-Za-z]+ c_any
+      '%' [A-Za-z] (c_ascii - [A-Za-z0-9])
       => {
         type, delimiter = tok[0..-2], tok[-1].chr
         fgoto *push_literal(type, delimiter, @ts);

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -2246,6 +2246,25 @@ class TestLexer < Minitest::Test
                    :tSTRING_END,     '%',    [6, 7])
   end
 
+  def test_string_pct_null
+    assert_scanned("%\0blah\0",
+                   :tSTRING_BEG,     "%\0",  [0, 2],
+                   :tSTRING_CONTENT, "blah", [2, 6],
+                   :tSTRING_END,     "\0",    [6, 7])
+  end
+
+  def test_string_pct_non_ascii
+    refute_scanned("%★foo★")
+  end
+
+  def test_string_pct_alphabet
+    refute_scanned("%AfooA")
+  end
+
+  def test_string_pct_number
+    refute_scanned("%1foo1")
+  end
+
   def test_string_pct_w
     assert_scanned("%w[s1 s2 ]",
                    :tQWORDS_BEG,     "%w[", [0, 3],
@@ -2291,6 +2310,26 @@ class TestLexer < Minitest::Test
                    :tSTRING_CONTENT, "def", [7, 10],
                    :tSPACE,          nil,   [10, 10],
                    :tSTRING_END,     ']',   [10, 11])
+  end
+
+  def test_string_pct_w_null
+    assert_scanned("%w\0abc\0",
+                   :tQWORDS_BEG,     "%w\0", [0, 3],
+                   :tSTRING_CONTENT, "abc",  [3, 6],
+                   :tSPACE,          nil,    [6, 6],
+                   :tSTRING_END,     "\0",   [6, 7])
+  end
+
+  def test_string_pct_w_non_ascii
+    refute_scanned("%w★foo★")
+  end
+
+  def test_string_pct_w_alphabet
+    refute_scanned("%wAfooA")
+  end
+
+  def test_string_pct_w_number
+    refute_scanned("%w1foo1")
   end
 
   def test_string_pct_i


### PR DESCRIPTION
CRuby only accepts ASCII characters except `[A-Za-z0-9]` as a delimiter
of percent literal, but the lexer accepts different characters.
For exmaple:

* CRuby accepts `%w^Dfoo^D`, but parser didn't (note: `^D` means 0x04)
* CRuby reject `%w1foo1`, but parser accepts
* CRuby reject `%w★foo★`, but parser accepts

This patch fixes the problems.


# Investigation of CRuby


CRuby parses percent literals here: https://github.com/ruby/ruby/blob/6072239121360293dbd2ed607f16b6a11668999a/parse.y#L8718-L8815



## ASCII delimiters

I confirmed Ruby 1.8 or greater accept all ASCII characters except alnum as delimiters with the following code.

`test.rb`

```ruby
(0..127).each do |n|
  next if /[a-zA-Z0-9()<>{}\[\]]/ =~ n.chr
  eval "%q#{n.chr}foo#{n.chr}"
end
```

```
$ docker run -it --rm -v $(pwd)/test.rb:/tmp/test.rb rubylang/all-ruby env ALL_RUBY_SINCE=1.8 ./all-ruby /tmp/test.rb
ruby-1.8.0
...
ruby-2.0.0-p648
ruby-2.1.0-preview1   (eval):1: warning: encountered \r in middle of line, treated as a mere space
...
ruby-2.7.4            (eval):1: warning: encountered \r in middle of line, treated as a mere space
ruby-3.0.0-preview1
...
ruby-3.0.2
```


## Number and multibyte delimiter


I also confirmed Ruby 1.8 or greater reject `1` and `★` as delimiters with the following commands.





```console
$ docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=1.8 ./all-ruby -ce '%q1foo1'
ruby-1.8.0            -e:1: unknown type of %string
                      %q1foo1
                         ^
                  exit 1
...
ruby-2.4.10           -e:1: unknown type of %string
                      %q1foo1
                         ^
                  exit 1
ruby-2.5.0-preview1   -e:1: unknown type of %string
                      %q1foo1
                      ^~~
                  exit 1
...
ruby-2.6.8            -e:1: unknown type of %string
                      %q1foo1
                      ^~~
                  exit 1
ruby-2.7.0-preview1   -e:1: unknown type of %string
                      %q1foo1
                      ^~~
                  exit 1
ruby-2.7.0-preview2   -e:1: unknown type of %string
                      %q1foo1
                      ^~~
                  exit 1
...
ruby-3.0.2            -e:1: unknown type of %string
                      %q1foo1
                      ^~~
                  exit 1
```

```console
$ docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=1.8 ./all-ruby -ce '%q★foo★'
ruby-1.8.0            -e:1: Invalid char `\230' in expression
                      -e:1: Invalid char `\205' in expression
                  exit 2
ruby-1.8.1            -e:1: Invalid char `\230' in expression
                      -e:1: Invalid char `\205' in expression
                  exit 1
...
ruby-1.8.7-p374       -e:1: Invalid char `\230' in expression
                      -e:1: Invalid char `\205' in expression
                  exit 1
ruby-1.9.0-0          -e:1: unknown type of %string
                      %q★foo★
                         ^
                  exit 1
...
ruby-2.4.10           -e:1: unknown type of %string
                      %q★foo★
                         ^
                  exit 1
ruby-2.5.0-preview1   -e:1: unknown type of %string
                      %q★foo★
                      ^~~
                  exit 1
...
ruby-2.6.8            -e:1: unknown type of %string
                      %q★foo★
                      ^~~
                  exit 1
ruby-2.7.0-preview1   -e:1: unknown type of %string
                      %q★foo★
                      ^~~
                  exit 1
ruby-2.7.0-preview2   -e:1: unknown type of %string
                      %q★foo★
                      ^~~
                  exit 1
...
ruby-2.7.4            -e:1: unknown type of %string
                      %q★foo★
                      ^~~
                  exit 1
ruby-3.0.0-preview1   -e:1: invalid multibyte char (US-ASCII)
                  exit 1
...
ruby-3.0.2            -e:1: invalid multibyte char (US-ASCII)
                  exit 1

```