### PR TITLE
+ ruby31.y: accept forward arg without parentheses.

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -714,7 +714,7 @@ module Parser
         node.updated(:gvasgn)
 
       when :const
-        unless @parser.context.dynamic_const_definition_allowed?
+        if @parser.context.in_def
           diagnostic :error, :dynamic_const, nil, node.loc.expression
         end
 

--- a/lib/parser/context.rb
+++ b/lib/parser/context.rb
@@ -16,60 +16,34 @@ module Parser
   # + :lambda - in the lambda body (-> {})
   #
   class Context
-    attr_reader :stack
+    FLAGS = %i[
+      in_defined
+      in_kwarg
+      in_argdef
+      in_def
+      in_class
+      in_block
+      in_lambda
+    ]
 
     def initialize
-      @stack = []
-      freeze
-    end
-
-    def push(state)
-      @stack << state
-    end
-
-    def pop
-      @stack.pop
+      reset
     end
 
     def reset
-      @stack.clear
+      @in_defined = false
+      @in_kwarg = false
+      @in_argdef = false
+      @in_def = false
+      @in_class = false
+      @in_block = false
+      @in_lambda = false
     end
 
-    def empty?
-      @stack.empty?
-    end
-
-    def in_class?
-      @stack.last == :class
-    end
-
-    def indirectly_in_def?
-      @stack.include?(:def) || @stack.include?(:defs)
-    end
-
-    def class_definition_allowed?
-      def_index = stack.rindex { |item| [:def, :defs].include?(item) }
-      sclass_index = stack.rindex(:sclass)
-
-      def_index.nil? || (!sclass_index.nil? && sclass_index > def_index)
-    end
-    alias module_definition_allowed? class_definition_allowed?
-    alias dynamic_const_definition_allowed? class_definition_allowed?
-
-    def in_block?
-      @stack.last == :block
-    end
-
-    def in_lambda?
-      @stack.last == :lambda
-    end
+    attr_accessor(*FLAGS)
 
     def in_dynamic_block?
-      in_block? || in_lambda?
-    end
-
-    def in_def_open_args?
-      @stack.last == :def_open_args
+      in_block || in_lambda
     end
   end
 end

--- a/lib/parser/lexer/explanation.rb
+++ b/lib/parser/lexer/explanation.rb
@@ -18,7 +18,7 @@ module Parser
     def advance
       type, (val, range) = advance_before_explanation
 
-      more = "(in-kwarg)" if @in_kwarg
+      more = "(in-kwarg)" if @context.in_kwarg
 
       puts decorate(range,
                     Color.green("#{type} #{val.inspect}"),

--- a/lib/parser/macruby.y
+++ b/lib/parser/macruby.y
@@ -274,14 +274,15 @@ rule
  cmd_brace_block: tLBRACE_ARG
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
          command: operation command_args =tLOWEST
@@ -1044,7 +1045,8 @@ rule
                     }
                 | tLAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   lambda
                     {
@@ -1053,6 +1055,8 @@ rule
                       args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
+
+                      @context.in_lambda = val[1].in_lambda
                     }
                 | kIF expr_value then compstmt if_tail kEND
                     {
@@ -1124,75 +1128,73 @@ rule
                                             val[2], val[4],
                                             val[5], val[7], val[8])
                     }
-                | kCLASS cpath superclass
+                | k_class cpath superclass
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:class)
+                      local_push
+                      @context.in_class = true
                     }
                     bodystmt kEND
                     {
-                      unless @context.class_definition_allowed?
-                        diagnostic :error, :class_in_def, nil, val[0]
+                      k_class, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :class_in_def, nil, k_class
                       end
 
                       lt_t, superclass = val[2]
-                      result = @builder.def_class(val[0], val[1],
+                      result = @builder.def_class(k_class, val[1],
                                                   lt_t, superclass,
                                                   val[4], val[5])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
-                | kCLASS tLSHFT expr term
+                | k_class tLSHFT expr term
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:sclass)
+                      @context.in_def = false
+                      @context.in_class = false
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      result = @builder.def_sclass(val[0], val[1], val[2],
+                      k_class, ctx = val[0]
+                      result = @builder.def_sclass(k_class, val[1], val[2],
                                                    val[5], val[6])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = ctx.in_def
+                      @context.in_class = ctx.in_class
                     }
-                | kMODULE cpath
+                | k_module cpath
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:module)
+                      @context.in_class = true
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      unless @context.module_definition_allowed?
-                        diagnostic :error, :module_in_def, nil, val[0]
+                      k_mod, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :module_in_def, nil, k_mod
                       end
 
-                      result = @builder.def_module(val[0], val[1],
+                      result = @builder.def_module(k_mod, val[1],
                                                    val[3], val[4])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
                 | kDEF fname
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:def)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_method(val[0], val[1],
                                   val[3], val[4], val[5])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[2].in_def
                     }
                 | kDEF singleton dot_or_colon
                     {
@@ -1200,18 +1202,17 @@ rule
                     }
                     fname
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:defs)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_singleton(val[0], val[1], val[2],
                                   val[4], val[6], val[7], val[8])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[5].in_def
                     }
                 | kBREAK
                     {
@@ -1231,6 +1232,16 @@ rule
                     }
 
    primary_value: primary
+
+         k_class: kCLASS
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
+
+        k_module: kMODULE
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
 
             then: term
                 | kTHEN
@@ -1459,13 +1470,9 @@ rule
           lambda:   {
                       @static_env.extend_dynamic
                     }
-                  f_larglist
+                  f_larglist lambda_body
                     {
-                      @context.pop
-                    }
-                  lambda_body
-                    {
-                      result = [ val[1], val[3] ]
+                      result = [ val[1], val[2] ]
 
                       @static_env.unextend
                     }
@@ -1481,34 +1488,37 @@ rule
 
      lambda_body: tLAMBEG
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
+                      @context.in_lambda = val[1].in_lambda
                     }
                 | kDO_LAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt kEND
                     {
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
+                      @context.in_lambda = val[1].in_lambda
                     }
 
         do_block: kDO_BLOCK
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt kEND
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
       block_call: command do_block
@@ -1582,26 +1592,28 @@ rule
      brace_block: tLCURLY
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
                 | kDO
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt kEND
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
        case_body: kWHEN args then compstmt cases
@@ -2205,4 +2217,16 @@ require 'parser'
 
   def default_encoding
     Encoding::BINARY
+  end
+
+  def local_push
+    @static_env.extend_static
+    @lexer.cmdarg.push(false)
+    @lexer.cond.push(false)
+  end
+
+  def local_pop
+    @static_env.unextend
+    @lexer.cmdarg.pop
+    @lexer.cond.pop
   end

--- a/lib/parser/max_numparam_stack.rb
+++ b/lib/parser/max_numparam_stack.rb
@@ -35,21 +35,21 @@ module Parser
     end
 
     def top
-      @stack.last
+      @stack.last[:value]
     end
 
-    def push
-      @stack.push(0)
+    def push(static:)
+      @stack.push(value: 0, static: static)
     end
 
     def pop
-      @stack.pop
+      @stack.pop[:value]
     end
 
     private
 
     def set(value)
-      @stack[@stack.length - 1] = value
+      @stack.last[:value] = value
     end
   end
 

--- a/lib/parser/ruby18.y
+++ b/lib/parser/ruby18.y
@@ -142,7 +142,7 @@ rule
                     }
                 | klBEGIN tLCURLY compstmt tRCURLY
                     {
-                      if @context.indirectly_in_def?
+                      if @context.in_def
                         diagnostic :error, :begin_in_method, nil, val[0]
                       end
 
@@ -268,14 +268,15 @@ rule
  cmd_brace_block: tLBRACE_ARG
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_var compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
          command: operation command_args =tLOWEST
@@ -1124,67 +1125,73 @@ rule
                                             val[2], val[4],
                                             val[5], val[7], val[8])
                     }
