### PR TITLE
+ lexer.rl: use Ragel -F0 on non-CRuby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,8 @@ tmp
 *.output
 .ruby-version
 .ruby-gemset
-lib/parser/lexer.rb
+lib/parser/lexer-F0.rb
+lib/parser/lexer-F1.rb
 lib/parser/ruby18.rb
 lib/parser/ruby19.rb
 lib/parser/ruby20.rb

--- a/.yardopts
+++ b/.yardopts
@@ -6,7 +6,8 @@
 --asset ./doc/css/common.css:css/common.css
 --verbose
 --api public
---exclude lib/parser/lexer.rb
+--exclude lib/parser/lexer-F0.rb
+--exclude lib/parser/lexer-F1.rb
 --exclude lib/parser/ruby18.rb
 --exclude lib/parser/ruby19.rb
 --exclude lib/parser/ruby20.rb

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,8 @@ end
 
 task :build => [:generate_release, :changelog]
 
-GENERATED_FILES = %w(lib/parser/lexer.rb
+GENERATED_FILES = %w(lib/parser/lexer-F0.rb
+                     lib/parser/lexer-F1.rb
                      lib/parser/ruby18.rb
                      lib/parser/ruby19.rb
                      lib/parser/ruby20.rb
@@ -151,8 +152,12 @@ task :changelog do
   sh('git commit CHANGELOG.md -m "Update changelog." || true')
 end
 
-rule '.rb' => '.rl' do |t|
+file 'lib/parser/lexer-F1.rb' => 'lib/parser/lexer.rl' do |t|
   sh "ragel -F1 -R #{t.source} -o #{t.name}"
+end
+
+file 'lib/parser/lexer-F0.rb' => 'lib/parser/lexer.rl' do |t|
+  sh "ragel -F0 -R #{t.source} -o #{t.name}"
 end
 
 rule '.rb' => '.y' do |t|

--- a/lib/parser.rb
+++ b/lib/parser.rb
@@ -64,7 +64,11 @@ module Parser
 
   require 'parser/static_environment'
 
-  require 'parser/lexer'
+  if RUBY_ENGINE == 'ruby'
+    require 'parser/lexer-F1'
+  else
+    require 'parser/lexer-F0'
+  end
   require 'parser/lexer/literal'
   require 'parser/lexer/stack_state'
   require 'parser/lexer/dedenter'

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -272,6 +272,7 @@ class Parser::Lexer
     _lex_to_state_actions   = klass.send :_lex_to_state_actions
     _lex_from_state_actions = klass.send :_lex_from_state_actions
     _lex_eof_trans          = klass.send :_lex_eof_trans
+    _lex_actions            = klass.send :_lex_actions if klass.respond_to?(:_lex_actions, true)
 
     pe = @source_pts.size + 2
     p, eof = @p, pe


### PR DESCRIPTION
* F0 generates a much smaller Parser::Lexer#advance method which is much better for JITs.
* See https://github.com/whitequark/parser/issues/871