### PR TITLE
* Bump maintenance branches to 3.1.2, 3.0.4, 2.7.6, and 2.6.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6.9", "2.7.5", "3.0.3", "3.1.1", "jruby-9.2"]
+        ruby: ["2.6.10", "2.7.6", "3.0.4", "3.1.2", "jruby-9.2"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"
             test_command: "bundle exec rake test || true"
           - ruby: "truffleruby"
             test_command: "bundle exec rake test || true"
-          - ruby: "3.1.1"
+          - ruby: "3.1.2"
             test_command: "./ci/run_rubocop_specs || true"
     steps:
     - uses: actions/checkout@v3

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -66,7 +66,7 @@ module Parser
     CurrentRuby = Ruby25
 
   when /^2\.6\./
-    current_version = '2.6.9'
+    current_version = '2.6.10'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby26', current_version
     end
@@ -75,7 +75,7 @@ module Parser
     CurrentRuby = Ruby26
 
   when /^2\.7\./
-    current_version = '2.7.5'
+    current_version = '2.7.6'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby27', current_version
     end
@@ -84,7 +84,7 @@ module Parser
     CurrentRuby = Ruby27
 
   when /^3\.0\./
-    current_version = '3.0.3'
+    current_version = '3.0.4'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby30', current_version
     end
@@ -93,7 +93,7 @@ module Parser
     CurrentRuby = Ruby30
 
   when /^3\.1\./
-    current_version = '3.1.1'
+    current_version = '3.1.2'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby31', current_version
     end


### PR DESCRIPTION
These Rubies has been released.

- https://www.ruby-lang.org/en/news/2022/04/12/ruby-3-1-2-released/
- https://www.ruby-lang.org/en/news/2022/04/12/ruby-3-0-4-released/
- https://www.ruby-lang.org/en/news/2022/04/12/ruby-2-7-6-released/
- https://www.ruby-lang.org/en/news/2022/04/12/ruby-2-6-10-released/

## Ruby 3.1 branch

Bump 3.1 branch from 3.1.1 to 3.1.2

https://github.com/ruby/ruby/compare/v3_1_1...v3_1_2

There seems to be no change to the syntax.

## Ruby 3.0 branch

Bump 3.0 branch from 3.0.3 to 3.0.4

https://github.com/ruby/ruby/compare/v3_0_3...v3_0_4

There seems to be no change to the syntax.

## Ruby 2.7 branch

Bump 2.7 branch from 2.7.5 to 2.7.6

https://github.com/ruby/ruby/compare/v2_7_5...v2_7_6

There seems to be no change to the syntax.

## Ruby 2.6 branch

Bump 2.6 branch from 2.6.9 to 2.6.10

https://github.com/ruby/ruby/compare/v2_6_9...v2_6_10

There seems to be no change to the syntax.