### PR TITLE
* add tests for kwopt+kwrest arguments and forwarded_kwrestarg.

### DIFF
--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -11133,4 +11133,19 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_3_1)
   end
+
+  def test_kwoptarg_with_kwrestarg_and_forwarded_args
+    assert_parses(
+      s(:def, :f,
+        s(:args,
+          s(:kwoptarg, :a,
+            s(:nil)),
+          s(:kwrestarg)),
+        s(:send, nil, :b,
+          s(:kwargs,
+            s(:forwarded_kwrestarg)))),
+      %Q{def f(a: nil, **); b(**) end},
+      %q{},
+      SINCE_3_2)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@ddd62fa.

Closes https://github.com/whitequark/parser/issues/885.

No changes to grammar, backporting test just to track it in the future.