### PR TITLE
Fixed default builder invalid subexp warning

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -2246,7 +2246,7 @@ module Parser
         source
       end
 
-      Regexp.new(source, (Regexp::EXTENDED if options.children.include?(:x)))
+      Regexp.new(source.to_s, (Regexp::EXTENDED if options.children.include?(:x)))
     end
 
     def static_regexp_node(node)


### PR DESCRIPTION
## Overview

Hello. :wave: I was getting Ruby warnings with the latest version of this gem when running RuboCop so this will help fix the issue.

## Screenshots/Screencasts

Was seeing the following when running RuboCop:

![2023-03-03_11-35-40-iTerm2](https://user-images.githubusercontent.com/50245/222800378-c62956bb-34e1-49dc-80e1-c249c5d821ee.png)

## Details

Necessary to resolve the following Ruby warnings from showing up in the console:

    parser-3.2.1.0/lib/parser/builders/default.rb:2249: warning: invalid subexp call

If the `source` is properly converted to a string then these warnings go away and keeps your console and logs clean.
