### PR TITLE
add tests for multiple pattern matches in a single body.

### DIFF
--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -11020,4 +11020,38 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_3_2)
   end
+
+  def test_multiple_pattern_matches
+    code = '{a: 0} => a:'
+    node = s(:match_pattern,
+            s(:hash,
+              s(:pair,
+                s(:sym, :a),
+                s(:int, 0))),
+            s(:hash_pattern,
+              s(:match_var, :a)))
+    assert_parses(
+      s(:begin,
+        node,
+        node),
+      %Q{#{code}\n#{code}},
+      %q{},
+      SINCE_3_2)
+
+    code = '{a: 0} in a:'
+    node = s(:match_pattern_p,
+            s(:hash,
+              s(:pair,
+                s(:sym, :a),
+                s(:int, 0))),
+            s(:hash_pattern,
+              s(:match_var, :a)))
+    assert_parses(
+      s(:begin,
+        node,
+        node),
+      %Q{#{code}\n#{code}},
+      %q{},
+      SINCE_3_2)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@db0e0da.

This is another piece that have been properly implemented in parser since the very beginning. I'm not going to backport the bug.

Closes https://github.com/whitequark/parser/issues/869.