### PR TITLE
+ ruby32.y: implement forwarded restarg and kwrestarg.

### DIFF
--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -1276,6 +1276,28 @@ Format:
      ~~~ expression
 ~~~
 
+### Method call taking positional arguments of the currently called method
+
+Format:
+
+~~~
+(send nil :foo
+  (forwarded-restarg))
+"foo(*)"
+     ~ expression
+~~~
+
+### Method call taking keyword arguments of the currently called method
+
+Format:
+
+~~~
+(send nil :foo
+  (forwarded-kwrestarg))
+"foo(**)"
+     ~~ expression
+~~~
+
 ## Send
 
 ### To self

--- a/lib/parser/ast/processor.rb
+++ b/lib/parser/ast/processor.rb
@@ -148,6 +148,9 @@ module Parser
       alias on_blockarg_expr  process_regular_node
       alias on_block_pass     process_regular_node
 
+      alias on_forwarded_restarg   process_regular_node
+      alias on_forwarded_kwrestarg process_regular_node
+
       alias on_module         process_regular_node
       alias on_class          process_regular_node
       alias on_sclass         process_regular_node

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1078,6 +1078,14 @@ module Parser
       n(:forwarded_args, [], token_map(dots_t))
     end
 
+    def forwarded_restarg(star_t)
+      n(:forwarded_restarg, [], token_map(star_t))
+    end
+
+    def forwarded_kwrestarg(dstar_t)
+      n(:forwarded_kwrestarg, [], token_map(dstar_t))
+    end
+
     def call_method(receiver, dot_t, selector_t,
                     lparen_t=nil, args=[], rparen_t=nil)
       type = call_type_for_dot(dot_t)

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -79,6 +79,8 @@ module Parser
     :invalid_id_to_get            => 'identifier %{identifier} is not valid to get',
     :forward_arg_after_restarg    => '... after rest argument',
     :no_anonymous_blockarg        => 'no anonymous block parameter',
+    :no_anonymous_restarg         => 'no anonymous rest parameter',
+    :no_anonymous_kwrestarg       => 'no anonymous keyword rest parameter',
 
     # Parser warnings
     :useless_else            => 'else without rescue is useless',

--- a/lib/parser/meta.rb
+++ b/lib/parser/meta.rb
@@ -33,6 +33,7 @@ module Parser
         hash_pattern const_pattern if_guard unless_guard match_nil_pattern
         empty_else find_pattern kwargs
         match_pattern_p match_pattern
+        forwarded_restarg forwarded_kwrestarg
       ).to_set.freeze
 
   end # Meta

--- a/lib/parser/ruby32.y
+++ b/lib/parser/ruby32.y
@@ -1175,6 +1175,14 @@ rule
                     {
                       result = [ @builder.splat(val[0], val[1]) ]
                     }
+                | tSTAR
+                    {
+                      if !@static_env.declared_anonymous_restarg?
+                        diagnostic :error, :no_anonymous_restarg, nil, val[0]
+                      end
+
+                      result = [ @builder.forwarded_restarg(val[0]) ]
+                    }
                 | args tCOMMA arg_value
                     {
                       result = val[0] << val[2]
@@ -2987,6 +2995,8 @@ f_opt_paren_args: f_paren_args
                     }
                 | kwrest_mark
                     {
+                      @static_env.declare_anonymous_kwrestarg
+
                       result = [ @builder.kwrestarg(val[0]) ]
                     }
 
@@ -3032,6 +3042,8 @@ f_opt_paren_args: f_paren_args
                     }
                 | restarg_mark
                     {
+                      @static_env.declare_anonymous_restarg
+
                       result = [ @builder.restarg(val[0]) ]
                     }
 
@@ -3099,6 +3111,14 @@ f_opt_paren_args: f_paren_args
                 | tDSTAR arg_value
                     {
                       result = @builder.kwsplat(val[0], val[1])
+                    }
+                | tDSTAR
+                    {
+                      if !@static_env.declared_anonymous_kwrestarg?
+                        diagnostic :error, :no_anonymous_kwrestarg, nil, val[0]
+                      end
+
+                      result = @builder.forwarded_kwrestarg(val[0])
                     }
 
        operation: tIDENTIFIER | tCONSTANT | tFID

--- a/lib/parser/static_environment.rb
+++ b/lib/parser/static_environment.rb
@@ -5,6 +5,8 @@ module Parser
   class StaticEnvironment
     FORWARD_ARGS = :FORWARD_ARGS
     ANONYMOUS_BLOCKARG = :ANONYMOUS_BLOCKARG
+    ANONYMOUS_RESTARG = :ANONYMOUS_RESTARG
+    ANONYMOUS_KWRESTARG = :ANONYMOUS_KWRESTARG
 
     def initialize
       reset
@@ -59,6 +61,22 @@ module Parser
 
     def declared_anonymous_blockarg?
       declared?(ANONYMOUS_BLOCKARG)
+    end
+
+    def declare_anonymous_restarg
+      declare(ANONYMOUS_RESTARG)
+    end
+
+    def declared_anonymous_restarg?
+      declared?(ANONYMOUS_RESTARG)
+    end
+
+    def declare_anonymous_kwrestarg
+      declare(ANONYMOUS_KWRESTARG)
+    end
+
+    def declared_anonymous_kwrestarg?
+      declared?(ANONYMOUS_KWRESTARG)
     end
 
     def empty?

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -10888,4 +10888,41 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_3_2)
   end
+
+  def test_forwarded_restarg
+    assert_parses(
+      s(:def, :foo,
+        s(:args,
+          s(:restarg)),
+        s(:send, nil, :bar,
+          s(:forwarded_restarg))),
+      %q{def foo(*); bar(*); end},
+      %q{                ~ expression (send.forwarded_restarg)},
+      SINCE_3_2)
+
+    assert_diagnoses(
+      [:error, :no_anonymous_restarg],
+      %q{def foo; bar(*); end},
+      %q{},
+      SINCE_3_2)
+  end
+
+  def test_forwarded_kwrestarg
+    assert_parses(
+      s(:def, :foo,
+        s(:args,
+          s(:kwrestarg)),
+        s(:send, nil, :bar,
+          s(:kwargs,
+            s(:forwarded_kwrestarg)))),
+      %q{def foo(**); bar(**); end},
+      %q{                 ~~ expression (send.kwargs.forwarded_kwrestarg)},
+      SINCE_3_2)
+
+    assert_diagnoses(
+      [:error, :no_anonymous_kwrestarg],
+      %q{def foo; bar(**); end},
+      %q{},
+      SINCE_3_2)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@f53dfab.

Closes https://github.com/whitequark/parser/issues/838.
