### PR TITLE
* Bump maintenance branches to 3.2.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7.7", "3.0.5", "3.1.3", "3.2.0", "jruby-9.2"]
+        ruby: ["2.7.7", "3.0.5", "3.1.3", "3.2.1", "jruby-9.2"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"
@@ -26,7 +26,7 @@ jobs:
             test_command: "bundle exec rake test || true"
           - ruby: "3.1.3"
             test_command: "./ci/run_rubocop_specs || true"
-          - ruby: "3.2.0"
+          - ruby: "3.2.1"
             test_command: "./ci/run_rubocop_specs || true"
     steps:
     - uses: actions/checkout@v3

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -102,7 +102,7 @@ module Parser
     CurrentRuby = Ruby31
 
   when /^3\.2\./
-    current_version = '3.2.0'
+    current_version = '3.2.1'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby32', current_version
     end


### PR DESCRIPTION
Ruby 3.2.1 has been released:
https://www.ruby-lang.org/en/news/2023/02/08/ruby-3-2-1-released/

Bump 3.2 branch from 3.2.0 to 3.2.1:
https://github.com/ruby/ruby/compare/v3_2_0...v3_2_1

There seems to be no change to the syntax.