### PR TITLE
- ruby32.y: fix a parse error when using forwarded argument with restarg

### DIFF
--- a/lib/parser/ruby32.y
+++ b/lib/parser/ruby32.y
@@ -1191,6 +1191,14 @@ rule
                     {
                       result = val[0] << @builder.splat(val[2], val[3])
                     }
+                | args tCOMMA tSTAR
+                    {
+                      if !@static_env.declared_anonymous_restarg?
+                        diagnostic :error, :no_anonymous_restarg, nil, val[2]
+                      end
+
+                      result = val[0] << @builder.forwarded_restarg(val[2])
+                    }
 
         mrhs_arg: mrhs
                     {

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -10909,6 +10909,26 @@ class TestParser < Minitest::Test
       SINCE_3_2)
   end
 
+  def test_forwarded_argument_with_restarg
+    assert_parses(
+      s(:def, :foo,
+        s(:args,
+          s(:arg, :argument),
+          s(:restarg)),
+        s(:send, nil, :bar,
+          s(:lvar, :argument),
+          s(:forwarded_restarg))),
+      %q{def foo(argument, *); bar(argument, *); end},
+      %q{                                    ~ expression (send.forwarded_restarg)},
+      SINCE_3_2)
+
+    assert_diagnoses(
+      [:error, :no_anonymous_restarg],
+      %q{def foo; bar(argument, *); end},
+      %q{},
+      SINCE_3_2)
+  end
+
   def test_forwarded_kwrestarg
     assert_parses(
       s(:def, :foo,
@@ -10924,6 +10944,27 @@ class TestParser < Minitest::Test
     assert_diagnoses(
       [:error, :no_anonymous_kwrestarg],
       %q{def foo; bar(**); end},
+      %q{},
+      SINCE_3_2)
+  end
+
+  def test_forwarded_argument_with_kwrestarg
+    assert_parses(
+      s(:def, :foo,
+        s(:args,
+          s(:arg, :argument),
+          s(:kwrestarg)),
+        s(:send, nil, :bar,
+          s(:lvar, :argument),
+          s(:kwargs,
+            s(:forwarded_kwrestarg)))),
+      %q{def foo(argument, **); bar(argument, **); end},
+      %q{                                     ~~ expression (send.kwargs.forwarded_kwrestarg)},
+      SINCE_3_2)
+
+    assert_diagnoses(
+      [:error, :no_anonymous_kwrestarg],
+      %q{def foo; bar(argument, **); end},
       %q{},
       SINCE_3_2)
   end


### PR DESCRIPTION
This PR fixes the following Ruby 3.2 parse error when using forwarded argument with restarg.

```console
% ruby-parse -e "def foo(arg, *); bar(arg, *); end"
warning: parser/current is loading parser/ruby32, which recognizes3.2.0-dev-compliant syntax, but you are running 3.2.0.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
(fragment:0):1:28: error: unexpected token tRPAREN
(fragment:0):1: def foo(arg, *); bar(arg, *); end
(fragment:0):1:
```

It's valid syntax in Ruby 3.2.

```console
% ruby -vce "def foo(arg, *); bar(arg, *); end"
ruby 3.2.0dev (2022-12-06T02:18:59Z master 80bd9c64aa) [x86_64-darwin19]
Syntax OK
```

It seems that #874's follow-up to the following was insufficient:
https://github.com/ruby/ruby/commit/f53dfab