### PR TITLE
add tests for newline after hash key in pattern matching.

### DIFF
--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -10977,4 +10977,47 @@ class TestParser < Minitest::Test
       %q{    ^ location},
       ALL_VERSIONS)
   end
+
+  def test_newline_in_hash_argument
+    assert_parses(
+      s(:send,
+        s(:send, nil, :obj), :set,
+        s(:kwargs,
+          s(:pair,
+            s(:sym, :foo),
+            s(:int, 1)))),
+      %Q{obj.set foo:\n1},
+      %q{},
+      SINCE_3_2)
+
+    assert_parses(
+      s(:send,
+        s(:send, nil, :obj), :set,
+        s(:kwargs,
+          s(:pair,
+            s(:sym, :foo),
+            s(:int, 1)))),
+      %Q{obj.set "foo":\n1},
+      %q{},
+      SINCE_3_2)
+
+    assert_parses(
+      s(:case_match,
+        s(:lvar, :foo),
+        s(:in_pattern,
+          s(:hash_pattern,
+            s(:match_var, :a)), nil,
+          s(:begin,
+            s(:int, 0),
+            s(:true))),
+        s(:in_pattern,
+          s(:hash_pattern,
+            s(:match_var, :b)), nil,
+          s(:begin,
+            s(:int, 0),
+            s(:true))), nil),
+      %Q{case foo\nin a:\n0\ntrue\nin "b":\n0\ntrue\nend},
+      %q{},
+      SINCE_3_2)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@eaeb130.

Ruby < 3.2 had a bug that emitted tNL if there's a newline after hash key in pattern matching like

```ruby
case foo
in a:
  0
  1
end
```

Before 3.2 it was `in a: 1` pattern, starting from 3.2 it's `in a:` with a multiline body.

Unfortunately unsetting `in_kwarg` in parsers < 3.2 is not enough to handle all cases, tNL must still be emitted in a few cases, for example for command:

```ruby
in a:
  p a
```

but not if it's a trivial expression. I think backporting this bug is not worth it, the chance of introduce new bugs is too high. If you know what is a proper fix please don't hesitate to send a PR.

This PR only adds tests for new behaviour that is implemented by all versions of parser.

Closes https://github.com/whitequark/parser/issues/862.