### PR TITLE
remove 2.6 branch from CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6.10", "2.7.6", "3.0.4", "3.1.2", "jruby-9.2"]
+        ruby: ["2.7.6", "3.0.4", "3.1.2", "jruby-9.2"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"


### PR DESCRIPTION
[It's no longer maintained](https://www.ruby-lang.org/en/downloads/branches/)