### PR TITLE
+ ruby32.y: Allow optional newlines before closing parenthesis

### DIFF
--- a/lib/parser/ruby32.y
+++ b/lib/parser/ruby32.y
@@ -2346,7 +2346,7 @@ opt_block_args_tail:
                       result = @builder.pin(val[0], non_lvar)
                     }
 
-      p_expr_ref: tCARET tLPAREN expr_value tRPAREN
+      p_expr_ref: tCARET tLPAREN expr_value rparen
                     {
                       expr = @builder.begin(val[1], val[2], val[3])
                       result = @builder.pin(val[0], expr)

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -10526,6 +10526,16 @@ class TestParser < Minitest::Test
       %q{   ~ selector (in_pattern.pin)
         |   ~~~~~~~~~~~~~~~~~~~~~ expression (in_pattern.pin)},
       SINCE_3_1)
+
+    assert_parses_pattern_match(
+      s(:in_pattern,
+        s(:pin,
+          s(:begin,
+          s(:int, 1))), nil, nil),
+      %Q{in ^(1\n)},
+      %q{   ~ selector (in_pattern.pin)
+        |   ~~~~~ expression (in_pattern.pin)},
+      SINCE_3_2)
   end
 
   def test_assignment_to_numparam_via_pattern_matching


### PR DESCRIPTION
Closes #891.

This commit tracks upstream commit https://github.com/ruby/ruby/commit/764da87.