### PR TITLE
+ ruby-parse: add ability to read fragment from stdin

### DIFF
--- a/lib/parser/runner.rb
+++ b/lib/parser/runner.rb
@@ -166,6 +166,7 @@ module Parser
       @option_parser.parse!(options)
 
       # Slop has just removed recognized options from `options`.
+      @fragments << $stdin.read if options.delete('-')
       options.each do |file_or_dir|
         if File.directory?(file_or_dir)
           Find.find(file_or_dir) do |path|

--- a/test/test_runner_parse.rb
+++ b/test/test_runner_parse.rb
@@ -53,4 +53,9 @@ class TestRunnerParse < Minitest::Test
     assert_prints ['--emit-json', '-e', ''],
                   "\n"
   end
+
+  def test_stdin_input
+    assert_prints ['--emit-ruby', '-', { stdin_data: '123' }],
+                  's(:int, 123)'
+  end
 end


### PR DESCRIPTION
use - as the filename to read from stdin

this is useful when parsing multiple lines or code containing characters that would otherwise need to be escaped