-                | kCLASS cpath superclass
+                | k_class cpath superclass
                     {
-                      @static_env.extend_static
-                      @context.push(:class)
+                      local_push
+                      @context.in_class = true
                     }
                     bodystmt kEND
                     {
-                      unless @context.class_definition_allowed?
-                        diagnostic :error, :class_in_def, nil, val[0]
+                      k_class, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :class_in_def, nil, k_class
                       end
 
                       lt_t, superclass = val[2]
-                      result = @builder.def_class(val[0], val[1],
+                      result = @builder.def_class(k_class, val[1],
                                                   lt_t, superclass,
                                                   val[4], val[5])
 
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
-                | kCLASS tLSHFT expr term
+                | k_class tLSHFT expr term
                     {
-                      @static_env.extend_static
-                      @context.push(:sclass)
+                      @context.in_def = false
+                      @context.in_class = false
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      result = @builder.def_sclass(val[0], val[1], val[2],
+                      k_class, ctx = val[0]
+                      result = @builder.def_sclass(k_class, val[1], val[2],
                                                    val[5], val[6])
 
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = ctx.in_def
+                      @context.in_class = ctx.in_class
                     }
-                | kMODULE cpath
+                | k_module cpath
                     {
-                      @static_env.extend_static
-                      @context.push(:module)
+                      @context.in_class = true
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      unless @context.module_definition_allowed?
-                        diagnostic :error, :module_in_def, nil, val[0]
+                      k_mod, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :module_in_def, nil, k_mod
                       end
 
-                      result = @builder.def_module(val[0], val[1],
+                      result = @builder.def_module(k_mod, val[1],
                                                    val[3], val[4])
 
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
                 | kDEF fname
                     {
-                      @static_env.extend_static
-                      @context.push(:def)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_method(val[0], val[1],
                                   val[3], val[4], val[5])
 
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[2].in_def
                     }
                 | kDEF singleton dot_or_colon
                     {
@@ -1192,16 +1199,17 @@ rule
                     }
                     fname
                     {
-                      @static_env.extend_static
-                      @context.push(:defs)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_singleton(val[0], val[1], val[2],
                                   val[4], val[6], val[7], val[8])
 
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[5].in_def
                     }
                 | kBREAK
                     {
@@ -1221,6 +1229,16 @@ rule
                     }
 
    primary_value: primary
+
+         k_class: kCLASS
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
+
+        k_module: kMODULE
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
 
             then: term
                 | tCOLON
@@ -1336,14 +1354,15 @@ rule
         do_block: kDO_BLOCK
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_var compstmt kEND
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
       block_call: command do_block
@@ -1401,26 +1420,28 @@ rule
      brace_block: tLCURLY
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_var compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
                 | kDO
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_var compstmt kEND
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
        case_body: kWHEN when_args then compstmt cases
@@ -1936,4 +1957,16 @@ require 'parser'
 
   def default_encoding
     Encoding::BINARY
+  end
+
+  def local_push
+    @static_env.extend_static
+    @lexer.cmdarg.push(false)
+    @lexer.cond.push(false)
+  end
+
+  def local_pop
+    @static_env.unextend
+    @lexer.cmdarg.pop
+    @lexer.cond.pop
   end

--- a/lib/parser/ruby20.y
+++ b/lib/parser/ruby20.y
@@ -116,7 +116,7 @@ rule
    stmt_or_begin: stmt
                 | klBEGIN tLCURLY top_compstmt tRCURLY
                     {
-                      if @context.indirectly_in_def?
+                      if @context.in_def
                         diagnostic :error, :begin_in_method, nil, val[0]
                       end
 
@@ -287,14 +287,15 @@ rule
  cmd_brace_block: tLBRACE_ARG
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
            fcall: operation
@@ -1041,7 +1042,8 @@ rule
                     }
                 | tLAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   lambda
                     {
@@ -1050,6 +1052,8 @@ rule
                       args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
+
+                      @context.in_lambda = val[1].in_lambda
                     }
                 | kIF expr_value then compstmt if_tail kEND
                     {
@@ -1121,75 +1125,73 @@ rule
                                             val[2], val[4],
                                             val[5], val[7], val[8])
                     }
-                | kCLASS cpath superclass
+                | k_class cpath superclass
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:class)
+                      local_push
+                      @context.in_class = true
                     }
                     bodystmt kEND
                     {
-                      unless @context.class_definition_allowed?
-                        diagnostic :error, :class_in_def, nil, val[0]
+                      k_class, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :class_in_def, nil, k_class
                       end
 
                       lt_t, superclass = val[2]
-                      result = @builder.def_class(val[0], val[1],
+                      result = @builder.def_class(k_class, val[1],
                                                   lt_t, superclass,
                                                   val[4], val[5])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
-                | kCLASS tLSHFT expr term
+                | k_class tLSHFT expr term
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:sclass)
+                      @context.in_def = false
+                      @context.in_class = false
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      result = @builder.def_sclass(val[0], val[1], val[2],
+                      k_class, ctx = val[0]
+                      result = @builder.def_sclass(k_class, val[1], val[2],
                                                    val[5], val[6])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = ctx.in_def
+                      @context.in_class = ctx.in_class
                     }
-                | kMODULE cpath
+                | k_module cpath
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:module)
+                      @context.in_class = true
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      unless @context.module_definition_allowed?
-                        diagnostic :error, :module_in_def, nil, val[0]
+                      k_mod, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :module_in_def, nil, k_mod
                       end
 
-                      result = @builder.def_module(val[0], val[1],
+                      result = @builder.def_module(k_mod, val[1],
                                                    val[3], val[4])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
                 | kDEF fname
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:def)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_method(val[0], val[1],
                                   val[3], val[4], val[5])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[2].in_def
                     }
                 | kDEF singleton dot_or_colon
                     {
@@ -1197,18 +1199,17 @@ rule
                     }
                     fname
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:defs)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_singleton(val[0], val[1], val[2],
                                   val[4], val[6], val[7], val[8])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[5].in_def
                     }
                 | kBREAK
                     {
@@ -1228,6 +1229,16 @@ rule
                     }
 
    primary_value: primary
+
+         k_class: kCLASS
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
+
+        k_module: kMODULE
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
 
             then: term
                 | kTHEN
@@ -1493,13 +1504,9 @@ opt_block_args_tail:
           lambda:   {
                       @static_env.extend_dynamic
                     }
-                  f_larglist
+                  f_larglist lambda_body
                     {
-                      @context.pop
-                    }
-                  lambda_body
-                    {
-                      result = [ val[1], val[3] ]
+                      result = [ val[1], val[2] ]
 
                       @static_env.unextend
                     }
@@ -1515,34 +1522,37 @@ opt_block_args_tail:
 
      lambda_body: tLAMBEG
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
+                      @context.in_lambda = val[1].in_lambda
                     }
                 | kDO_LAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt kEND
                     {
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
+                      @context.in_lambda = val[1].in_lambda
                     }
 
         do_block: kDO_BLOCK
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt kEND
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
       block_call: command do_block
@@ -1629,26 +1639,28 @@ opt_block_args_tail:
      brace_block: tLCURLY
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
                 | kDO
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                  opt_block_param compstmt kEND
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
        case_body: kWHEN args then compstmt cases
@@ -2360,4 +2372,16 @@ require 'parser'
 
   def default_encoding
     Encoding::UTF_8
+  end
+
+  def local_push
+    @static_env.extend_static
+    @lexer.cmdarg.push(false)
+    @lexer.cond.push(false)
+  end
+
+  def local_pop
+    @static_env.unextend
+    @lexer.cmdarg.pop
+    @lexer.cond.pop
   end

--- a/lib/parser/ruby21.y
+++ b/lib/parser/ruby21.y
@@ -279,14 +279,15 @@ rule
  cmd_brace_block: tLBRACE_ARG
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
            fcall: operation
@@ -1031,7 +1032,8 @@ rule
                     }
                 | tLAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   lambda
                     {
@@ -1040,6 +1042,8 @@ rule
                       args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
+
+                      @context.in_lambda = val[1].in_lambda
                     }
                 | kIF expr_value then compstmt if_tail kEND
                     {
@@ -1111,75 +1115,73 @@ rule
                                             val[2], val[4],
                                             val[5], val[7], val[8])
                     }
-                | kCLASS cpath superclass
+                | k_class cpath superclass
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:class)
+                      local_push
+                      @context.in_class = true
                     }
                     bodystmt kEND
                     {
-                      unless @context.class_definition_allowed?
-                        diagnostic :error, :class_in_def, nil, val[0]
+                      k_class, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :class_in_def, nil, k_class
                       end
 
                       lt_t, superclass = val[2]
-                      result = @builder.def_class(val[0], val[1],
+                      result = @builder.def_class(k_class, val[1],
                                                   lt_t, superclass,
                                                   val[4], val[5])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
-                | kCLASS tLSHFT expr term
+                | k_class tLSHFT expr term
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:sclass)
+                      @context.in_def = false
+                      @context.in_class = false
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      result = @builder.def_sclass(val[0], val[1], val[2],
+                      k_class, ctx = val[0]
+                      result = @builder.def_sclass(k_class, val[1], val[2],
                                                    val[5], val[6])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = ctx.in_def
+                      @context.in_class = ctx.in_class
                     }
-                | kMODULE cpath
+                | k_module cpath
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:module)
+                      @context.in_class = true
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      unless @context.module_definition_allowed?
-                        diagnostic :error, :module_in_def, nil, val[0]
+                      k_mod, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :module_in_def, nil, k_mod
                       end
 
