### PR TITLE
+ ruby31.y: parse forward argument without parentheses

### DIFF
--- a/lib/parser/context.rb
+++ b/lib/parser/context.rb
@@ -9,6 +9,9 @@ module Parser
   # + :sclass - in the singleton class body (class << obj; end)
   # + :def - in the method body (def m; end)
   # + :defs - in the singleton method body (def self.m; end)
+  # + :def_open_args - in the arglist of the method definition
+  #                    keep in mind that it's set **only** after reducing the first argument,
+  #                    if you need to handle the first argument check `lex_state == expr_fname`
   # + :block - in the block body (tap {})
   # + :lambda - in the lambda body (-> {})
   #
@@ -63,6 +66,10 @@ module Parser
 
     def in_dynamic_block?
       in_block? || in_lambda?
+    end
+
+    def in_def_open_args?
+      @stack.last == :def_open_args
     end
   end
 end

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -77,6 +77,7 @@ module Parser
     :duplicate_pattern_key        => 'duplicate hash pattern key %{name}',
     :endless_setter               => 'setter method cannot be defined in an endless method definition',
     :invalid_id_to_get            => 'identifier %{identifier} is not valid to get',
+    :forward_arg_after_restarg    => '... after rest argument',
 
     # Parser warnings
     :useless_else            => 'else without rescue is useless',

--- a/lib/parser/ruby31.y
+++ b/lib/parser/ruby31.y
@@ -2700,28 +2700,16 @@ f_opt_paren_args: f_paren_args
 
                       @lexer.state = :expr_value
                     }
-                | tLPAREN2 f_arg tCOMMA args_forward rparen
-                    {
-                      args = [ *val[1], @builder.forward_arg(val[3]) ]
-                      result = @builder.args(val[0], args, val[4])
-
-                      @static_env.declare_forward_args
-                    }
-                | tLPAREN2 args_forward rparen
-                    {
-                      result = @builder.forward_only_args(val[0], val[1], val[2])
-                      @static_env.declare_forward_args
-
-                      @lexer.state = :expr_value
-                    }
 
        f_arglist: f_paren_args
                 |   {
                       result = @lexer.in_kwarg
                       @lexer.in_kwarg = true
+                      @context.push(:def_open_args)
                     }
                   f_args term
                     {
+                      @context.pop
                       @lexer.in_kwarg = val[0]
                       result = @builder.args(nil, val[1], nil)
                     }
@@ -2741,6 +2729,11 @@ f_opt_paren_args: f_paren_args
                 | f_block_arg
                     {
                       result = [ val[0] ]
+                    }
+                | args_forward
+                    {
+                      @static_env.declare_forward_args
+                      result = [ @builder.forward_arg(val[0]) ]
                     }
 
    opt_args_tail: tCOMMA args_tail


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@13a9597.

Closes https://github.com/whitequark/parser/issues/823.

Also I think I've found a bug in MRI implementation. This code is valid on 3.0:

```ruby
def foo a = 1...
2
  p a
end

foo
```

It's a method with 1 argument that has a default value `1...2`. Current MRI/master gives an error:
```ruby
../parser/test.rb:1: syntax error, unexpected (..., expecting ';' or '\n'
def foo a = 1...
../parser/test.rb:4: syntax error, unexpected `end', expecting end-of-input
```

... because it treats **all** triple-dot tokens followed by newline between method-name and method-body as "forward argument".

I think I know how to fix it, there's a single flag for "being in a method arguments definition section", right now it's set once at the beginning of arglist (with a few exceptions that temporary unset-on-enter and restore-on-exit), and for example optional arguments do not affect it, but they should in a very similar way, `push` on reading default value, `pop` on leave.

Let's pretend it works as intended 👀 