### PR TITLE
Reduce the number of allocated Ranges

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -191,11 +191,20 @@ module Parser
         end
       end
 
-      def slice(range)
+      def slice(start, length = nil)
+        if length.nil?
+          if start.is_a?(::Range)
+            length = start.size
+            start = start.begin
+          else
+            length = 1
+          end
+        end
+
         if @slice_source.nil?
-          @source[range]
+          @source[start, length]
         else
-          @slice_source[range].encode(@source.encoding)
+          @slice_source[start, length].encode(@source.encoding)
         end
       end
 

--- a/lib/parser/source/range.rb
+++ b/lib/parser/source/range.rb
@@ -130,7 +130,7 @@ module Parser
       # @return [String] all source code covered by this range.
       #
       def source
-        @source_buffer.slice(self.begin_pos...self.end_pos)
+        @source_buffer.slice(@begin_pos, @end_pos - @begin_pos)
       end
 
       ##


### PR DESCRIPTION
While optimizing rubocop, I identified that `parser` creates ~100Mb of unneeded `Range` objects while checking just 660 ruby files.

Additionally, made 2 more tiny changes which were producing 1-2% of execution and made them a little faster. 

See https://github.com/rubocop/rubocop/pull/11300 for more details.