### PR TITLE
Bump 3.1 branch to 3.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6.9", "2.7.5", "3.0.3", "3.1.0", "jruby-9.2"]
+        ruby: ["2.6.9", "2.7.5", "3.0.3", "3.1.1", "jruby-9.2"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"
             test_command: "bundle exec rake test || true"
           - ruby: "truffleruby"
             test_command: "bundle exec rake test || true"
-          - ruby: "3.1.0"
+          - ruby: "3.1.1"
             test_command: "./ci/run_rubocop_specs || true"
     steps:
     - uses: actions/checkout@v2

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -93,7 +93,7 @@ module Parser
     CurrentRuby = Ruby30
 
   when /^3\.1\./
-    current_version = '3.1.0'
+    current_version = '3.1.1'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby31', current_version
     end


### PR DESCRIPTION
Ruby 3.1.1 has been released.
https://www.ruby-lang.org/en/news/2022/02/18/ruby-3-1-1-released/

Bump 3.1 branch from 3.1.0 to 3.1.1
https://github.com/ruby/ruby/compare/v3_1_0...v3_1_1

There seems to be no change to the syntax.