### PR TITLE
* backport tests for mixed usage of anonymous kwarg/kwrestarg and forwarded-arguments

### DIFF
--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -11148,4 +11148,36 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_3_2)
   end
+
+  def test_argument_forwarding_with_anon_rest_kwrest_and_block
+    assert_diagnoses(
+      [:error, :unexpected_token, { token: 'tBDOT3' }],
+      %q{def f(*, **, &); g(...); end},
+      %q{},
+      SINCE_3_2)
+
+    assert_diagnoses(
+      [:error, :no_anonymous_restarg],
+      %q{def f(...); g(*); end},
+      %q{},
+      SINCE_3_2)
+
+    assert_diagnoses(
+      [:error, :no_anonymous_restarg],
+      %q{def f(...); g(0, *); end},
+      %q{},
+      SINCE_3_2)
+
+    assert_diagnoses(
+      [:error, :no_anonymous_kwrestarg],
+      %q{def f(...); g(**); end},
+      %q{},
+      SINCE_3_2)
+
+    assert_diagnoses(
+      [:error, :no_anonymous_kwrestarg],
+      %q{def f(...); g(x: 1, **); end},
+      %q{},
+      SINCE_3_2)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@2581de1.

Closes https://github.com/whitequark/parser/issues/895 and https://github.com/whitequark/parser/issues/888.

There are no changes to grammar, it's a backport of tests.