### PR TITLE
Move blocks outside Lexer#advance

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -714,7 +714,7 @@ class Parser::Lexer
 
     emit(:tSTRING_DVAR, nil, @ts, @ts + 1)
 
-    p = @ts
+    @ts
   end
 
   def encode_escaped_char(p)


### PR DESCRIPTION
* This gives big compilation size and time benefit, because the local variables of Lexer#advance are no longer captured by those blocks (even if unused due to Ruby semantics and `Proc#binding`).
* See https://github.com/whitequark/parser/issues/871#issuecomment-1362218586