### PR TITLE
bump racc to 1.6.0

### DIFF
--- a/parser.gemspec
+++ b/parser.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler',   '>= 1.15', '< 3.0.0'
   spec.add_development_dependency 'rake',      '~> 13.0.1'
-  spec.add_development_dependency 'racc',      '= 1.4.15'
+  spec.add_development_dependency 'racc',      '= 1.6.0'
   spec.add_development_dependency 'cliver',    '~> 0.3.2'
 
   spec.add_development_dependency 'yard'


### PR DESCRIPTION
Currently there's an error on CI

```
racc --superclass=Parser::Base lib/parser/ruby18.y -o lib/parser/ruby18.rb --no-line-convert
/home/runner/work/parser/parser/vendor/bundle/ruby/3.2.0+3/gems/racc-1.4.15/lib/racc/statetransitiontable.rb:224:in `initialize': unknown regexp option: n (ArgumentError)

      Regexp.compile(map, 'n')
                     ^^^^^^^^
	from /home/runner/work/parser/parser/vendor/bundle/ruby/3.2.0+3/gems/racc-1.4/lib/racc/statetransitiontable.rb:224:in `compile'
```