-                      result = @builder.def_module(val[0], val[1],
+                      result = @builder.def_module(k_mod, val[1],
                                                    val[3], val[4])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
                 | kDEF fname
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:def)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_method(val[0], val[1],
                                   val[3], val[4], val[5])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[2].in_def
                     }
                 | kDEF singleton dot_or_colon
                     {
@@ -1187,18 +1189,17 @@ rule
                     }
                     fname
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:defs)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_singleton(val[0], val[1], val[2],
                                   val[4], val[6], val[7], val[8])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[5].in_def
                     }
                 | kBREAK
                     {
@@ -1218,6 +1219,16 @@ rule
                     }
 
    primary_value: primary
+
+         k_class: kCLASS
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
+
+        k_module: kMODULE
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
 
             then: term
                 | kTHEN
@@ -1477,7 +1488,6 @@ opt_block_args_tail:
                     {
                       result = @lexer.cmdarg.dup
                       @lexer.cmdarg.clear
-                      @context.pop
                     }
                   lambda_body
                     {
@@ -1500,34 +1510,37 @@ opt_block_args_tail:
 
      lambda_body: tLAMBEG
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
+                      @context.in_lambda = val[1].in_lambda
                     }
                 | kDO_LAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt kEND
                     {
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
+                      @context.in_lambda = val[1].in_lambda
                     }
 
         do_block: kDO_BLOCK
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt kEND
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
       block_call: command do_block
@@ -1614,26 +1627,28 @@ opt_block_args_tail:
      brace_block: tLCURLY
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
                 | kDO
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                  opt_block_param compstmt kEND
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
        case_body: kWHEN args then compstmt cases
@@ -1998,12 +2013,12 @@ keyword_variable: kNIL
                       @lexer.state = :expr_value
                     }
                 |   {
-                      result = @lexer.in_kwarg
-                      @lexer.in_kwarg = true
+                      result = @context.in_kwarg
+                      @context.in_kwarg = true
                     }
                   f_args term
                     {
-                      @lexer.in_kwarg = val[0]
+                      @context.in_kwarg = val[0]
                       result = @builder.args(nil, val[1], nil)
                     }
 
@@ -2361,4 +2376,16 @@ require 'parser'
 
   def default_encoding
     Encoding::UTF_8
+  end
+
+  def local_push
+    @static_env.extend_static
+    @lexer.cmdarg.push(false)
+    @lexer.cond.push(false)
+  end
+
+  def local_pop
+    @static_env.unextend
+    @lexer.cmdarg.pop
+    @lexer.cond.pop
   end

--- a/lib/parser/ruby22.y
+++ b/lib/parser/ruby22.y
@@ -279,14 +279,15 @@ rule
  cmd_brace_block: tLBRACE_ARG
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
            fcall: operation
@@ -1030,7 +1031,8 @@ rule
                     }
                 | tLAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   lambda
                     {
@@ -1039,6 +1041,8 @@ rule
                       args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
+
+                      @context.in_lambda = val[1].in_lambda
                     }
                 | kIF expr_value then compstmt if_tail kEND
                     {
@@ -1110,75 +1114,73 @@ rule
                                             val[2], val[4],
                                             val[5], val[7], val[8])
                     }
-                | kCLASS cpath superclass
+                | k_class cpath superclass
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:class)
+                      local_push
+                      @context.in_class = true
                     }
                     bodystmt kEND
                     {
-                      unless @context.class_definition_allowed?
-                        diagnostic :error, :class_in_def, nil, val[0]
+                      k_class, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :class_in_def, nil, k_class
                       end
 
                       lt_t, superclass = val[2]
-                      result = @builder.def_class(val[0], val[1],
+                      result = @builder.def_class(k_class, val[1],
                                                   lt_t, superclass,
                                                   val[4], val[5])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
-                | kCLASS tLSHFT expr term
+                | k_class tLSHFT expr term
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:sclass)
+                      @context.in_def = false
+                      @context.in_class = false
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      result = @builder.def_sclass(val[0], val[1], val[2],
+                      k_class, ctx = val[0]
+                      result = @builder.def_sclass(k_class, val[1], val[2],
                                                    val[5], val[6])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = ctx.in_def
+                      @context.in_class = ctx.in_class
                     }
-                | kMODULE cpath
+                | k_module cpath
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:module)
+                      @context.in_class = true
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      unless @context.module_definition_allowed?
-                        diagnostic :error, :module_in_def, nil, val[0]
+                      k_mod, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :module_in_def, nil, k_mod
                       end
 
-                      result = @builder.def_module(val[0], val[1],
+                      result = @builder.def_module(k_mod, val[1],
                                                    val[3], val[4])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
                 | kDEF fname
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:def)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_method(val[0], val[1],
                                   val[3], val[4], val[5])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[2].in_def
                     }
                 | kDEF singleton dot_or_colon
                     {
@@ -1186,18 +1188,17 @@ rule
                     }
                     fname
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:defs)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_singleton(val[0], val[1], val[2],
                                   val[4], val[6], val[7], val[8])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[5].in_def
                     }
                 | kBREAK
                     {
@@ -1217,6 +1218,16 @@ rule
                     }
 
    primary_value: primary
+
+         k_class: kCLASS
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
+
+        k_module: kMODULE
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
 
             then: term
                 | kTHEN
@@ -1476,7 +1487,6 @@ opt_block_args_tail:
                     {
                       result = @lexer.cmdarg.dup
                       @lexer.cmdarg.clear
-                      @context.pop
                     }
                   lambda_body
                     {
@@ -1499,34 +1509,37 @@ opt_block_args_tail:
 
      lambda_body: tLAMBEG
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
+                      @context.in_lambda = val[1].in_lambda
                     }
                 | kDO_LAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt kEND
                     {
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
+                      @context.in_lambda = val[1].in_lambda
                     }
 
         do_block: kDO_BLOCK
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt kEND
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
       block_call: command do_block
@@ -1613,26 +1626,28 @@ opt_block_args_tail:
      brace_block: tLCURLY
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
                 | kDO
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                  opt_block_param compstmt kEND
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
        case_body: kWHEN args then compstmt cases
@@ -1997,12 +2012,12 @@ keyword_variable: kNIL
                       @lexer.state = :expr_value
                     }
                 |   {
-                      result = @lexer.in_kwarg
-                      @lexer.in_kwarg = true
+                      result = @context.in_kwarg
+                      @context.in_kwarg = true
                     }
                   f_args term
                     {
-                      @lexer.in_kwarg = val[0]
+                      @context.in_kwarg = val[0]
                       result = @builder.args(nil, val[1], nil)
                     }
 
@@ -2368,4 +2383,16 @@ require 'parser'
 
   def default_encoding
     Encoding::UTF_8
+  end
+
+  def local_push
+    @static_env.extend_static
+    @lexer.cmdarg.push(false)
+    @lexer.cond.push(false)
+  end
+
+  def local_pop
+    @static_env.unextend
+    @lexer.cmdarg.pop
+    @lexer.cond.pop
   end

--- a/lib/parser/ruby23.y
+++ b/lib/parser/ruby23.y
@@ -279,14 +279,15 @@ rule
  cmd_brace_block: tLBRACE_ARG
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
            fcall: operation
@@ -1030,7 +1031,8 @@ rule
                     }
                 | tLAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   lambda
                     {
@@ -1039,6 +1041,8 @@ rule
                       args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
+
+                      @context.in_lambda = val[1].in_lambda
                     }
                 | kIF expr_value then compstmt if_tail kEND
                     {
@@ -1110,75 +1114,73 @@ rule
                                             val[2], val[4],
                                             val[5], val[7], val[8])
                     }
-                | kCLASS cpath superclass
+                | k_class cpath superclass
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:class)
+                      local_push
+                      @context.in_class = true
                     }
                     bodystmt kEND
                     {
-                      unless @context.class_definition_allowed?
-                        diagnostic :error, :class_in_def, nil, val[0]
+                      k_class, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :class_in_def, nil, k_class
                       end
 
                       lt_t, superclass = val[2]
-                      result = @builder.def_class(val[0], val[1],
+                      result = @builder.def_class(k_class, val[1],
                                                   lt_t, superclass,
                                                   val[4], val[5])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
-                | kCLASS tLSHFT expr term
+                | k_class tLSHFT expr term
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:sclass)
+                      @context.in_def = false
+                      @context.in_class = false
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      result = @builder.def_sclass(val[0], val[1], val[2],
+                      k_class, ctx = val[0]
+                      result = @builder.def_sclass(k_class, val[1], val[2],
                                                    val[5], val[6])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = ctx.in_def
+                      @context.in_class = ctx.in_class
                     }
-                | kMODULE cpath
+                | k_module cpath
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:module)
+                      @context.in_class = true
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      unless @context.module_definition_allowed?
-                        diagnostic :error, :module_in_def, nil, val[0]
+                      k_mod, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :module_in_def, nil, k_mod
                       end
 
