### PR TITLE
fix escaping of ctrl- and meta-chars in regexes

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -937,7 +937,11 @@ class Parser::Lexer
         #   b"
         # must be parsed as "ab"
         current_literal.extend_string(tok.gsub("\\\n".freeze, ''.freeze), @ts, @te)
-      elsif current_literal.regexp? && @version < 31
+      elsif current_literal.regexp? && @version >= 31 && %w[c C m M].include?(escaped_char)
+        # Ruby >= 3.1 escapes \c- and \m chars, that's the only escape sequence
+        # supported by regexes so far, so it needs a separate branch.
+        current_literal.extend_string(@escape, @ts, @te)
+      elsif current_literal.regexp?
         # Regular expressions should include escape sequences in their
         # escaped form. On the other hand, escaped newlines are removed (in cases like "\\C-\\\n\\M-x")
         current_literal.extend_string(tok.gsub("\\\n".freeze, ''.freeze), @ts, @te)

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -10673,7 +10673,61 @@ class TestParser < Minitest::Test
       SINCE_3_1)
   end
 
-  def test_control_meta_escape_chars_in_regexp
+  def test_parser_bug_830
+    assert_parses(
+      s(:regexp,
+        s(:str, "\\("),
+        s(:regopt)),
+      %q{/\(/},
+      %q{},
+      ALL_VERSIONS)
+  end
+
+  def test_control_meta_escape_chars_in_regexp__before_31
+    assert_parses(
+      s(:regexp, s(:str, "\\c\\xFF"), s(:regopt)),
+      %q{/\c\xFF/}.dup.force_encoding('ascii-8bit'),
+      %q{},
+      ALL_VERSIONS - SINCE_3_1)
+
+    assert_parses(
+      s(:regexp, s(:str, "\\c\\M-\\xFF"), s(:regopt)),
+      %q{/\c\M-\xFF/}.dup.force_encoding('ascii-8bit'),
+      %q{},
+      ALL_VERSIONS - SINCE_3_1)
+
+    assert_parses(
+      s(:regexp, s(:str, "\\C-\\xFF"), s(:regopt)),
+      %q{/\C-\xFF/}.dup.force_encoding('ascii-8bit'),
+      %q{},
+      ALL_VERSIONS - SINCE_3_1)
+
+    assert_parses(
+      s(:regexp, s(:str, "\\C-\\M-\\xFF"), s(:regopt)),
+      %q{/\C-\M-\xFF/}.dup.force_encoding('ascii-8bit'),
+      %q{},
+      ALL_VERSIONS - SINCE_3_1)
+
+    assert_parses(
+      s(:regexp, s(:str, "\\M-\\xFF"), s(:regopt)),
+      %q{/\M-\xFF/}.dup.force_encoding('ascii-8bit'),
+      %q{},
+      ALL_VERSIONS - SINCE_3_1)
+
+    assert_parses(
+      s(:regexp, s(:str, "\\M-\\C-\\xFF"), s(:regopt)),
+      %q{/\M-\C-\xFF/}.dup.force_encoding('ascii-8bit'),
+      %q{},
+      ALL_VERSIONS - SINCE_3_1)
+
+    assert_parses(
+      s(:regexp, s(:str, "\\M-\\c\\xFF"), s(:regopt)),
+      %q{/\M-\c\xFF/}.dup.force_encoding('ascii-8bit'),
+      %q{},
+      ALL_VERSIONS - SINCE_3_1)
+  end
+
+  def test_control_meta_escape_chars_in_regexp__since_31
     x9f = "\x9F".dup.force_encoding('ascii-8bit')
 
     assert_parses(


### PR DESCRIPTION
the bug was introduced in [24d2f68](https://github.com/whitequark/parser/commit/24d2f682c56319266602a3b3115e087fd81d667e) and affects only 3.1-dev

Closes https://github.com/whitequark/parser/issues/830