### PR TITLE
Fix doc.

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -161,7 +161,7 @@ module Parser
       #
       # ```
       # (send nil :foo
-      #   (hash
+      #   (kwargs
       #     (pair
       #       (sym :a)
       #       (int 42))


### PR DESCRIPTION
The current documentation reads:

``` ruby
      # Note that `kwargs` node is just a replacement for `hash` argument,
      # so if there's are multiple arguments (or a `kwsplat`) all of them
      # are wrapped into `kwargs` instead of `hash`:
      #
      # ```
      # (send nil :foo
      #   (hash
      #     (pair
      #       (sym :a)
      #       (int 42))
      #     (kwsplat
      #       (send nil :b))
      #     (pair
      #       (sym :c)
      #       (int 10))))
      # ```
```

I believe the last `hash` was meant to be `kwargs`.