### PR TITLE
* Bump maintenance branches to 3.0.3, 2.7.5, and 2.6.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.4.10", "2.5.9", "2.6.8", "2.7.4", "3.0.2", "jruby-9.2"]
+        ruby: ["2.4.10", "2.5.9", "2.6.9", "2.7.5", "3.0.3", "jruby-9.2"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"
             test_command: "bundle exec rake test || true"
           - ruby: "truffleruby"
             test_command: "bundle exec rake test || true"
-          - ruby: "3.0.2"
+          - ruby: "3.0.3"
             test_command: "./ci/run_rubocop_specs || true"
     steps:
     - uses: actions/checkout@v2

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -66,7 +66,7 @@ module Parser
     CurrentRuby = Ruby25
 
   when /^2\.6\./
-    current_version = '2.6.8'
+    current_version = '2.6.9'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby26', current_version
     end
@@ -75,7 +75,7 @@ module Parser
     CurrentRuby = Ruby26
 
   when /^2\.7\./
-    current_version = '2.7.4'
+    current_version = '2.7.5'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby27', current_version
     end
@@ -84,7 +84,7 @@ module Parser
     CurrentRuby = Ruby27
 
   when /^3\.0\./
-    current_version = '3.0.2'
+    current_version = '3.0.3'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby30', current_version
     end


### PR DESCRIPTION
These Rubies has been released.

- https://www.ruby-lang.org/en/news/2021/11/24/ruby-3-0-3-released/
- https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-7-5-released/
- https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-6-9-released/

## Ruby 3.0 branch

Bump 3.0 branch from 3.0.2 to 3.0.3

https://github.com/ruby/ruby/compare/v3_0_2...v3_0_3

There seems to be no change to the syntax.

## Ruby 2.7 branch

Bump 2.7 branch from 2.7.4 to 2.7.5

https://github.com/ruby/ruby/compare/v2_7_4...v2_7_5

There seems to be no change to the syntax.

## Ruby 2.6 branch

Bump 2.6 branch from 2.6.8 to 2.6.9

https://github.com/ruby/ruby/compare/v2_6_8...v2_6_9

There seems to be no change to the syntax.