### PR TITLE
- ruby31.y: handle local variables as hash labels with omitted values

### DIFF
--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -266,6 +266,42 @@ Format:
  ~~~~~~~~~~ expression (pair)
 ~~~
 
+#### With local variable
+
+Format:
+
+~~~
+(pair (sym :foo) (lvar :foo))
+"{foo:}"
+     ^ operator (pair)
+  ~~~ expression (sym)
+  ~~~ expression (lvar)
+~~~
+
+#### With constant
+
+Format:
+
+~~~
+(pair (sym :foo) (const nil :foo))
+"{FOO:}"
+     ^ operator (pair)
+  ~~~ expression (const)
+  ~~~ expression (lvar)
+~~~
+
+#### With method call
+
+Format:
+
+~~~
+(pair (sym :puts) (send nil :puts))
+"{puts:}"
+      ^ operator (pair)
+  ~~~~ expression (sym)
+  ~~~~ expression (send)
+~~~
+
 #### Plain
 
 Format:

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -76,6 +76,7 @@ module Parser
     :duplicate_variable_name      => 'duplicate variable name %{name}',
     :duplicate_pattern_key        => 'duplicate hash pattern key %{name}',
     :endless_setter               => 'setter method cannot be defined in an endless method definition',
+    :invalid_id_to_get            => 'identifier %{identifier} is not valid to get',
 
     # Parser warnings
     :useless_else            => 'else without rescue is useless',

--- a/lib/parser/ruby30.y
+++ b/lib/parser/ruby30.y
@@ -2219,7 +2219,7 @@ opt_block_args_tail:
 
       p_variable: tIDENTIFIER
                     {
-                      result = @builder.match_var(val[0])
+                      result = @builder.assignable(@builder.match_var(val[0]))
                     }
 
        p_var_ref: tCARET tIDENTIFIER
@@ -2556,46 +2556,6 @@ keyword_variable: kNIL
 
          var_ref: user_variable
                     {
-                      if (node = val[0]) && node.type == :ident
-                        name = node.children[0]
-
-                        if name =~ /\A_[1-9]\z/ && !static_env.declared?(name) && context.in_dynamic_block?
-                          # definitely an implicit param
-                          location = node.loc.expression
-
-                          if max_numparam_stack.has_ordinary_params?
-                            diagnostic :error, :ordinary_param_defined, nil, [nil, location]
-                          end
-
-                          raw_context = context.stack.dup
-                          raw_max_numparam_stack = max_numparam_stack.stack.dup
-
-                          # ignore current block scope
-                          raw_context.pop
-                          raw_max_numparam_stack.pop
-
-                          raw_context.reverse_each do |outer_scope|
-                            if outer_scope == :block || outer_scope == :lambda
-                              outer_scope_has_numparams = raw_max_numparam_stack.pop > 0
-
-                              if outer_scope_has_numparams
-                                diagnostic :error, :numparam_used_in_outer_scope, nil, [nil, location]
-                              else
-                                # for now it's ok, but an outer scope can also be a block
-                                # with numparams, so we need to continue
-                              end
-                            else
-                              # found an outer scope that can't have numparams
-                              # like def/class/etc
-                              break
-                            end
-                          end
-
-                          static_env.declare(name)
-                          max_numparam_stack.register(name[1].to_i)
-                        end
-                      end
-
                       result = @builder.accessible(val[0])
                     }
                 | keyword_variable
@@ -3073,5 +3033,49 @@ require 'parser'
   def endless_method_name(name_t)
     if !%w[=== == != <= >=].include?(name_t[0]) && name_t[0].end_with?('=')
       diagnostic :error, :endless_setter, nil, name_t
+    end
+  end
+
+  def try_declare_numparam(node)
+    name = node.children[0]
+
+    if name =~ /\A_[1-9]\z/ && !static_env.declared?(name) && context.in_dynamic_block?
+      # definitely an implicit param
+      location = node.loc.expression
+
+      if max_numparam_stack.has_ordinary_params?
+        diagnostic :error, :ordinary_param_defined, nil, [nil, location]
+      end
+
+      raw_context = context.stack.dup
+      raw_max_numparam_stack = max_numparam_stack.stack.dup
+
+      # ignore current block scope
+      raw_context.pop
+      raw_max_numparam_stack.pop
+
+      raw_context.reverse_each do |outer_scope|
+        if outer_scope == :block || outer_scope == :lambda
+          outer_scope_has_numparams = raw_max_numparam_stack.pop > 0
+
+          if outer_scope_has_numparams
+            diagnostic :error, :numparam_used_in_outer_scope, nil, [nil, location]
+          else
+            # for now it's ok, but an outer scope can also be a block
+            # with numparams, so we need to continue
+          end
+        else
+          # found an outer scope that can't have numparams
+          # like def/class/etc
+          break
+        end
+      end
+
+      static_env.declare(name)
+      max_numparam_stack.register(name[1].to_i)
+
+      true
+    else
+      false
     end
   end

