### PR TITLE
warn_syntax_deviation: call `warn` only once

### DIFF
--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -3,9 +3,9 @@
 module Parser
   class << self
     def warn_syntax_deviation(feature, version)
-      warn "warning: parser/current is loading #{feature}, which recognizes"
-      warn "warning: #{version}-compliant syntax, but you are running #{RUBY_VERSION}."
-      warn "warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri."
+      warn "warning: parser/current is loading #{feature}, which recognizes" \
+        "#{version}-compliant syntax, but you are running #{RUBY_VERSION}.\n" \
+        "Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri."
     end
     private :warn_syntax_deviation
   end


### PR DESCRIPTION
Calling `warn` 3 times is very annoying for warning management tools that define `Warning.warn`, they're seen as 3 distinct warning instead of a single one.

cc @paracycle