### PR TITLE
Add full-release Ruby 3.2.0 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7.7", "3.0.5", "3.1.3", "jruby-9.2"]
+        ruby: ["2.7.7", "3.0.5", "3.1.3", "3.2.0", "jruby-9.2"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"
@@ -25,6 +25,8 @@ jobs:
           - ruby: "truffleruby"
             test_command: "bundle exec rake test || true"
           - ruby: "3.1.3"
+            test_command: "./ci/run_rubocop_specs || true"
+          - ruby: "3.2.0"
             test_command: "./ci/run_rubocop_specs || true"
     steps:
     - uses: actions/checkout@v3

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -102,7 +102,7 @@ module Parser
     CurrentRuby = Ruby31
 
   when /^3\.2\./
-    current_version = '3.2.0-dev'
+    current_version = '3.2.0'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby32', current_version
     end
@@ -112,8 +112,8 @@ module Parser
 
   else # :nocov:
     # Keep this in sync with released Ruby.
-    warn_syntax_deviation 'parser/ruby31', '3.1.x'
-    require 'parser/ruby31'
-    CurrentRuby = Ruby31
+    warn_syntax_deviation 'parser/ruby32', '3.2.x'
+    require 'parser/ruby32'
+    CurrentRuby = Ruby32
   end
 end


### PR DESCRIPTION
:wave: Trying to add full-release (non-dev) Ruby 3.2.0 support. Based the implementation on https://github.com/whitequark/parser/commit/2f3ce7c57fa72996c28648a5ba8af5f787987fad.

https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/

Inspired by seeing the following message while running `rubocop` with Ruby 3.2.0 targeted.

```
❯ bundle exec rubocop
warning: parser/current is loading parser/ruby32, which recognizes 3.2.0-dev-compliant syntax, but you are running 3.2.0.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1086 files
..............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

1086 files inspected, no offenses detected
```