### PR TITLE
- builders/default: allow forwarded_kwrestarg with additional kwargs

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -540,8 +540,13 @@ module Parser
     def associate(begin_t, pairs, end_t)
       0.upto(pairs.length - 1) do |i|
         (i + 1).upto(pairs.length - 1) do |j|
-          key1, = *pairs[i]
-          key2, = *pairs[j]
+          pair_i = pairs[i]
+          pair_j = pairs[j]
+
+          next if pair_i.type != :pair || pair_j.type != :pair
+
+          key1, = *pair_i
+          key2, = *pair_j
 
           do_warn = false
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -10958,6 +10958,32 @@ class TestParser < Minitest::Test
       SINCE_3_2)
   end
 
+  def test_forwarded_kwrestarg_with_additional_kwarg
+    assert_parses(
+      s(:def, :foo,
+        s(:args,
+          s(:kwrestarg)),
+        s(:send, nil, :bar,
+          s(:kwargs,
+            s(:forwarded_kwrestarg),
+            s(:pair,
+              s(:sym, :from_foo),
+              s(:true))))),
+      %q{def foo(**); bar(**, from_foo: true); end},
+      %q{                 ~~ expression (send.kwargs.forwarded_kwrestarg)},
+      SINCE_3_2)
+
+    refute_diagnoses(
+      %q{def foo(**); bar(**, from_foo: true); end},
+      SINCE_3_2)
+
+    assert_diagnoses(
+      [:warning, :duplicate_hash_key],
+      %q{def foo(**); bar(foo: 1, **, foo: 2); end},
+      %q{                             ^^^ location},
+      SINCE_3_2)
+  end
+
   def test_forwarded_argument_with_kwrestarg
     assert_parses(
       s(:def, :foo,


### PR DESCRIPTION
Fixes #911