### PR TITLE
- ruby31.y: fix preparing the state for one-line patterns without braces

### DIFF
--- a/lib/parser/ruby31.y
+++ b/lib/parser/ruby31.y
@@ -359,6 +359,7 @@ rule
                       @lexer.state = :expr_beg
                       @lexer.command_start = false
                       @pattern_variables.push
+                      @pattern_hash_keys.push
 
                       result = @context.in_kwarg
                       @context.in_kwarg = true
@@ -366,6 +367,7 @@ rule
                   p_top_expr_body
                     {
                       @pattern_variables.pop
+                      @pattern_hash_keys.pop
                       @context.in_kwarg = val[2]
                       result = @builder.match_pattern(val[0], val[1], val[3])
                     }
@@ -374,6 +376,7 @@ rule
                       @lexer.state = :expr_beg
                       @lexer.command_start = false
                       @pattern_variables.push
+                      @pattern_hash_keys.push
 
                       result = @context.in_kwarg
                       @context.in_kwarg = true
@@ -381,6 +384,7 @@ rule
                   p_top_expr_body
                     {
                       @pattern_variables.pop
+                      @pattern_hash_keys.pop
                       @context.in_kwarg = val[2]
                       result = @builder.match_pattern_p(val[0], val[1], val[3])
                     }

--- a/lib/parser/ruby32.y
+++ b/lib/parser/ruby32.y
@@ -359,6 +359,7 @@ rule
                       @lexer.state = :expr_beg
                       @lexer.command_start = false
                       @pattern_variables.push
+                      @pattern_hash_keys.push
 
                       result = @context.in_kwarg
                       @context.in_kwarg = true
@@ -366,6 +367,7 @@ rule
                   p_top_expr_body
                     {
                       @pattern_variables.pop
+                      @pattern_hash_keys.pop
                       @context.in_kwarg = val[2]
                       result = @builder.match_pattern(val[0], val[1], val[3])
                     }
@@ -374,6 +376,7 @@ rule
                       @lexer.state = :expr_beg
                       @lexer.command_start = false
                       @pattern_variables.push
+                      @pattern_hash_keys.push
 
                       result = @context.in_kwarg
                       @context.in_kwarg = true
@@ -381,6 +384,7 @@ rule
                   p_top_expr_body
                     {
                       @pattern_variables.pop
+                      @pattern_hash_keys.pop
                       @context.in_kwarg = val[2]
                       result = @builder.match_pattern_p(val[0], val[1], val[3])
                     }

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -9621,6 +9621,40 @@ class TestParser < Minitest::Test
       %q{~~~~~~~~~~~~ expression (match_pattern_p)
         |       ~~ operator (match_pattern_p)},
       SINCE_3_1)
+
+    assert_parses(
+      s(:begin,
+        s(:match_pattern_p,
+          s(:hash,
+            s(:pair,
+              s(:sym, :key),
+              s(:sym, :value))),
+          s(:hash_pattern,
+            s(:pair,
+              s(:sym, :key),
+              s(:match_var, :value)))),
+        s(:lvar, :value)),
+      %q{{key: :value} in key: value; value},
+      %q{~~~~~~~~~~~~~~~~~~~~~~~~~~~ expression (match_pattern_p)
+        |              ~~ operator (match_pattern_p)},
+      SINCE_3_1)
+
+    assert_parses(
+      s(:begin,
+        s(:match_pattern,
+          s(:hash,
+            s(:pair,
+              s(:sym, :key),
+              s(:sym, :value))),
+          s(:hash_pattern,
+            s(:pair,
+              s(:sym, :key),
+              s(:match_var, :value)))),
+        s(:lvar, :value)),
+      %q{{key: :value} => key: value; value},
+      %q{~~~~~~~~~~~~~~~~~~~~~~~~~~~ expression (match_pattern)
+        |              ~~ operator (match_pattern)},
+      SINCE_3_1)
   end
 
   def test_ruby_bug_pattern_matching_restore_in_kwarg_flag


### PR DESCRIPTION
Fixes #861 