### PR TITLE
Reuse `p_kwnorest` and `operation` rules

### DIFF
--- a/lib/parser/ruby32.y
+++ b/lib/parser/ruby32.y
@@ -2967,7 +2967,7 @@ f_opt_paren_args: f_paren_args
 
      kwrest_mark: tPOW | tDSTAR
 
-      f_no_kwarg: kwrest_mark kNIL
+      f_no_kwarg: p_kwnorest
                     {
                       result = [ @builder.kwnilarg(val[0], val[1]) ]
                     }

--- a/lib/parser/ruby32.y
+++ b/lib/parser/ruby32.y
@@ -3095,7 +3095,7 @@ f_opt_paren_args: f_paren_args
                     }
 
        operation: tIDENTIFIER | tCONSTANT | tFID
-      operation2: tIDENTIFIER | tCONSTANT | tFID | op
+      operation2: operation | op
       operation3: tIDENTIFIER | tFID | op
     dot_or_colon: call_op | tCOLON2
          call_op: tDOT


### PR DESCRIPTION
Closes #845.

The commits in this PR are separated according to upstream https://github.com/ruby/ruby/pull/5540 and https://github.com/ruby/ruby/pull/5545.