### PR TITLE
add test for bare backslash error.

### DIFF
--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -10969,4 +10969,12 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_3_2)
   end
+
+  def test_bare_backslash
+    assert_diagnoses(
+      [:error, :bare_backslash],
+      %q{x = \ 42},
+      %q{    ^ location},
+      ALL_VERSIONS)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@982cda9.

`parser` has never been affected by this bug, and I'm not going to backport it. However we have no tests for this diagnostic, so this PR adds one.

Closes https://github.com/whitequark/parser/issues/860.