### PR TITLE
+ ruby31.y: Allow value omission in Hash literals

### DIFF
--- a/lib/parser/ruby31.y
+++ b/lib/parser/ruby31.y
@@ -3098,6 +3098,11 @@ f_opt_paren_args: f_paren_args
                     {
                       result = @builder.pair_keyword(val[0], val[1])
                     }
+                | tLABEL
+                    {
+                      value = @builder.call_method(nil, nil, val[0])
+                      result = @builder.pair_keyword(val[0], value)
+                    }
                 | tSTRING_BEG string_contents tLABEL_END arg_value
                     {
                       result = @builder.pair_quoted(val[0], val[1], val[2], val[3])

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -10054,6 +10054,22 @@ class TestParser < Minitest::Test
       SINCE_3_1)
   end
 
+  def test_value_omission
+    assert_parses(
+      s(:hash,
+        s(:pair, s(:sym, :a), s(:send, nil, :a)),
+        s(:pair, s(:sym, :b), s(:send, nil, :b))),
+      %q{{a:, b:}},
+      %q{^ begin
+        |       ^ end
+        |  ^ operator (pair)
+        | ~ expression (pair.sym)
+        | ~~ expression (pair.send)
+        | ~~ expression (pair)
+        |~~~~~~~~ expression},
+      SINCE_3_1)
+  end
+
   def test_rasgn_line_continuation
     assert_diagnoses(
       [:error, :unexpected_token, { :token => 'tASSOC' }],


### PR DESCRIPTION
Closes #817.

This commit tracks upstream commit https://github.com/ruby/ruby/commit/c60dbcd