### PR TITLE
Fix broken link to ast gem documentation

### DIFF
--- a/lib/parser/ast/node.rb
+++ b/lib/parser/ast/node.rb
@@ -5,8 +5,8 @@ module Parser
 
     ##
     # {Parser::AST::Node} contains information about a single AST node and its
-    # child nodes. It extends the basic [AST::Node](http://rdoc.info/gems/ast/AST/Node)
-    # class provided by gem [ast](http://rdoc.info/gems/ast).
+    # child nodes. It extends the basic [AST::Node](https://www.rubydoc.info/gems/ast/AST/Node)
+    # class provided by gem [ast](https://www.rubydoc.info/gems/ast).
     #
     # @api public
     #


### PR DESCRIPTION
This PR is fix broken link to ast gem documentation.
`ERR_TOO_MANY_REDIRECTS` is raised when accessing [link](http://rdoc.info/gems/ast).