### PR TITLE
Code size reduction for advance method

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -687,6 +687,14 @@ class Parser::Lexer
     p
   end
 
+  def read_post_meta_or_ctrl_char(p)
+    @escape = @source_buffer.slice(p - 1, 1).chr
+
+    if @version >= 27 && ((0..8).include?(@escape.ord) || (14..31).include?(@escape.ord))
+      diagnostic :fatal, :invalid_escape
+    end
+  end
+
   # Mapping of strings to parser tokens.
 
   PUNCTUATION = {
@@ -927,11 +935,7 @@ class Parser::Lexer
   }
 
   action read_post_meta_or_ctrl_char {
-    @escape = @source_buffer.slice(p - 1, 1).chr
-
-    if @version >= 27 && ((0..8).include?(@escape.ord) || (14..31).include?(@escape.ord))
-      diagnostic :fatal, :invalid_escape
-    end
+    read_post_meta_or_ctrl_char(p)
   }
 
   action slash_c_char {

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -759,6 +759,16 @@ class Parser::Lexer
     end
   end
 
+  def emit_colon_with_digits(p, tm, diag_msg)
+    if @version >= 27
+      diagnostic :error, diag_msg, { name: tok(tm, @te) }, range(tm, @te)
+    else
+      emit(:tCOLON, tok(@ts, @ts + 1), @ts, @ts + 1)
+      p = @ts
+    end
+    p
+  end
+
   # Mapping of strings to parser tokens.
 
   PUNCTUATION = {
@@ -2056,12 +2066,7 @@ class Parser::Lexer
           | '@@' %{ tm = p - 2; diag_msg = :cvar_name }
           ) [0-9]*
       => {
-        if @version >= 27
-          diagnostic :error, diag_msg, { name: tok(tm, @te) }, range(tm, @te)
-        else
-          emit(:tCOLON, tok(@ts, @ts + 1), @ts, @ts + 1)
-          p = @ts
-        end
+        emit_colon_with_digits(p, tm, diag_msg)
 
         fnext expr_end; fbreak;
       };

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -536,6 +536,15 @@ class Parser::Lexer
     end
   end
 
+  def extend_interp_digit_var
+    if @version >= 27
+      literal.extend_string(tok, @ts, @te)
+    else
+      message = tok.start_with?('#@@') ? :cvar_name : :ivar_name
+      diagnostic :error, message, { :name => tok(@ts + 1, @te) }, range(@ts + 1, @te)
+    end
+  end
+
   # Mapping of strings to parser tokens.
 
   PUNCTUATION = {
@@ -1097,12 +1106,7 @@ class Parser::Lexer
   interp_digit_var = '#' ('@' | '@@') digit c_alpha*;
 
   action extend_interp_digit_var {
-    if @version >= 27
-      literal.extend_string(tok, @ts, @te)
-    else
-      message = tok.start_with?('#@@') ? :cvar_name : :ivar_name
-      diagnostic :error, message, { :name => tok(@ts + 1, @te) }, range(@ts + 1, @te)
-    end
+    extend_interp_digit_var
   }
 
   # Interpolations with code blocks must match nested curly braces, as

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -747,6 +747,18 @@ class Parser::Lexer
     end
   end
 
+  def e_rbrace_rparen_rbrack
+    emit_table(PUNCTUATION)
+
+    if @version < 24
+      @cond.lexpop
+      @cmdarg.lexpop
+    else
+      @cond.pop
+      @cmdarg.pop
+    end
+  end
+
   # Mapping of strings to parser tokens.
 
   PUNCTUATION = {
@@ -2575,15 +2587,7 @@ class Parser::Lexer
 
       e_rbrace | e_rparen | e_rbrack
       => {
-        emit_table(PUNCTUATION)
-
-        if @version < 24
-          @cond.lexpop
-          @cmdarg.lexpop
-        else
-          @cond.pop
-          @cmdarg.pop
-        end
+        e_rbrace_rparen_rbrack
 
         if tok == '}'.freeze || tok == ']'.freeze
           if @version >= 25

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -695,6 +695,15 @@ class Parser::Lexer
     end
   end
 
+  def extend_interp_var(current_literal)
+    current_literal.flush_string
+    current_literal.extend_content
+
+    emit(:tSTRING_DVAR, nil, @ts, @ts + 1)
+
+    p = @ts
+  end
+
   # Mapping of strings to parser tokens.
 
   PUNCTUATION = {
@@ -1158,12 +1167,7 @@ class Parser::Lexer
 
   action extend_interp_var {
     current_literal = literal
-    current_literal.flush_string
-    current_literal.extend_content
-
-    emit(:tSTRING_DVAR, nil, @ts, @ts + 1)
-
-    p = @ts
+    p = extend_interp_var(current_literal)
     fcall expr_variable;
   }
 

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -737,7 +737,7 @@ class Parser::Lexer
     end
   end
 
-  def global_var
+  def emit_global_var
     if tok =~ /^\$([1-9][0-9]*)$/
       emit(:tNTH_REF, tok(@ts + 1).to_i)
     elsif tok =~ /^\$([&`'+])$/
@@ -747,7 +747,7 @@ class Parser::Lexer
     end
   end
 
-  def e_rbrace_rparen_rbrack
+  def emit_rbrace_rparen_rbrack
     emit_table(PUNCTUATION)
 
     if @version < 24
@@ -1527,7 +1527,7 @@ class Parser::Lexer
   expr_variable := |*
       global_var
       => {
-        global_var
+        emit_global_var
 
         fnext *stack_pop; fbreak;
       };
@@ -2598,7 +2598,7 @@ class Parser::Lexer
 
       e_rbrace | e_rparen | e_rbrack
       => {
-        e_rbrace_rparen_rbrack
+        emit_rbrace_rparen_rbrack
 
         if tok == '}'.freeze || tok == ']'.freeze
           if @version >= 25

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -774,6 +774,12 @@ class Parser::Lexer
     emit(:tLSHFT, '<<'.freeze,    @te - 2, @te)
   end
 
+  def check_invalid_escapes(p)
+    if emit_invalid_escapes?
+      diagnostic :fatal, :invalid_unicode_escape, nil, range(@escape_s - 1, p)
+    end
+  end
+
   # Mapping of strings to parser tokens.
 
   PUNCTUATION = {
@@ -1065,17 +1071,13 @@ class Parser::Lexer
       # \u123
     | 'u' xdigit{0,3}
       % {
-        if emit_invalid_escapes?
-          diagnostic :fatal, :invalid_unicode_escape, nil, range(@escape_s - 1, p)
-        end
+        check_invalid_escapes(p)
       }
 
       # u{not hex} or u{}
     | 'u{' ( c_any - xdigit - [ \t}] )* '}'
       % {
-        if emit_invalid_escapes?
-          diagnostic :fatal, :invalid_unicode_escape, nil, range(@escape_s - 1, p)
-        end
+        check_invalid_escapes(p)
       }
 
       # \u{  \t  123  \t 456   \t\t }

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -726,6 +726,17 @@ class Parser::Lexer
     end
   end
 
+  def check_ambiguous_slash(tm)
+    if tok(tm, tm + 1) == '/'.freeze
+      # Ambiguous regexp literal.
+      if @version < 30
+        diagnostic :warning, :ambiguous_literal, nil, range(tm, tm + 1)
+      else
+        diagnostic :warning, :ambiguous_regexp, nil, range(tm, tm + 1)
+      end
+    end
+  end
+
   # Mapping of strings to parser tokens.
 
   PUNCTUATION = {
@@ -1705,14 +1716,7 @@ class Parser::Lexer
       | '<<'
       )
       => {
-        if tok(tm, tm + 1) == '/'.freeze
-          # Ambiguous regexp literal.
-          if @version < 30
-            diagnostic :warning, :ambiguous_literal, nil, range(tm, tm + 1)
-          else
-            diagnostic :warning, :ambiguous_regexp, nil, range(tm, tm + 1)
-          end
-        end
+        check_ambiguous_slash(tm)
 
         p = tm - 1
         fgoto expr_beg;

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -594,6 +594,18 @@ class Parser::Lexer
     end
   end
 
+  def extend_string_slice_end(lookahead)
+    # tLABEL_END is only possible in non-cond context on >= 2.2
+    if @version >= 22 && !@cond.active?
+      lookahead = @source_buffer.slice(@te, 2)
+    end
+    lookahead
+  end
+
+  def extend_string_for_token_range(current_literal, string)
+    current_literal.extend_string(string, @ts, @te)
+  end
+
   # Mapping of strings to parser tokens.
 
   PUNCTUATION = {
@@ -1035,10 +1047,7 @@ class Parser::Lexer
   action extend_string {
     string = tok
 
-    # tLABEL_END is only possible in non-cond context on >= 2.2
-    if @version >= 22 && !@cond.active?
-      lookahead = @source_buffer.slice(@te, 2)
-    end
+    lookahead = extend_string_slice_end(lookahead)
 
     current_literal = literal
     if !current_literal.heredoc? &&
@@ -1052,7 +1061,7 @@ class Parser::Lexer
       end
       fbreak;
     else
-      current_literal.extend_string(string, @ts, @te)
+      extend_string_for_token_range(current_literal, string)
     end
   }
 

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -382,6 +382,10 @@ class Parser::Lexer
     nil
   end
 
+  def emit_comment_from_range(p, pe)
+    emit_comment(@sharp_s, p == pe ? p - 2 : p)
+  end
+
   def diagnostic(type, reason, arguments=nil, location=range, highlights=[])
     @diagnostics.process(
         Parser::Diagnostic.new(type, reason, arguments, location, highlights))
@@ -1286,7 +1290,7 @@ class Parser::Lexer
       '#'     %{ @sharp_s = p - 1 }
       # The (p == pe) condition compensates for added "\0" and
       # the way Ragel handles EOF.
-      c_line* %{ emit_comment(@sharp_s, p == pe ? p - 2 : p) }
+      c_line* %{ emit_comment_from_range(p, pe) }
     ;
 
   w_space_comment =

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -677,6 +677,16 @@ class Parser::Lexer
     end
   end
 
+  def e_heredoc_nl(p)
+    # After every heredoc was parsed, @herebody_s contains the
+    # position of next token after all heredocs.
+    if @herebody_s
+      p = @herebody_s
+      @herebody_s = nil
+    end
+    p
+  end
+
   # Mapping of strings to parser tokens.
 
   PUNCTUATION = {
@@ -1063,12 +1073,7 @@ class Parser::Lexer
   # containing another heredocs) is closed, the previous value is restored.
 
   e_heredoc_nl = c_nl % {
-    # After every heredoc was parsed, @herebody_s contains the
-    # position of next token after all heredocs.
-    if @herebody_s
-      p = @herebody_s
-      @herebody_s = nil
-    end
+    p = e_heredoc_nl(p)
   };
 
   action extend_string {

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -527,6 +527,15 @@ class Parser::Lexer
     @command_start = true
   end
 
+  def e_lbrace
+    @cond.push(false); @cmdarg.push(false)
+
+    current_literal = literal
+    if current_literal
+      current_literal.start_interp_brace
+    end
+  end
+
   # Mapping of strings to parser tokens.
 
   PUNCTUATION = {
@@ -1111,12 +1120,7 @@ class Parser::Lexer
   interp_code = '#{';
 
   e_lbrace = '{' % {
-    @cond.push(false); @cmdarg.push(false)
-
-    current_literal = literal
-    if current_literal
-      current_literal.start_interp_brace
-    end
+    e_lbrace
   };
 
   e_rbrace = '}' % {

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -737,6 +737,16 @@ class Parser::Lexer
     end
   end
 
+  def global_var
+    if tok =~ /^\$([1-9][0-9]*)$/
+      emit(:tNTH_REF, tok(@ts + 1).to_i)
+    elsif tok =~ /^\$([&`'+])$/
+      emit(:tBACK_REF)
+    else
+      emit(:tGVAR)
+    end
+  end
+
   # Mapping of strings to parser tokens.
 
   PUNCTUATION = {
@@ -1488,13 +1498,7 @@ class Parser::Lexer
   expr_variable := |*
       global_var
       => {
-        if    tok =~ /^\$([1-9][0-9]*)$/
-          emit(:tNTH_REF, tok(@ts + 1).to_i)
-        elsif tok =~ /^\$([&`'+])$/
-          emit(:tBACK_REF)
-        else
-          emit(:tGVAR)
-        end
+        global_var
 
         fnext *stack_pop; fbreak;
       };

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -512,6 +512,21 @@ class Parser::Lexer
     end
   end
 
+  def extend_interp_code(current_literal)
+    current_literal.flush_string
+    current_literal.extend_content
+
+    emit(:tSTRING_DBEG, '#{'.freeze)
+
+    if current_literal.heredoc?
+      current_literal.saved_herebody_s = @herebody_s
+      @herebody_s = nil
+    end
+
+    current_literal.start_interp_brace
+    @command_start = true
+  end
+
   # Mapping of strings to parser tokens.
 
   PUNCTUATION = {
@@ -1132,18 +1147,7 @@ class Parser::Lexer
 
   action extend_interp_code {
     current_literal = literal
-    current_literal.flush_string
-    current_literal.extend_content
-
-    emit(:tSTRING_DBEG, '#{'.freeze)
-
-    if current_literal.heredoc?
-      current_literal.saved_herebody_s = @herebody_s
-      @herebody_s = nil
-    end
-
-    current_literal.start_interp_brace
-    @command_start = true
+    extend_interp_code(current_literal)
     fnext expr_value;
     fbreak;
   }

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -746,6 +746,11 @@ class Parser::Lexer
     'BEGIN'  => :klBEGIN,      'END'      => :klEND,
   }
 
+  ESCAPE_WHITESPACE = {
+    " "  => '\s', "\r" => '\r', "\n" => '\n', "\t" => '\t',
+    "\v" => '\v', "\f" => '\f'
+  }
+
   %w(class module def undef begin end then elsif else ensure case when
      for break next redo retry in do return yield super self nil true
      false and or not alias __FILE__ __LINE__ __ENCODING__).each do |keyword|
@@ -2042,8 +2047,7 @@ class Parser::Lexer
 
       '?' c_space_nl
       => {
-        escape = { " "  => '\s', "\r" => '\r', "\n" => '\n', "\t" => '\t',
-                   "\v" => '\v', "\f" => '\f' }[@source_buffer.slice(@ts + 1, 1)]
+        escape = ESCAPE_WHITESPACE[@source_buffer.slice(@ts + 1, 1)]
         diagnostic :warning, :invalid_escape_use, { :escape => escape }, range
 
         p = @ts - 1

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -769,6 +769,11 @@ class Parser::Lexer
     p
   end
 
+  def emit_singleton_class
+    emit(:kCLASS, 'class'.freeze, @ts, @ts + 5)
+    emit(:tLSHFT, '<<'.freeze,    @te - 2, @te)
+  end
+
   # Mapping of strings to parser tokens.
 
   PUNCTUATION = {
@@ -2401,8 +2406,7 @@ class Parser::Lexer
            fnext expr_fname; fbreak; };
 
       'class' w_any* '<<'
-      => { emit(:kCLASS, 'class'.freeze, @ts, @ts + 5)
-           emit(:tLSHFT, '<<'.freeze,    @te - 2, @te)
+      => { emit_singleton_class
            fnext expr_value; fbreak; };
 
       # a if b:c: Syntax error.


### PR DESCRIPTION
See #871 for longer discussion about the size of the `advance` method and the problems it causes for JIT-enabled runtimes.

This PR is a start at "outlining" (as opposed to inlining) repetitive code blocks from the `advance` method by moving them into utility methods. Each commit details the change made plus the reduction in the F1 `advance` instruction count on JRuby 9.4.

My process for outlining, for anyone that wishes to reproduce it:

* Use the [flay](https://github.com/seattlerb/flay) gem to analyze the code, looking for duplicate sections of code.
* Example the findings, ignoring tiny items (simple ivar assignments for example) and blocks of code that have state transitions or multiple "out" variables.
* Outline as much of the remaining duplicate code blocks as possible.

At the time of this PR creation, it reduces the F1 `advance` size from 19235 to 15573. It may improve performance on JRuby slightly, but the method is still too large to fully JIT.

This PR also reduces the size of the F0 `advance` method from 11691 to 10235—still far too large to JIT but a good reduction.