### PR TITLE
Fix using p_kwnorest in f_no_kwarg

### DIFF
--- a/lib/parser/ruby32.y
+++ b/lib/parser/ruby32.y
@@ -2252,11 +2252,14 @@ opt_block_args_tail:
 
       p_kwnorest: kwrest_mark kNIL
                     {
-                      result = [ @builder.match_nil_pattern(val[0], val[1]) ]
+                      result = val
                     }
 
     p_any_kwrest: p_kwrest
                 | p_kwnorest
+                    {
+                      result = [ @builder.match_nil_pattern(val[0][0], val[0][1]) ]
+                    }
 
          p_value: p_primitive
                 | p_primitive tDOT2 p_primitive
@@ -2969,7 +2972,7 @@ f_opt_paren_args: f_paren_args
 
       f_no_kwarg: p_kwnorest
                     {
-                      result = [ @builder.kwnilarg(val[0], val[1]) ]
+                      result = [ @builder.kwnilarg(val[0][0], val[0][1]) ]
                     }
 
         f_kwrest: kwrest_mark tIDENTIFIER

--- a/test/parse_helper.rb
+++ b/test/parse_helper.rb
@@ -7,7 +7,7 @@ module ParseHelper
   require 'parser/macruby'
   require 'parser/rubymotion'
 
-  ALL_VERSIONS = %w(1.8 1.9 2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 mac ios)
+  ALL_VERSIONS = %w(1.8 1.9 2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 mac ios)
 
   def setup
     @diagnostics = []


### PR DESCRIPTION
Also, enable testing for 3.2 (that's why we haven't caught this yet).

`p_kwnorest` is resolved into `s(:match_nil_pattern)`, which we can not use in `f_no_kwarg`.

Ref https://github.com/whitequark/parser/commit/820cc04b8d176c6f46ccc9a010c55f6113f4b2a