### PR TITLE
+ lexer.rl: parse meta-control-hex chars in regexes starting from 3.1

### DIFF
--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -3719,4 +3719,29 @@ class TestLexer < Minitest::Test
     refute_scanned_meta_escape_slash_u('"\M-\u0000"')
     refute_scanned_meta_escape_slash_u('"\M-\U0000"')
   end
+
+  def test_meta_control_hex_escaped_char
+    setup_lexer(19)
+
+    assert_scanned("\"\\c\\xFF\"",
+                    :tSTRING, "\x9F", [0, 8])
+
+    assert_scanned("\"\\c\\M-\\xFF\"",
+                    :tSTRING, "\x9F", [0, 11])
+
+    assert_scanned("\"\\C-\\xFF\"",
+                    :tSTRING, "\x9F", [0, 9])
+
+    assert_scanned("\"\\C-\\M-\\xFF\"",
+                    :tSTRING, "\x9F", [0, 12])
+
+    assert_scanned("\"\\M-\\xFF\"",
+                    :tSTRING, "\x9F", [0, 9])
+
+    assert_scanned("\"\\M-\\C-\\xFF\"",
+                    :tSTRING, "\x9F", [0, 12])
+
+    assert_scanned("\"\\M-\\c\\xFF\"",
+                    :tSTRING, "\x9F", [0, 11])
+  end
 end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -5608,7 +5608,7 @@ class TestParser < Minitest::Test
         s(:str, "")),
       %q{/\xa8/n =~ ""}.dup.force_encoding(Encoding::UTF_8),
       %{},
-      SINCE_1_9)
+      SINCE_3_1 - SINCE_1_9)
   end
 
   #
@@ -6513,7 +6513,7 @@ class TestParser < Minitest::Test
         s(:str, "#")),
       %q{[/()\\1/, ?#]},
       %q{},
-      SINCE_1_9)
+      SINCE_3_1 - SINCE_1_9)
   end
 
   def test_parser_bug_272
@@ -10670,6 +10670,52 @@ class TestParser < Minitest::Test
       [:warning, :duplicate_hash_key],
       %q{ { /foo/ => 1, /foo/ => 2 } },
       %q{               ~~~~~ location},
+      SINCE_3_1)
+  end
+
+  def test_control_meta_escape_chars_in_regexp
+    x9f = "\x9F".dup.force_encoding('ascii-8bit')
+
+    assert_parses(
+      s(:regexp, s(:str, x9f), s(:regopt)),
+      %q{/\c\xFF/}.dup.force_encoding('ascii-8bit'),
+      %q{},
+      SINCE_3_1)
+
+    assert_parses(
+      s(:regexp, s(:str, x9f), s(:regopt)),
+      %q{/\c\M-\xFF/}.dup.force_encoding('ascii-8bit'),
+      %q{},
+      SINCE_3_1)
+
+    assert_parses(
+      s(:regexp, s(:str, x9f), s(:regopt)),
+      %q{/\C-\xFF/}.dup.force_encoding('ascii-8bit'),
+      %q{},
+      SINCE_3_1)
+
+    assert_parses(
+      s(:regexp, s(:str, x9f), s(:regopt)),
+      %q{/\C-\M-\xFF/}.dup.force_encoding('ascii-8bit'),
+      %q{},
+      SINCE_3_1)
+
+    assert_parses(
+      s(:regexp, s(:str, x9f), s(:regopt)),
+      %q{/\M-\xFF/}.dup.force_encoding('ascii-8bit'),
+      %q{},
+      SINCE_3_1)
+
+    assert_parses(
+      s(:regexp, s(:str, x9f), s(:regopt)),
+      %q{/\M-\C-\xFF/}.dup.force_encoding('ascii-8bit'),
+      %q{},
+      SINCE_3_1)
+
+    assert_parses(
+      s(:regexp, s(:str, x9f), s(:regopt)),
+      %q{/\M-\c\xFF/}.dup.force_encoding('ascii-8bit'),
+      %q{},
       SINCE_3_1)
   end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@11ae581.

Completely closes https://github.com/whitequark/parser/issues/800