-                      result = @builder.def_module(val[0], val[1],
+                      result = @builder.def_module(k_mod, val[1],
                                                    val[3], val[4])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
                 | kDEF fname
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:def)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_method(val[0], val[1],
                                   val[3], val[4], val[5])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[2].in_def
                     }
                 | kDEF singleton dot_or_colon
                     {
@@ -1186,18 +1188,17 @@ rule
                     }
                     fname
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:defs)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_singleton(val[0], val[1], val[2],
                                   val[4], val[6], val[7], val[8])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[5].in_def
                     }
                 | kBREAK
                     {
@@ -1217,6 +1218,16 @@ rule
                     }
 
    primary_value: primary
+
+         k_class: kCLASS
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
+
+        k_module: kMODULE
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
 
             then: term
                 | kTHEN
@@ -1476,7 +1487,6 @@ opt_block_args_tail:
                     {
                       result = @lexer.cmdarg.dup
                       @lexer.cmdarg.clear
-                      @context.pop
                     }
                   lambda_body
                     {
@@ -1499,34 +1509,37 @@ opt_block_args_tail:
 
      lambda_body: tLAMBEG
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
+                      @context.in_lambda = val[1].in_lambda
                     }
                 | kDO_LAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt kEND
                     {
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
+                      @context.in_lambda = val[1].in_lambda
                     }
 
         do_block: kDO_BLOCK
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt kEND
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
       block_call: command do_block
@@ -1613,26 +1626,28 @@ opt_block_args_tail:
      brace_block: tLCURLY
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
                 | kDO
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                  opt_block_param compstmt kEND
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
        case_body: kWHEN args then compstmt cases
@@ -1995,12 +2010,12 @@ keyword_variable: kNIL
                       @lexer.state = :expr_value
                     }
                 |   {
-                      result = @lexer.in_kwarg
-                      @lexer.in_kwarg = true
+                      result = @context.in_kwarg
+                      @context.in_kwarg = true
                     }
                   f_args term
                     {
-                      @lexer.in_kwarg = val[0]
+                      @context.in_kwarg = val[0]
                       result = @builder.args(nil, val[1], nil)
                     }
 
@@ -2374,4 +2389,16 @@ require 'parser'
 
   def default_encoding
     Encoding::UTF_8
+  end
+
+  def local_push
+    @static_env.extend_static
+    @lexer.cmdarg.push(false)
+    @lexer.cond.push(false)
+  end
+
+  def local_pop
+    @static_env.unextend
+    @lexer.cmdarg.pop
+    @lexer.cond.pop
   end

--- a/lib/parser/ruby24.y
+++ b/lib/parser/ruby24.y
@@ -285,12 +285,13 @@ rule
 
  cmd_brace_block: tLBRACE_ARG
                     {
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                   brace_body tRCURLY
                     {
                       result = [ val[0], *val[2], val[3] ]
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
            fcall: operation
@@ -1049,7 +1050,8 @@ rule
                     }
                 | tLAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   lambda
                     {
@@ -1058,6 +1060,8 @@ rule
                       args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
+
+                      @context.in_lambda = val[1].in_lambda
                     }
                 | kIF expr_value then compstmt if_tail kEND
                     {
@@ -1129,75 +1133,73 @@ rule
                                             val[2], val[4],
                                             val[5], val[7], val[8])
                     }
