### PR TITLE
+ ruby31.y: parse anonymous block argument.

### DIFF
--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -1014,6 +1014,17 @@ Format:
 
 Begin of the `expression` points to `&`.
 
+
+### Anonymous block argument
+
+Format:
+
+~~~
+(blockarg nil)
+"&"
+ ~ expression
+~~~
+
 ### Auto-expanding proc argument (1.9)
 
 In Ruby 1.9 and later, when a proc-like closure (i.e. a closure
@@ -1389,6 +1400,15 @@ Used when passing expression as block `foo(&bar)`
 "foo(1, &foo)"
         ^ operator
         ~~~~ expression
+~~~
+
+### Passing expression as anonymous block `foo(&)`
+
+~~~
+(send nil :foo (int 1) (block-pass nil))
+"foo(1, &)"
+        ^ operator
+        ~ expression
 ~~~
 
 ### "Stabby lambda"

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -973,9 +973,12 @@ module Parser
     end
 
     def blockarg(amper_t, name_t)
-      check_reserved_for_numparam(value(name_t), loc(name_t))
+      if !name_t.nil?
+        check_reserved_for_numparam(value(name_t), loc(name_t))
+      end
 
-      n(:blockarg, [ value(name_t).to_sym ],
+      arg_name = name_t ? value(name_t).to_sym : nil
+      n(:blockarg, [ arg_name ],
         arg_prefix_map(amper_t, name_t))
     end
 

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -78,6 +78,7 @@ module Parser
     :endless_setter               => 'setter method cannot be defined in an endless method definition',
     :invalid_id_to_get            => 'identifier %{identifier} is not valid to get',
     :forward_arg_after_restarg    => '... after rest argument',
+    :no_anonymous_blockarg        => 'no anonymous block parameter',
 
     # Parser warnings
     :useless_else            => 'else without rescue is useless',

--- a/lib/parser/ruby31.y
+++ b/lib/parser/ruby31.y
@@ -1159,6 +1159,14 @@ rule
                     {
                       result = @builder.block_pass(val[0], val[1])
                     }
+                | tAMPER
+                    {
+                      if !@static_env.declared_anonymous_blockarg?
+                        diagnostic :error, :no_anonymous_blockarg, nil, val[0]
+                      end
+
+                      result = @builder.block_pass(val[0], nil)
+                    }
 
    opt_block_arg: tCOMMA block_arg
                     {
@@ -3011,6 +3019,12 @@ f_opt_paren_args: f_paren_args
                       @static_env.declare val[1][0]
 
                       result = @builder.blockarg(val[0], val[1])
+                    }
+                | blkarg_mark
+                    {
+                      @static_env.declare_anonymous_blockarg
+
+                      result = @builder.blockarg(val[0], nil)
                     }
 
  opt_f_block_arg: tCOMMA f_block_arg

--- a/lib/parser/static_environment.rb
+++ b/lib/parser/static_environment.rb
@@ -4,6 +4,7 @@ module Parser
 
   class StaticEnvironment
     FORWARD_ARGS = :FORWARD_ARGS
+    ANONYMOUS_BLOCKARG = :ANONYMOUS_BLOCKARG
 
     def initialize
       reset
@@ -50,6 +51,14 @@ module Parser
 
     def declared_forward_args?
       declared?(FORWARD_ARGS)
+    end
+
+    def declare_anonymous_blockarg
+      declare(ANONYMOUS_BLOCKARG)
+    end
+
+    def declared_anonymous_blockarg?
+      declared?(ANONYMOUS_BLOCKARG)
     end
 
     def empty?

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -10826,4 +10826,30 @@ class TestParser < Minitest::Test
         |        ~~~~~ highlights (0)},
       SINCE_3_1)
   end
+
+  def test_anonymous_blockarg
+    assert_parses(
+      s(:def, :foo,
+        s(:args,
+          s(:blockarg, nil)),
+        s(:send, nil, :bar,
+          s(:block_pass, nil))),
+      %q{def foo(&); bar(&); end},
+      %q{        ~ expression (args.blockarg)
+        |                ~ operator (send.block_pass)
+        |                ~ expression (send.block_pass)},
+      SINCE_3_1)
+
+    assert_diagnoses(
+      [:error, :no_anonymous_blockarg],
+      %q{def foo(); bar(&); end},
+      %q{               ^ location},
+      SINCE_3_1)
+
+    assert_diagnoses(
+      [:error, :unexpected_token, { :token => 'tINTEGER' }],
+      %q{def foo(&0); end},
+      %q{         ^ location},
+      SINCE_3_1)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@4adb012.

Closes https://github.com/whitequark/parser/issues/826