### PR TITLE
* ruby32.y: reuse opt_nl rule.

### DIFF
--- a/lib/parser/ruby32.y
+++ b/lib/parser/ruby32.y
@@ -3147,7 +3147,7 @@ f_opt_paren_args: f_paren_args
                     {
                       result = val[1]
                     }
-         trailer:  | tNL | tCOMMA
+         trailer: opt_nl | tCOMMA
 
             term: tSEMI
                   {


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@3541f32.

Closes https://github.com/whitequark/parser/issues/866.

@koic I'm so sorry, I totally missed an empty rule that you left in https://github.com/whitequark/parser/pull/867, that's why you had a conflict 😄 . Sorry again, I should've noticed it during initial review. IIRC Racc doesn't support comments, this is why empty rules have no visual representation.
