### PR TITLE
add tests for `class/module <keyword> ...` definition.

### DIFF
--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -10925,4 +10925,48 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_3_2)
   end
+
+  def test_if_while_after_class__since_32
+    assert_parses(
+      s(:module,
+        s(:const,
+          s(:if,
+            s(:true),
+            s(:const, nil, :Object), nil), :Kernel), nil),
+      %q{module if true; Object end::Kernel; end},
+      %q{},
+      SINCE_3_2)
+
+    assert_parses(
+      s(:module,
+        s(:const,
+          s(:while,
+            s(:true),
+            s(:break,
+              s(:const, nil, :Object))), :Kernel), nil),
+      %q{module while true; break Object end::Kernel; end},
+      %q{},
+      SINCE_3_2)
+
+    assert_parses(
+      s(:class,
+        s(:const,
+          s(:if,
+            s(:true),
+            s(:const, nil, :Object), nil), :Kernel), nil, nil),
+      %q{class if true; Object end::Kernel; end},
+      %q{},
+      SINCE_3_2)
+
+    assert_parses(
+      s(:class,
+        s(:const,
+          s(:while,
+            s(:true),
+            s(:break,
+              s(:const, nil, :Object))), :Kernel), nil, nil),
+      %q{class while true; break Object end::Kernel; end},
+      %q{},
+      SINCE_3_2)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@685efac.

I'm not going to break it for old Rubies, if your code relies on this incorrect behaviour of Ruby < 3.2 feel free to send a PR.

Closes https://github.com/whitequark/parser/issues/859.