### PR TITLE
* parser/current: update for 3.1.0 release.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.4.10", "2.5.9", "2.6.9", "2.7.5", "3.0.3", "jruby-9.2"]
+        ruby: ["2.6.9", "2.7.5", "3.0.3", "3.1.0", "jruby-9.2"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"
             test_command: "bundle exec rake test || true"
           - ruby: "truffleruby"
             test_command: "bundle exec rake test || true"
-          - ruby: "3.0.3"
+          - ruby: "3.1.0"
             test_command: "./ci/run_rubocop_specs || true"
     steps:
     - uses: actions/checkout@v2

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -93,7 +93,7 @@ module Parser
     CurrentRuby = Ruby30
 
   when /^3\.1\./
-    current_version = '3.1.0-dev'
+    current_version = '3.1.0'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby31', current_version
     end
@@ -103,8 +103,8 @@ module Parser
 
   else # :nocov:
     # Keep this in sync with released Ruby.
-    warn_syntax_deviation 'parser/ruby30', '3.0.x'
-    require 'parser/ruby30'
-    CurrentRuby = Ruby30
+    warn_syntax_deviation 'parser/ruby31', '3.1.x'
+    require 'parser/ruby31'
+    CurrentRuby = Ruby31
   end
 end

--- a/lib/parser/version.rb
+++ b/lib/parser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Parser
-  VERSION = '3.0.3.2'
+  VERSION = '3.1.0.0'
 end


### PR DESCRIPTION
also updated CI config, [2.6 is the latest supported version](https://www.ruby-lang.org/en/downloads/branches/)