--- a/lib/parser/ruby31.y
+++ b/lib/parser/ruby31.y
@@ -2288,7 +2288,7 @@ opt_block_args_tail:
 
       p_variable: tIDENTIFIER
                     {
-                      result = @builder.match_var(val[0])
+                      result = @builder.assignable(@builder.match_var(val[0]))
                     }
 
        p_var_ref: tCARET tIDENTIFIER
@@ -2650,46 +2650,6 @@ keyword_variable: kNIL
 
          var_ref: user_variable
                     {
-                      if (node = val[0]) && node.type == :ident
-                        name = node.children[0]
-
-                        if name =~ /\A_[1-9]\z/ && !static_env.declared?(name) && context.in_dynamic_block?
-                          # definitely an implicit param
-                          location = node.loc.expression
-
-                          if max_numparam_stack.has_ordinary_params?
-                            diagnostic :error, :ordinary_param_defined, nil, [nil, location]
-                          end
-
-                          raw_context = context.stack.dup
-                          raw_max_numparam_stack = max_numparam_stack.stack.dup
-
-                          # ignore current block scope
-                          raw_context.pop
-                          raw_max_numparam_stack.pop
-
-                          raw_context.reverse_each do |outer_scope|
-                            if outer_scope == :block || outer_scope == :lambda
-                              outer_scope_has_numparams = raw_max_numparam_stack.pop > 0
-
-                              if outer_scope_has_numparams
-                                diagnostic :error, :numparam_used_in_outer_scope, nil, [nil, location]
-                              else
-                                # for now it's ok, but an outer scope can also be a block
-                                # with numparams, so we need to continue
-                              end
-                            else
-                              # found an outer scope that can't have numparams
-                              # like def/class/etc
-                              break
-                            end
-                          end
-
-                          static_env.declare(name)
-                          max_numparam_stack.register(name[1].to_i)
-                        end
-                      end
-
                       result = @builder.accessible(val[0])
                     }
                 | keyword_variable
@@ -3100,8 +3060,7 @@ f_opt_paren_args: f_paren_args
                     }
                 | tLABEL
                     {
-                      value = @builder.call_method(nil, nil, val[0])
-                      result = @builder.pair_keyword(val[0], value)
+                      result = @builder.pair_label(val[0])
                     }
                 | tSTRING_BEG string_contents tLABEL_END arg_value
                     {
@@ -3172,5 +3131,49 @@ require 'parser'
   def endless_method_name(name_t)
     if !%w[=== == != <= >=].include?(name_t[0]) && name_t[0].end_with?('=')
       diagnostic :error, :endless_setter, nil, name_t
+    end
+  end
+
+  def try_declare_numparam(node)
+    name = node.children[0]
+
+    if name =~ /\A_[1-9]\z/ && !static_env.declared?(name) && context.in_dynamic_block?
+      # definitely an implicit param
+      location = node.loc.expression
+
+      if max_numparam_stack.has_ordinary_params?
+        diagnostic :error, :ordinary_param_defined, nil, [nil, location]
+      end
+
+      raw_context = context.stack.dup
+      raw_max_numparam_stack = max_numparam_stack.stack.dup
+
+      # ignore current block scope
+      raw_context.pop
+      raw_max_numparam_stack.pop
+
+      raw_context.reverse_each do |outer_scope|
+        if outer_scope == :block || outer_scope == :lambda
+          outer_scope_has_numparams = raw_max_numparam_stack.pop > 0
+
+          if outer_scope_has_numparams
+            diagnostic :error, :numparam_used_in_outer_scope, nil, [nil, location]
+          else
+            # for now it's ok, but an outer scope can also be a block
+            # with numparams, so we need to continue
+          end
+        else
+          # found an outer scope that can't have numparams
+          # like def/class/etc
+          break
+        end
+      end
+
+      static_env.declare(name)
+      max_numparam_stack.register(name[1].to_i)
+
+      true
+    else
+      false
     end
   end


### PR DESCRIPTION
There's a new rule in 3.1 that allows hash value to be omitted if it's equal to key:
```sh
$ ./miniruby -ve 'p({ rand: })'
ruby 3.1.0dev (2021-09-24T13:56:38Z master 40a65030e5) [x86_64-darwin20]
{:rand=>0.6152290626750991}
```

We backported it in https://github.com/whitequark/parser/pull/818, but there's one case that we missed - local variables can also be used:
```sh
./miniruby -ve 'foo = 1; p({ foo: })'
ruby 3.1.0dev (2021-09-24T13:56:38Z master 40a65030e5) [x86_64-darwin20]
{:foo=>1}
```

This PR amends this logic.

And of course, there are implications like circular arguments validation that was missing:
```
$ /bin/cat ../ruby/test.rb
def m(a = { a: })
end

$ bin/ruby-parse --31 ../ruby/test.rb
../ruby/test.rb:1:13: error: circular argument reference a
../ruby/test.rb:1: def m(a = { a: })
../ruby/test.rb:1:             ^

$ ../ruby/miniruby -cv ../ruby/test.rb
ruby 3.1.0dev (2021-09-24T13:56:38Z master 40a65030e5) [x86_64-darwin20]
../ruby/test.rb:1: circular argument reference - a
```

@marcandre @koic @mbj @palkan Can I get a review of this API please? Are there any issues with multiple nodes having the same source location?