-                | kCLASS cpath superclass
+                | k_class cpath superclass
                     {
-                      @static_env.extend_static
-                      @lexer.cmdarg.push(false)
-                      @context.push(:class)
+                      local_push
+                      @context.in_class = true
                     }
                     bodystmt kEND
                     {
-                      unless @context.class_definition_allowed?
-                        diagnostic :error, :class_in_def, nil, val[0]
+                      k_class, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :class_in_def, nil, k_class
                       end
 
                       lt_t, superclass = val[2]
-                      result = @builder.def_class(val[0], val[1],
+                      result = @builder.def_class(k_class, val[1],
                                                   lt_t, superclass,
                                                   val[4], val[5])
 
-                      @lexer.cmdarg.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
-                | kCLASS tLSHFT expr term
+                | k_class tLSHFT expr term
                     {
-                      @static_env.extend_static
-                      @lexer.cmdarg.push(false)
-                      @context.push(:sclass)
+                      @context.in_def = false
+                      @context.in_class = false
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      result = @builder.def_sclass(val[0], val[1], val[2],
+                      k_class, ctx = val[0]
+                      result = @builder.def_sclass(k_class, val[1], val[2],
                                                    val[5], val[6])
 
-                      @lexer.cmdarg.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = ctx.in_def
+                      @context.in_class = ctx.in_class
                     }
-                | kMODULE cpath
+                | k_module cpath
                     {
-                      @static_env.extend_static
-                      @lexer.cmdarg.push(false)
-                      @context.push(:module)
+                      @context.in_class = true
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      unless @context.module_definition_allowed?
-                        diagnostic :error, :module_in_def, nil, val[0]
+                      k_mod, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :module_in_def, nil, k_mod
                       end
 
-                      result = @builder.def_module(val[0], val[1],
+                      result = @builder.def_module(k_mod, val[1],
                                                    val[3], val[4])
 
-                      @lexer.cmdarg.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
                 | kDEF fname
                     {
-                      @static_env.extend_static
-                      @lexer.cmdarg.push(false)
-                      @context.push(:def)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_method(val[0], val[1],
                                   val[3], val[4], val[5])
 
-                      @lexer.cmdarg.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[2].in_def
                     }
                 | kDEF singleton dot_or_colon
                     {
@@ -1205,18 +1207,17 @@ rule
                     }
                     fname
                     {
-                      @static_env.extend_static
-                      @lexer.cmdarg.push(false)
-                      @context.push(:defs)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_singleton(val[0], val[1], val[2],
                                   val[4], val[6], val[7], val[8])
 
-                      @lexer.cmdarg.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[5].in_def
                     }
                 | kBREAK
                     {
@@ -1236,6 +1237,15 @@ rule
                     }
 
    primary_value: primary
+
+         k_class: kCLASS
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
+        k_module: kMODULE
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
 
             then: term
                 | kTHEN
@@ -1493,7 +1503,6 @@ opt_block_args_tail:
                     }
                   f_larglist
                     {
-                      @context.pop
                       @lexer.cmdarg.push(false)
                     }
                   lambda_body
@@ -1516,31 +1525,34 @@ opt_block_args_tail:
 
      lambda_body: tLAMBEG
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
+                      @context.in_lambda = val[1].in_lambda
                     }
                 | kDO_LAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt kEND
                     {
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
+                      @context.in_lambda = val[1].in_lambda
                     }
 
         do_block: kDO_BLOCK
                     {
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                   do_body kEND
                     {
                       result = [ val[0], *val[2], val[3] ]
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
       block_call: command do_block
@@ -1626,21 +1638,23 @@ opt_block_args_tail:
 
      brace_block: tLCURLY
                     {
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                   brace_body tRCURLY
                     {
                       result = [ val[0], *val[2], val[3] ]
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
                 | kDO
                     {
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                   do_body kEND
                     {
                       result = [ val[0], *val[2], val[3] ]
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
       brace_body:   {
@@ -2033,12 +2047,12 @@ keyword_variable: kNIL
                       @lexer.state = :expr_value
                     }
                 |   {
-                      result = @lexer.in_kwarg
-                      @lexer.in_kwarg = true
+                      result = @context.in_kwarg
+                      @context.in_kwarg = true
                     }
                   f_args term
                     {
-                      @lexer.in_kwarg = val[0]
+                      @context.in_kwarg = val[0]
                       result = @builder.args(nil, val[1], nil)
                     }
 
@@ -2412,4 +2426,16 @@ require 'parser'
 
   def default_encoding
     Encoding::UTF_8
+  end
+
+  def local_push
+    @static_env.extend_static
+    @lexer.cmdarg.push(false)
+    @lexer.cond.push(false)
+  end
+
+  def local_pop
+    @static_env.unextend
+    @lexer.cmdarg.pop
+    @lexer.cond.pop
   end

--- a/lib/parser/ruby25.y
+++ b/lib/parser/ruby25.y
@@ -299,12 +299,13 @@ rule
 
  cmd_brace_block: tLBRACE_ARG
                     {
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                   brace_body tRCURLY
                     {
                       result = [ val[0], *val[2], val[3] ]
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
            fcall: operation
@@ -1059,7 +1060,8 @@ rule
                     }
                 | tLAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   lambda
                     {
@@ -1068,6 +1070,8 @@ rule
                       args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
+
+                      @context.in_lambda = val[1].in_lambda
                     }
                 | kIF expr_value then compstmt if_tail kEND
                     {
@@ -1111,81 +1115,73 @@ rule
                     {
                       result = @builder.for(val[0], val[1], val[2], *val[3], val[4], val[5])
                     }
-                | kCLASS cpath superclass
+                | k_class cpath superclass
                     {
-                      @static_env.extend_static
-                      @lexer.cmdarg.push(false)
-                      @lexer.cond.push(false)
-                      @context.push(:class)
+                      local_push
+                      @context.in_class = true
                     }
                     bodystmt kEND
                     {
-                      unless @context.class_definition_allowed?
-                        diagnostic :error, :class_in_def, nil, val[0]
+                      k_class, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :class_in_def, nil, k_class
                       end
 
                       lt_t, superclass = val[2]
-                      result = @builder.def_class(val[0], val[1],
+                      result = @builder.def_class(k_class, val[1],
                                                   lt_t, superclass,
                                                   val[4], val[5])
 
-                      @lexer.cmdarg.pop
-                      @lexer.cond.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
-                | kCLASS tLSHFT expr term
+                | k_class tLSHFT expr term
                     {
-                      @static_env.extend_static
-                      @lexer.cmdarg.push(false)
-                      @lexer.cond.push(false)
-                      @context.push(:sclass)
+                      @context.in_def = false
+                      @context.in_class = false
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      result = @builder.def_sclass(val[0], val[1], val[2],
+                      k_class, ctx = val[0]
+                      result = @builder.def_sclass(k_class, val[1], val[2],
                                                    val[5], val[6])
 
-                      @lexer.cmdarg.pop
-                      @lexer.cond.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = ctx.in_def
+                      @context.in_class = ctx.in_class
                     }
-                | kMODULE cpath
+                | k_module cpath
                     {
-                      @static_env.extend_static
-                      @lexer.cmdarg.push(false)
-                      @context.push(:module)
+                      @context.in_class = true
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      unless @context.module_definition_allowed?
-                        diagnostic :error, :module_in_def, nil, val[0]
+                      k_mod, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :module_in_def, nil, k_mod
                       end
 
-                      result = @builder.def_module(val[0], val[1],
+                      result = @builder.def_module(k_mod, val[1],
                                                    val[3], val[4])
 
-                      @lexer.cmdarg.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
                 | kDEF fname
                     {
-                      @static_env.extend_static
-                      @lexer.cmdarg.push(false)
-                      @lexer.cond.push(false)
-                      @context.push(:def)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_method(val[0], val[1],
                                   val[3], val[4], val[5])
 
-                      @lexer.cmdarg.pop
-                      @lexer.cond.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[2].in_def
                     }
                 | kDEF singleton dot_or_colon
                     {
@@ -1193,20 +1189,17 @@ rule
                     }
                     fname
                     {
-                      @static_env.extend_static
-                      @lexer.cmdarg.push(false)
-                      @lexer.cond.push(false)
-                      @context.push(:defs)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_singleton(val[0], val[1], val[2],
                                   val[4], val[6], val[7], val[8])
 
-                      @lexer.cmdarg.pop
-                      @lexer.cond.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[5].in_def
                     }
                 | kBREAK
                     {
@@ -1227,9 +1220,19 @@ rule
 
    primary_value: primary
 
+         k_class: kCLASS
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
+
+        k_module: kMODULE
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
+
         k_return: kRETURN
                     {
-                      if @context.in_class?
+                      if @context.in_class && !@context.in_def && !(context.in_block || context.in_lambda)
                         diagnostic :error, :invalid_return, nil, val[0]
                       end
                     }
@@ -1490,7 +1493,6 @@ opt_block_args_tail:
                     }
                   f_larglist
                     {
-                      @context.pop
                       @lexer.cmdarg.push(false)
                     }
                   lambda_body
@@ -1513,31 +1515,34 @@ opt_block_args_tail:
 
      lambda_body: tLAMBEG
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
+                      @context.in_lambda = val[1].in_lambda
                     }
                 | kDO_LAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt kEND
                     {
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
+                      @context.in_lambda = val[1].in_lambda
                     }
 
         do_block: kDO_BLOCK
                     {
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                   do_body kEND
                     {
                       result = [ val[0], *val[2], val[3] ]
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
       block_call: command do_block
@@ -1623,21 +1628,23 @@ opt_block_args_tail:
 
      brace_block: tLCURLY
                     {
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                   brace_body tRCURLY
                     {
                       result = [ val[0], *val[2], val[3] ]
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
                 | kDO
                     {
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                   do_body kEND
                     {
                       result = [ val[0], *val[2], val[3] ]
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
       brace_body:   {
@@ -2030,12 +2037,12 @@ keyword_variable: kNIL
                       @lexer.state = :expr_value
                     }
                 |   {
-                      result = @lexer.in_kwarg
-                      @lexer.in_kwarg = true
+                      result = @context.in_kwarg
+                      @context.in_kwarg = true
                     }
                   f_args term
                     {
-                      @lexer.in_kwarg = val[0]
+                      @context.in_kwarg = val[0]
                       result = @builder.args(nil, val[1], nil)
                     }
 
@@ -2409,4 +2416,16 @@ require 'parser'
 
   def default_encoding
     Encoding::UTF_8
+  end
+
+  def local_push
+    @static_env.extend_static
+    @lexer.cmdarg.push(false)
+    @lexer.cond.push(false)
+  end
+
+  def local_pop
+    @static_env.unextend
+    @lexer.cmdarg.pop
+    @lexer.cond.pop
   end

--- a/lib/parser/ruby31.y
+++ b/lib/parser/ruby31.y
@@ -48,7 +48,7 @@ rule
 
          program:   {
                       @current_arg_stack.push(nil)
-                      @max_numparam_stack.push
+                      @max_numparam_stack.push(static: true)
                     }
                   top_compstmt
                     {
@@ -263,21 +263,19 @@ rule
                     }
                 | defn_head f_opt_paren_args tEQL command
                     {
-                      _def_t, name_t = val[0]
+                      def_t, (name_t, ctx) = val[0]
                       endless_method_name(name_t)
 
-                      result = @builder.def_endless_method(*val[0],
+                      result = @builder.def_endless_method(def_t, name_t,
                                  val[1], val[2], val[3])
 
-                      @lexer.cmdarg.pop
-                      @lexer.cond.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
                       @current_arg_stack.pop
+                      @context.in_def = ctx.in_def
                     }
                 | defn_head f_opt_paren_args tEQL command kRESCUE_MOD arg
                     {
-                      _def_t, name_t = val[0]
+                      def_t, (name_t, ctx) = val[0]
                       endless_method_name(name_t)
 
                       rescue_body = @builder.rescue_body(val[4],
@@ -286,32 +284,28 @@ rule
 
                       method_body = @builder.begin_body(val[3], [ rescue_body ])
 
-                      result = @builder.def_endless_method(*val[0],
+                      result = @builder.def_endless_method(def_t, name_t,
                                  val[1], val[2], method_body)
 
-                      @lexer.cmdarg.pop
-                      @lexer.cond.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
                       @current_arg_stack.pop
+                      @context.in_def = ctx.in_def
                     }
                 | defs_head f_opt_paren_args tEQL command
                     {
-                      _def_t, _recv, _dot_t, name_t = val[0]
+                      def_t, recv, dot_t, (name_t, ctx) = val[0]
                       endless_method_name(name_t)
 
-                      result = @builder.def_endless_singleton(*val[0],
+                      result = @builder.def_endless_singleton(def_t, recv, dot_t, name_t,
                                  val[1], val[2], val[3])
 
-                      @lexer.cmdarg.pop
-                      @lexer.cond.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
                       @current_arg_stack.pop
+                      @context.in_def = ctx.in_def
                     }
                 | defs_head f_opt_paren_args tEQL command kRESCUE_MOD arg
                     {
-                      _def_t, _recv, _dot_t, name_t = val[0]
+                      def_t, recv, dot_t, (name_t, ctx) = val[0]
                       endless_method_name(name_t)
 
                       rescue_body = @builder.rescue_body(val[4],
@@ -320,14 +314,12 @@ rule
 
                       method_body = @builder.begin_body(val[3], [ rescue_body ])
 
-                      result = @builder.def_endless_singleton(*val[0],
+                      result = @builder.def_endless_singleton(def_t, recv, dot_t, name_t,
                                  val[1], val[2], method_body)
 
-                      @lexer.cmdarg.pop
-                      @lexer.cond.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
                       @current_arg_stack.pop
+                      @context.in_def = ctx.in_def
                     }
                 | backref tOP_ASGN command_rhs
                     {
@@ -368,13 +360,13 @@ rule
                       @lexer.command_start = false
                       @pattern_variables.push
 
-                      result = @lexer.in_kwarg
-                      @lexer.in_kwarg = true
+                      result = @context.in_kwarg
+                      @context.in_kwarg = true
                     }
                   p_top_expr_body
                     {
                       @pattern_variables.pop
-                      @lexer.in_kwarg = val[2]
+                      @context.in_kwarg = val[2]
                       result = @builder.match_pattern(val[0], val[1], val[3])
                     }
                 | arg kIN
@@ -383,13 +375,13 @@ rule
                       @lexer.command_start = false
                       @pattern_variables.push
 
-                      result = @lexer.in_kwarg
-                      @lexer.in_kwarg = true
+                      result = @context.in_kwarg
+                      @context.in_kwarg = true
                     }
                   p_top_expr_body
                     {
                       @pattern_variables.pop
-                      @lexer.in_kwarg = val[2]
+                      @context.in_kwarg = val[2]
                       result = @builder.match_pattern_p(val[0], val[1], val[3])
                     }
                 | arg =tLBRACE_ARG
@@ -407,29 +399,25 @@ rule
 
         def_name: fname
                     {
-                      @static_env.extend_static
-                      @lexer.cmdarg.push(false)
-                      @lexer.cond.push(false)
+                      local_push
                       @current_arg_stack.push(nil)
 
-                      result = val[0]
+                      result = [ val[0], @context.dup ]
+                      @context.in_def = true
                     }
 
-       defn_head: kDEF def_name
+       defn_head: k_def def_name
                     {
-                      @context.push(:def)
-
                       result = [ val[0], val[1] ]
                     }
 
-       defs_head: kDEF singleton dot_or_colon
+       defs_head: k_def singleton dot_or_colon
                     {
                       @lexer.state = :expr_fname
+                      @context.in_argdef = true
                     }
                   def_name
                     {
-                      @context.push(:defs)
-
                       result = [ val[0], val[1], val[2], val[4] ]
                     }
 
@@ -446,12 +434,13 @@ rule
 
  cmd_brace_block: tLBRACE_ARG
                     {
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                   brace_body tRCURLY
                     {
+                      @context.in_block = val[1].in_block
                       result = [ val[0], *val[2], val[3] ]
-                      @context.pop
                     }
 
            fcall: operation
@@ -932,9 +921,14 @@ rule
                     {
                       result = @builder.logical_op(:or, val[0], val[1], val[2])
                     }
-                | kDEFINED opt_nl arg
+                | kDEFINED opt_nl
                     {
-                      result = @builder.keyword_cmd(:defined?, val[0], nil, [ val[2] ], nil)
+                      @context.in_defined = true
+                    }
+                  arg
+                    {
+                      @context.in_defined = false
+                      result = @builder.keyword_cmd(:defined?, val[0], nil, [ val[3] ], nil)
                     }
                 | arg tEH arg opt_nl tCOLON arg
                     {
@@ -943,21 +937,19 @@ rule
                     }
                 | defn_head f_opt_paren_args tEQL arg
                     {
-                      _def_t, name_t = val[0]
+                      def_t, (name_t, ctx) = val[0]
                       endless_method_name(name_t)
 
-                      result = @builder.def_endless_method(*val[0],
+                      result = @builder.def_endless_method(def_t, name_t,
                                  val[1], val[2], val[3])
 
-                      @lexer.cmdarg.pop
-                      @lexer.cond.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
                       @current_arg_stack.pop
+                      @context.in_def = ctx.in_def
                     }
                 | defn_head f_opt_paren_args tEQL arg kRESCUE_MOD arg
                     {
-                      _def_t, name_t = val[0]
+                      def_t, (name_t, ctx) = val[0]
                       endless_method_name(name_t)
 
                       rescue_body = @builder.rescue_body(val[4],
@@ -966,32 +958,28 @@ rule
 
                       method_body = @builder.begin_body(val[3], [ rescue_body ])
 
-                      result = @builder.def_endless_method(*val[0],
+                      result = @builder.def_endless_method(def_t, name_t,
                                  val[1], val[2], method_body)
 
-                      @lexer.cmdarg.pop
-                      @lexer.cond.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
                       @current_arg_stack.pop
+                      @context.in_def = ctx.in_def
                     }
                 | defs_head f_opt_paren_args tEQL arg
                     {
-                      _def_t, _recv, _dot_t, name_t = val[0]
+                      def_t, recv, dot_t, (name_t, ctx) = val[0]
                       endless_method_name(name_t)
 
-                      result = @builder.def_endless_singleton(*val[0],
+                      result = @builder.def_endless_singleton(def_t, recv, dot_t, name_t,
                                  val[1], val[2], val[3])
 
-                      @lexer.cmdarg.pop
-                      @lexer.cond.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
                       @current_arg_stack.pop
+                      @context.in_def = ctx.in_def
                     }
                 | defs_head f_opt_paren_args tEQL arg kRESCUE_MOD arg
                     {
-                      _def_t, _recv, _dot_t, name_t = val[0]
+                      def_t, recv, dot_t, (name_t, ctx) = val[0]
                       endless_method_name(name_t)
 
                       rescue_body = @builder.rescue_body(val[4],
@@ -1000,14 +988,12 @@ rule
 
                       method_body = @builder.begin_body(val[3], [ rescue_body ])
 
-                      result = @builder.def_endless_singleton(*val[0],
+                      result = @builder.def_endless_singleton(def_t, recv, dot_t, name_t,
                                  val[1], val[2], method_body)
 
-                      @lexer.cmdarg.pop
-                      @lexer.cond.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
                       @current_arg_stack.pop
+                      @context.in_def = ctx.in_def
                     }
                 | primary
 
@@ -1289,10 +1275,15 @@ rule
                     {
                       result = @builder.keyword_cmd(:yield, val[0])
                     }
-                | kDEFINED opt_nl tLPAREN2 expr rparen
+                | kDEFINED opt_nl tLPAREN2
                     {
+                      @context.in_defined = true
+                    }
+                  expr rparen
+                    {
+                      @context.in_defined = false
                       result = @builder.keyword_cmd(:defined?, val[0],
-                                                    val[2], [ val[3] ], val[4])
+                                                    val[2], [ val[4] ], val[5])
                     }
                 | kNOT tLPAREN2 expr rparen
                     {
@@ -1368,86 +1359,77 @@ rule
                     {
                       result = @builder.for(val[0], val[1], val[2], *val[3], val[4], val[5])
                     }
-                | kCLASS cpath superclass
+                | k_class cpath superclass
                     {
-                      @static_env.extend_static
-                      @lexer.cmdarg.push(false)
-                      @lexer.cond.push(false)
-                      @context.push(:class)
+                      @context.in_class = true
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      unless @context.class_definition_allowed?
-                        diagnostic :error, :class_in_def, nil, val[0]
+                      k_class, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :class_in_def, nil, k_class
                       end
-
                       lt_t, superclass = val[2]
-                      result = @builder.def_class(val[0], val[1],
+                      result = @builder.def_class(k_class, val[1],
                                                   lt_t, superclass,
                                                   val[4], val[5])
 
-                      @lexer.cmdarg.pop
-                      @lexer.cond.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
-                | kCLASS tLSHFT expr term
+                | k_class tLSHFT expr term
                     {
-                      @static_env.extend_static
-                      @lexer.cmdarg.push(false)
-                      @lexer.cond.push(false)
-                      @context.push(:sclass)
+                      @context.in_def = false
+                      @context.in_class = false
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      result = @builder.def_sclass(val[0], val[1], val[2],
+                      k_class, ctx = val[0]
+                      result = @builder.def_sclass(k_class, val[1], val[2],
                                                    val[5], val[6])
 
-                      @lexer.cmdarg.pop
-                      @lexer.cond.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = ctx.in_def
+                      @context.in_class = ctx.in_class
                     }
-                | kMODULE cpath
+                | k_module cpath
                     {
-                      @static_env.extend_static
-                      @lexer.cmdarg.push(false)
-                      @context.push(:module)
+                      @context.in_class = true
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      unless @context.module_definition_allowed?
-                        diagnostic :error, :module_in_def, nil, val[0]
+                      k_mod, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :module_in_def, nil, k_mod
                       end
-
-                      result = @builder.def_module(val[0], val[1],
+                      result = @builder.def_module(k_mod, val[1],
                                                    val[3], val[4])
 
-                      @lexer.cmdarg.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
                 | defn_head f_arglist bodystmt kEND
                     {
-                      result = @builder.def_method(*val[0], val[1],
+                      def_t, (name_t, ctx) = val[0]
+                      result = @builder.def_method(def_t, name_t, val[1],
                                   val[2], val[3])
 
-                      @lexer.cmdarg.pop
-                      @lexer.cond.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
                       @current_arg_stack.pop
+                      @context.in_def = ctx.in_def
                     }
                 | defs_head f_arglist bodystmt kEND
                     {
-                      result = @builder.def_singleton(*val[0], val[1],
+                      def_t, recv, dot_t, (name_t, ctx) = val[0]
+                      result = @builder.def_singleton(def_t, recv, dot_t, name_t, val[1],
                                   val[2], val[3])
 
-                      @lexer.cmdarg.pop
-                      @lexer.cond.pop
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
                       @current_arg_stack.pop
+                      @context.in_def = ctx.in_def
                     }
                 | kBREAK
                     {
@@ -1468,9 +1450,25 @@ rule
 
    primary_value: primary
 
+         k_class: kCLASS
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
+
+        k_module: kMODULE
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
+
+           k_def: kDEF
+                    {
+                      result = val[0]
+                      @context.in_argdef = true
+                    }
+
         k_return: kRETURN
                     {
-                      if @context.in_class?
+                      if @context.in_class && !@context.in_def && !(context.in_block || context.in_lambda)
                         diagnostic :error, :invalid_return, nil, val[0]
                       end
                     }
@@ -1555,6 +1553,15 @@ rule
 
     f_any_kwrest: f_kwrest
                 | f_no_kwarg
+
+
+            f_eq:   {
+                      @context.in_argdef = false
+                    }
+                  tEQL
+                    {
+                      result = val[1]
+                    }
 
  block_args_tail: f_block_kwarg tCOMMA f_kwrest opt_f_block_arg
                     {
@@ -1685,12 +1692,14 @@ opt_block_args_tail:
                     {
                       @max_numparam_stack.has_ordinary_params!
                       @current_arg_stack.set(nil)
+                      @context.in_argdef = false
                       result = @builder.args(val[0], val[1], val[2])
                     }
                 | tPIPE block_param opt_bv_decl tPIPE
                     {
                       @max_numparam_stack.has_ordinary_params!
                       @current_arg_stack.set(nil)
+                      @context.in_argdef = false
                       result = @builder.args(val[0], val[1].concat(val[2]), val[3])
                     }
 
@@ -1722,12 +1731,12 @@ opt_block_args_tail:
           lambda: tLAMBDA
                     {
                       @static_env.extend_dynamic
-                      @max_numparam_stack.push
-                      @context.push(:lambda)
+                      @max_numparam_stack.push(static: false)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   f_larglist
                     {
-                      @context.pop
                       @lexer.cmdarg.push(false)
                     }
                   lambda_body
@@ -1739,6 +1748,7 @@ opt_block_args_tail:
                       @max_numparam_stack.pop
                       @static_env.unextend
                       @lexer.cmdarg.pop
+                      @context.in_lambda = val[1].in_lambda
 
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
@@ -1746,11 +1756,13 @@ opt_block_args_tail:
 
      f_larglist: tLPAREN2 f_args opt_bv_decl tRPAREN
                     {
+                      @context.in_argdef = false
                       @max_numparam_stack.has_ordinary_params!
                       result = @builder.args(val[0], val[1].concat(val[2]), val[3])
                     }
                 | f_args
                     {
+                      @context.in_argdef = false
                       if val[0].any?
                         @max_numparam_stack.has_ordinary_params!
                       end
@@ -1759,31 +1771,34 @@ opt_block_args_tail:
 
      lambda_body: tLAMBEG
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt tRCURLY
                     {
+                      @context.in_lambda = val[1].in_lambda
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
                     }
                 | kDO_LAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   bodystmt kEND
                     {
+                      @context.in_lambda = val[1].in_lambda
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
                     }
 
         do_block: kDO_BLOCK
                     {
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                   do_body kEND
                     {
+                      @context.in_block = val[1].in_block
                       result = [ val[0], *val[2], val[3] ]
-                      @context.pop
                     }
 
       block_call: command do_block
@@ -1869,26 +1884,28 @@ opt_block_args_tail:
 
      brace_block: tLCURLY
                     {
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                   brace_body tRCURLY
                     {
+                      @context.in_block = val[1].in_block
                       result = [ val[0], *val[2], val[3] ]
-                      @context.pop
                     }
                 | kDO
                     {
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                   do_body kEND
                     {
+                      @context.in_block = val[1].in_block
                       result = [ val[0], *val[2], val[3] ]
-                      @context.pop
                     }
 
       brace_body:   {
                       @static_env.extend_dynamic
-                      @max_numparam_stack.push
+                      @max_numparam_stack.push(static: false)
                     }
                     opt_block_param compstmt
                     {
@@ -1901,7 +1918,7 @@ opt_block_args_tail:
 
          do_body:   {
                       @static_env.extend_dynamic
-                      @max_numparam_stack.push
+                      @max_numparam_stack.push(static: false)
                     }
                     {
                       @lexer.cmdarg.push(false)
@@ -1935,14 +1952,14 @@ opt_block_args_tail:
                       @pattern_variables.push
                       @pattern_hash_keys.push
 
-                      result = @lexer.in_kwarg
-                      @lexer.in_kwarg = true
+                      result = @context.in_kwarg
+                      @context.in_kwarg = true
                     }
                   p_top_expr then
                     {
                       @pattern_variables.pop
                       @pattern_hash_keys.pop
-                      @lexer.in_kwarg = val[1]
+                      @context.in_kwarg = val[1]
                     }
                   compstmt p_cases
                     {
@@ -2084,13 +2101,13 @@ opt_block_args_tail:
                 | tLBRACE
                     {
                       @pattern_hash_keys.push
-                      result = @lexer.in_kwarg
-                      @lexer.in_kwarg = false
+                      result = @context.in_kwarg
+                      @context.in_kwarg = false
                     }
                   p_kwargs rbrace
                     {
                       @pattern_hash_keys.pop
-                      @lexer.in_kwarg = val[1]
+                      @context.in_kwarg = val[1]
                       result = @builder.hash_pattern(val[0], val[2], val[3])
                     }
                 | tLBRACE rbrace
@@ -2699,6 +2716,7 @@ keyword_variable: kNIL
 f_opt_paren_args: f_paren_args
                 | none
                     {
+                      @context.in_argdef = false
                       result = @builder.args(nil, [], nil)
                     }
 
@@ -2707,18 +2725,19 @@ f_opt_paren_args: f_paren_args
                       result = @builder.args(val[0], val[1], val[2])
 
                       @lexer.state = :expr_value
+                      @context.in_argdef = false
                     }
 
        f_arglist: f_paren_args
                 |   {
-                      result = @lexer.in_kwarg
-                      @lexer.in_kwarg = true
-                      @context.push(:def_open_args)
+                      result = @context.dup
+                      @context.in_kwarg = true
+                      @context.in_argdef = true
                     }
                   f_args term
                     {
-                      @context.pop
-                      @lexer.in_kwarg = val[0]
+                      @context.in_kwarg = val[0].in_kwarg
+                      @context.in_argdef = false
                       result = @builder.args(nil, val[1], nil)
                     }
 
@@ -2909,6 +2928,7 @@ f_opt_paren_args: f_paren_args
                       @max_numparam_stack.has_ordinary_params!
 
                       @current_arg_stack.set(val[0][0])
+                      @context.in_argdef = false
 
                       result = val[0]
                     }
@@ -2916,20 +2936,24 @@ f_opt_paren_args: f_paren_args
             f_kw: f_label arg_value
                     {
                       @current_arg_stack.set(nil)
+                      @context.in_argdef = true
                       result = @builder.kwoptarg(val[0], val[1])
                     }
                 | f_label
                     {
                       @current_arg_stack.set(nil)
+                      @context.in_argdef = true
                       result = @builder.kwarg(val[0])
                     }
 
       f_block_kw: f_label primary_value
                     {
+                      @context.in_argdef = true
                       result = @builder.kwoptarg(val[0], val[1])
                     }
                 | f_label
                     {
+                      @context.in_argdef = true
                       result = @builder.kwarg(val[0])
                     }
 
@@ -2969,15 +2993,17 @@ f_opt_paren_args: f_paren_args
                       result = [ @builder.kwrestarg(val[0]) ]
                     }
 
-           f_opt: f_arg_asgn tEQL arg_value
+           f_opt: f_arg_asgn f_eq arg_value
                     {
                       @current_arg_stack.set(0)
+                      @context.in_argdef = true
                       result = @builder.optarg(val[0], val[1], val[2])
                     }
 
-     f_block_opt: f_arg_asgn tEQL primary_value
+     f_block_opt: f_arg_asgn f_eq primary_value
                     {
                       @current_arg_stack.set(0)
+                      @context.in_argdef = true
                       result = @builder.optarg(val[0], val[1], val[2])
                     }
 
@@ -3141,10 +3167,24 @@ require 'parser'
     end
   end
 
+  def local_push
+    @static_env.extend_static
+    @lexer.cmdarg.push(false)
+    @lexer.cond.push(false)
+    @max_numparam_stack.push(static: true)
+  end
+
+  def local_pop
+    @static_env.unextend
+    @lexer.cmdarg.pop
+    @lexer.cond.pop
+    @max_numparam_stack.pop
+  end
+
   def try_declare_numparam(node)
     name = node.children[0]
 
-    if name =~ /\A_[1-9]\z/ && !static_env.declared?(name) && context.in_dynamic_block?
+    if name =~ /\A_[1-9]\z/ && !static_env.declared?(name) && @context.in_dynamic_block?
       # definitely an implicit param
       location = node.loc.expression
 
@@ -3152,27 +3192,25 @@ require 'parser'
         diagnostic :error, :ordinary_param_defined, nil, [nil, location]
       end
 
-      raw_context = context.stack.dup
       raw_max_numparam_stack = max_numparam_stack.stack.dup
-
       # ignore current block scope
-      raw_context.pop
       raw_max_numparam_stack.pop
 
-      raw_context.reverse_each do |outer_scope|
-        if outer_scope == :block || outer_scope == :lambda
-          outer_scope_has_numparams = raw_max_numparam_stack.pop > 0
+      raw_max_numparam_stack.reverse_each do |outer_scope|
+        if outer_scope[:static]
+          # found an outer scope that can't have numparams
+          # like def/class/etc
+          break
+        else
+          outer_scope_has_numparams = outer_scope[:value] > 0
 
           if outer_scope_has_numparams
             diagnostic :error, :numparam_used_in_outer_scope, nil, [nil, location]
           else
             # for now it's ok, but an outer scope can also be a block
+            # like proc { _1; proc { proc { proc { _2 }} }}
             # with numparams, so we need to continue
           end
-        else
-          # found an outer scope that can't have numparams
-          # like def/class/etc
-          break
         end
       end
 

--- a/lib/parser/rubymotion.y
+++ b/lib/parser/rubymotion.y
@@ -141,7 +141,7 @@ rule
                     }
                 | klBEGIN tLCURLY compstmt tRCURLY
                     {
-                      if @context.indirectly_in_def?
+                      if @context.in_def
                         diagnostic :error, :begin_in_method, nil, val[0]
                       end
 
@@ -265,14 +265,15 @@ rule
  cmd_brace_block: tLBRACE_ARG
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
          command: operation command_args =tLOWEST
@@ -1020,7 +1021,8 @@ rule
                     }
                 | tLAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   lambda
                     {
@@ -1029,6 +1031,8 @@ rule
                       args, (begin_t, body, end_t) = val[2]
                       result      = @builder.block(lambda_call,
                                       begin_t, args, body, end_t)
+
+                      @context.in_lambda = val[1].in_lambda
                     }
                 | kIF expr_value then compstmt if_tail kEND
                     {
@@ -1100,75 +1104,73 @@ rule
                                             val[2], val[4],
                                             val[5], val[7], val[8])
                     }
-                | kCLASS cpath superclass
+                | k_class cpath superclass
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:class)
+                      local_push
+                      @context.in_class = true
                     }
                     bodystmt kEND
                     {
-                      unless @context.class_definition_allowed?
-                        diagnostic :error, :class_in_def, nil, val[0]
+                      k_class, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :class_in_def, nil, k_class
                       end
 
                       lt_t, superclass = val[2]
-                      result = @builder.def_class(val[0], val[1],
+                      result = @builder.def_class(k_class, val[1],
                                                   lt_t, superclass,
                                                   val[4], val[5])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
-                | kCLASS tLSHFT expr term
+                | k_class tLSHFT expr term
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:sclass)
+                      @context.in_def = false
+                      @context.in_class = false
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      result = @builder.def_sclass(val[0], val[1], val[2],
+                      k_class, ctx = val[0]
+                      result = @builder.def_sclass(k_class, val[1], val[2],
                                                    val[5], val[6])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = ctx.in_def
+                      @context.in_class = ctx.in_class
                     }
-                | kMODULE cpath
+                | k_module cpath
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:module)
+                      @context.in_class = true
+                      local_push
                     }
                     bodystmt kEND
                     {
-                      unless @context.module_definition_allowed?
-                        diagnostic :error, :module_in_def, nil, val[0]
+                      k_mod, ctx = val[0]
+                      if @context.in_def
+                        diagnostic :error, :module_in_def, nil, k_mod
                       end
 
-                      result = @builder.def_module(val[0], val[1],
+                      result = @builder.def_module(k_mod, val[1],
                                                    val[3], val[4])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_class = ctx.in_class
                     }
                 | kDEF fname
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:def)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_method(val[0], val[1],
                                   val[3], val[4], val[5])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[2].in_def
                     }
                 | kDEF singleton dot_or_colon
                     {
@@ -1176,18 +1178,17 @@ rule
                     }
                     fname
                     {
-                      @static_env.extend_static
-                      @lexer.push_cmdarg
-                      @context.push(:defs)
+                      local_push
+                      result = context.dup
+                      @context.in_def = true
                     }
                     f_arglist bodystmt kEND
                     {
                       result = @builder.def_singleton(val[0], val[1], val[2],
                                   val[4], val[6], val[7], val[8])
 
-                      @lexer.pop_cmdarg
-                      @static_env.unextend
-                      @context.pop
+                      local_pop
+                      @context.in_def = val[5].in_def
                     }
                 | kBREAK
                     {
@@ -1207,6 +1208,16 @@ rule
                     }
 
    primary_value: primary
+
+         k_class: kCLASS
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
+
+        k_module: kMODULE
+                    {
+                      result = [ val[0], @context.dup ]
+                    }
 
             then: term
                 | kTHEN
@@ -1435,13 +1446,9 @@ rule
           lambda:   {
                       @static_env.extend_dynamic
                     }
-                  f_larglist
+                  f_larglist lambda_body
                     {
-                      @context.pop
-                    }
-                  lambda_body
-                    {
-                      result = [ val[1], val[3] ]
+                      result = [ val[1], val[2] ]
 
                       @static_env.unextend
                     }
@@ -1457,34 +1464,37 @@ rule
 
      lambda_body: tLAMBEG
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
+                      @context.in_lambda = val[1].in_lambda
                     }
                 | kDO_LAMBDA
                     {
-                      @context.push(:lambda)
+                      result = @context.dup
+                      @context.in_lambda = true
                     }
                   compstmt kEND
                     {
                       result = [ val[0], val[2], val[3] ]
-                      @context.pop
+                      @context.in_lambda = val[1].in_lambda
                     }
 
         do_block: kDO_BLOCK
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt kEND
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
       block_call: command do_block
@@ -1558,26 +1568,28 @@ rule
      brace_block: tLCURLY
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt tRCURLY
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
                 | kDO
                     {
                       @static_env.extend_dynamic
-                      @context.push(:block)
+                      result = @context.dup
+                      @context.in_block = true
                     }
                     opt_block_param compstmt kEND
                     {
                       result = [ val[0], val[2], val[3], val[4] ]
 
                       @static_env.unextend
-                      @context.pop
+                      @context.in_block = val[1].in_block
                     }
 
        case_body: kWHEN args then compstmt cases
@@ -2189,4 +2201,16 @@ require 'parser'
 
   def default_encoding
     Encoding::BINARY
+  end
+
+  def local_push
+    @static_env.extend_static
+    @lexer.cmdarg.push(false)
+    @lexer.cond.push(false)
+  end
+
+  def local_pop
+    @static_env.unextend
+    @lexer.cmdarg.pop
+    @lexer.cond.pop
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -96,7 +96,7 @@ module NodeContextExt
 
   module BuilderExt
     def n(type, children, source_map)
-      super.updated(nil, nil, context: @parser.context.stack.dup)
+      super.updated(nil, nil, context: @parser.context.dup)
     end
   end
   Parser::Builders::Default.prepend(BuilderExt)

--- a/test/parse_helper.rb
+++ b/test/parse_helper.rb
@@ -264,7 +264,8 @@ module ParseHelper
       assert_equal 1, nodes.count, "there must exactly 1 `get_context()` call"
 
       node = nodes.first
-      assert_equal context, node.context, "(#{version}) expect parsing context to match"
+      actual_context = Parser::Context::FLAGS.each_with_object([]) { |flag, acc| acc << flag if node.context.public_send(flag) }
+      assert_equal context.sort, actual_context.sort, "(#{version}) expect parsing context to match"
     end
   end
 
@@ -354,7 +355,9 @@ module ParseHelper
     assert lexer.lambda_stack.empty?, "(#{version}) expected lambda_stack to be empty after parsing"
 
     assert parser.static_env.empty?, "(#{version}) expected static_env to be empty after parsing"
-    assert parser.context.empty?, "(#{version}) expected context to be empty after parsing"
+    Parser::Context::FLAGS.each do |ctx_flag|
+      refute parser.context.public_send(ctx_flag), "(#{version}) expected context.#{ctx_flag} to be `false` after parsing"
+    end
     assert parser.max_numparam_stack.empty?, "(#{version}) expected max_numparam_stack to be empty after parsing"
     assert parser.current_arg_stack.empty?, "(#{version}) expected current_arg_stack to be empty after parsing"
     assert parser.pattern_variables.empty?, "(#{version}) expected pattern_variables to be empty after parsing"


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@aa7c4c3.

Also there's a change to Context API that caused a massive rewrite in all grammars.
However, it doesn't affect any logic before 3.1, it's mostly a refactoring.

Closes https://github.com/whitequark/parser/issues/837.