### PR TITLE
+ ruby{32,33}.y: declare anonymous {rest,kwrest}args on forwarded argument.

### DIFF
--- a/lib/parser/ruby32.y
+++ b/lib/parser/ruby32.y
@@ -2762,6 +2762,11 @@ f_opt_paren_args: f_paren_args
                 | args_forward
                     {
                       @static_env.declare_forward_args
+
+                      @static_env.declare_anonymous_restarg
+                      @static_env.declare_anonymous_kwrestarg
+                      @static_env.declare_anonymous_blockarg
+
                       result = [ @builder.forward_arg(val[0]) ]
                     }
 

--- a/lib/parser/ruby33.y
+++ b/lib/parser/ruby33.y
@@ -2762,6 +2762,11 @@ f_opt_paren_args: f_paren_args
                 | args_forward
                     {
                       @static_env.declare_forward_args
+
+                      @static_env.declare_anonymous_restarg
+                      @static_env.declare_anonymous_kwrestarg
+                      @static_env.declare_anonymous_blockarg
+
                       result = [ @builder.forward_arg(val[0]) ]
                     }
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -11148,4 +11148,23 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_3_2)
   end
+
+  def test_anonymous_args_with_forwarded_args
+    assert_parses(
+      s(:def, :deconstruct,
+        s(:args,
+          s(:forward_arg)),
+        s(:array,
+          s(:send, nil, :args,
+            s(:forwarded_restarg)),
+          s(:send, nil, :kw,
+            s(:kwargs,
+              s(:forwarded_kwrestarg))),
+          s(:csend,
+            s(:send, nil, :block,
+              s(:block_pass, nil)), :call))),
+      %Q{def deconstruct(...); [args(*), kw(**), block(&)&.call] end},
+      %q{},
+      SINCE_3_2)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@4fc668a.

This is the only change that I forgot to backport for 3.2 grammar.

Closes https://github.com/whitequark/parser/issues/888.