### PR TITLE
+ ruby31.y: Add pattern matching pin support for instance/class/global variables

### DIFF
--- a/lib/parser/ruby31.y
+++ b/lib/parser/ruby31.y
@@ -2302,6 +2302,12 @@ opt_block_args_tail:
                       result = @builder.pin(val[0], lvar)
                     }
 
+                | tCARET nonlocal_var
+                    {
+                      non_lvar = @builder.accessible(val[1])
+                      result = @builder.pin(val[0], non_lvar)
+                    }
+
       p_expr_ref: tCARET tLPAREN expr_value tRPAREN
                     {
                       expr = @builder.begin(val[1], val[2], val[3])
@@ -2577,6 +2583,19 @@ regexp_contents: # nothing
                     {
                       @lexer.state = :expr_end
                       result = @builder.complex(val[0])
+                    }
+
+    nonlocal_var: tIVAR
+                    {
+                      result = @builder.ivar(val[0])
+                    }
+                | tGVAR
+                    {
+                      result = @builder.gvar(val[0])
+                    }
+                | tCVAR
+                    {
+                      result = @builder.cvar(val[0])
                     }
 
    user_variable: tIDENTIFIER

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -10379,5 +10379,32 @@ class TestParser < Minitest::Test
         |        ~ end (in_pattern.pin.begin)
         |    ~~~~~ expression (in_pattern.pin.begin)},
       SINCE_3_1)
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:pin,
+          s(:ivar, :@a)), nil, nil),
+      %q{in ^@a},
+      %q{   ~ selector (in_pattern.pin)
+        |   ~~~ expression (in_pattern.pin)},
+      SINCE_3_1)
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:pin,
+          s(:cvar, :@@TestPatternMatching)), nil, nil),
+      %q{in ^@@TestPatternMatching},
+      %q{   ~ selector (in_pattern.pin)
+        |   ~~~~~~~~~~~~~~~~~~~~~~ expression (in_pattern.pin)},
+      SINCE_3_1)
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:pin,
+          s(:gvar, :$TestPatternMatching)), nil, nil),
+      %q{in ^$TestPatternMatching},
+      %q{   ~ selector (in_pattern.pin)
+        |   ~~~~~~~~~~~~~~~~~~~~~ expression (in_pattern.pin)},
+      SINCE_3_1)
   end
 end


### PR DESCRIPTION
Closes #812.

This commit tracks upstream commit https://github.com/ruby/ruby/commit/fa87f72.