### PR TITLE
* Bump maintenance branches to 3.1.3, 3.0.5, 2.7.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7.6", "3.0.4", "3.1.2", "jruby-9.2"]
+        ruby: ["2.7.7", "3.0.5", "3.1.3", "jruby-9.2"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"
             test_command: "bundle exec rake test || true"
           - ruby: "truffleruby"
             test_command: "bundle exec rake test || true"
-          - ruby: "3.1.2"
+          - ruby: "3.1.3"
             test_command: "./ci/run_rubocop_specs || true"
     steps:
     - uses: actions/checkout@v3

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -75,7 +75,7 @@ module Parser
     CurrentRuby = Ruby26
 
   when /^2\.7\./
-    current_version = '2.7.6'
+    current_version = '2.7.7'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby27', current_version
     end
@@ -84,7 +84,7 @@ module Parser
     CurrentRuby = Ruby27
 
   when /^3\.0\./
-    current_version = '3.0.4'
+    current_version = '3.0.5'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby30', current_version
     end
@@ -93,7 +93,7 @@ module Parser
     CurrentRuby = Ruby30
 
   when /^3\.1\./
-    current_version = '3.1.2'
+    current_version = '3.1.3'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby31', current_version
     end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -11038,7 +11038,7 @@ class TestParser < Minitest::Test
         node),
       %Q{#{code}\n#{code}},
       %q{},
-      SINCE_3_2)
+      SINCE_3_1)
 
     code = '{a: 0} in a:'
     node = s(:match_pattern_p,
@@ -11054,6 +11054,6 @@ class TestParser < Minitest::Test
         node),
       %Q{#{code}\n#{code}},
       %q{},
-      SINCE_3_2)
+      SINCE_3_1)
   end
 end


### PR DESCRIPTION
These Rubies have been released.

- https://www.ruby-lang.org/en/news/2022/11/24/ruby-3-1-3-released/
- https://www.ruby-lang.org/en/news/2022/11/24/ruby-3-0-5-released/
- https://www.ruby-lang.org/en/news/2022/11/24/ruby-2-7-7-released/

## Ruby 3.1 branch

Bump 3.1 branch from 3.1.2 to 3.1.3

https://github.com/ruby/ruby/compare/v3_1_2...v3_1_3

3 commits have been backported.

The following backport is for testing only, just like #880.

- https://github.com/ruby/ruby/commit/163947f4dc031bb5e619ae64ad4a6a02f8885717

The following two seem to have no corresponding commits in the parser gem for porting.

- https://github.com/ruby/ruby/commit/ffd3d83ea8ccf111061a0f03036e5a093bb03674
- https://github.com/ruby/ruby/commit/750d4dc3aff7c2fef25fe99f1b98327f68734c9a

So, there seems to be no change to the backport syntax.

## Ruby 3.0 branch

Bump 3.0 branch from 3.0.4 to 3.0.5

https://github.com/ruby/ruby/compare/v3_0_4...v3_0_5

No backport commits. So, there seems to be no change to the syntax.

## Ruby 2.7 branch

Bump 2.7 branch from 2.7.6 to 2.7.7

https://github.com/ruby/ruby/compare/v2_7_6...v2_7_7

The following backport appear to have no effect on syntax.

- https://github.com/ruby/ruby/commit/168ec2b1e5ad0e4688e963d9de019557c78feed9

So, there seems to be no change to the syntax.