### PR TITLE
* bump Racc to 1.6.1

### DIFF
--- a/parser.gemspec
+++ b/parser.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler',   '>= 1.15', '< 3.0.0'
   spec.add_development_dependency 'rake',      '~> 13.0.1'
-  spec.add_development_dependency 'racc',      '= 1.6.0'
+  spec.add_development_dependency 'racc',      '= 1.6.1'
   spec.add_development_dependency 'cliver',    '~> 0.3.2'
 
   spec.add_development_dependency 'yard'


### PR DESCRIPTION
This PR prevents the following error when using Racc 1.6.0 with Ruby 3.2.0-dev:

```console
% cd whitequark/parser
% ruby -v
ruby 3.2.0dev (2022-12-07T03:32:29Z master bcd8b2f00a) [x86_64-darwin19]
% bundle exec rake
racc --superclass=Parser::Base lib/parser/ruby32.y -o lib/parser/ruby32.rb --no-line-convert
/Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/lib/racc/statetransitiontable.rb:219:in `initialize': unknown regexp option: n (ArgumentError)

      Regexp.compile(map, 'n')
                     ^^^^^^^^
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/lib/racc/statetransitiontable.rb:219:in `compile'
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/lib/racc/statetransitiontable.rb:219:in `mkmapexp'
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/lib/racc/statetransitiontable.rb:179:in `addent'
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/lib/racc/statetransitiontable.rb:122:in `block in gen_action_tables'
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/lib/racc/state.rb:56:in `each'
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/lib/racc/state.rb:56:in `each_state'
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/lib/racc/statetransitiontable.rb:112:in `gen_action_tables'
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/lib/racc/statetransitiontable.rb:72:in `generate'
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/lib/racc/statetransitiontable.rb:35:in `generate'
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/lib/racc/state.rb:93:in `state_transition_table'
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/lib/racc/grammar.rb:153:in `parser_class'
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/lib/racc/grammarfileparser.rb:144:in `<module:Racc>'
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/lib/racc/grammarfileparser.rb:20:in `<top (required)>'
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/lib/racc/static.rb:3:in `require'
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/lib/racc/static.rb:3:in `<top (required)>'
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/bin/racc:11:in `require'
        from /Users/koic/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+3/gems/racc-1.6.0/bin/racc:11:in `<top (required)>'
        from /Users/koic/.rbenv/versions/3.2.0-dev/bin/racc:25:in `load'
        from /Users/koic/.rbenv/versions/3.2.0-dev/bin/racc:25:in `<main>'
rake aborted!
Command failed with status (1): [racc --superclass=Parser::Base lib/parser/...]
/Users/koic/src/github.com/whitequark/parser/Rakefile:166:in `block in <top (required)>'
/Users/koic/.rbenv/versions/3.2.0-dev/bin/bundle:25:in `load'
/Users/koic/.rbenv/versions/3.2.0-dev/bin/bundle:25:in `<main>'
Tasks: TOP => default => test => generate => lib/parser/ruby32.rb
(See full trace by running task with --trace)
```

This error resolved by Racc 1.6.1:
https://bugs.ruby-lang.org/issues/19190