### PR TITLE
- dedenter.rb: fix an encoding/squiggly heredoc regression

### DIFF
--- a/lib/parser/lexer/dedenter.rb
+++ b/lib/parser/lexer/dedenter.rb
@@ -41,7 +41,7 @@ module Parser
       if lines.length == 1
         # If the line continuation sequence was found but there is no second
         # line, it was not really a line continuation and must be ignored.
-        lines = [string]
+        lines = [string.force_encoding(original_encoding)]
       else
         lines.map! {|s| s.force_encoding(original_encoding) }
       end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -316,6 +316,13 @@ class TestParser < Minitest::Test
 
     assert_parses(
       s(:send, nil, :p,
+        s(:str, "ð\n")),
+      %Q{p <<~E\n  ð\nE},
+      %q{},
+      SINCE_2_3)
+
+    assert_parses(
+      s(:send, nil, :p,
         s(:dstr,
           s(:str, "x\n"),
           s(:str, "  y\n"))),


### PR DESCRIPTION
There was a missing force_encoding call, which caused Unicode
strings to be returned as binary.

The bug was introduced by 61bf873

This fixes #835