### PR TITLE
* Bump maintenance branches to 3.2.2, 3.1.4, 3.0.6, and 2.7.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7.7", "3.0.5", "3.1.3", "3.2.1", "jruby-9.2"]
+        ruby: ["2.7.8", "3.0.6", "3.1.4", "3.2.2", "jruby-9.2"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"
             test_command: "bundle exec rake test || true"
           - ruby: "truffleruby"
             test_command: "bundle exec rake test || true"
-          - ruby: "3.1.3"
+          - ruby: "3.1.4"
             test_command: "./ci/run_rubocop_specs || true"
-          - ruby: "3.2.1"
+          - ruby: "3.2.2"
             test_command: "./ci/run_rubocop_specs || true"
     steps:
     - uses: actions/checkout@v3

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -75,7 +75,7 @@ module Parser
     CurrentRuby = Ruby26
 
   when /^2\.7\./
-    current_version = '2.7.7'
+    current_version = '2.7.8'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby27', current_version
     end
@@ -84,7 +84,7 @@ module Parser
     CurrentRuby = Ruby27
 
   when /^3\.0\./
-    current_version = '3.0.5'
+    current_version = '3.0.6'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby30', current_version
     end
@@ -93,7 +93,7 @@ module Parser
     CurrentRuby = Ruby30
 
   when /^3\.1\./
-    current_version = '3.1.3'
+    current_version = '3.1.4'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby31', current_version
     end
@@ -102,7 +102,7 @@ module Parser
     CurrentRuby = Ruby31
 
   when /^3\.2\./
-    current_version = '3.2.1'
+    current_version = '3.2.2'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby32', current_version
     end


### PR DESCRIPTION
These Rubies have been released.

- https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-2-2-released/
- https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-1-4-released/
- https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-0-6-released/
- https://www.ruby-lang.org/en/news/2023/03/30/ruby-2-7-8-released/

## Ruby 3.2 branch

Bump 3.2 branch from 3.2.1 to 3.2.2

https://github.com/ruby/ruby/compare/v3_2_1...v3_2_2

There seems to be no change to syntax.

## Ruby 3.1 branch

Bump 3.1 branch from 3.1.3 to 3.1.4

https://github.com/ruby/ruby/compare/v3_1_3...v3_1_4

There seems to be no change to syntax.

## Ruby 3.0 branch

Bump 3.0 branch from 3.0.5 to 3.0.6

https://github.com/ruby/ruby/compare/v3_0_5...v3_0_6

There seems to be no change to syntax.

## Ruby 2.7 branch

Bump 2.7 branch from 2.7.7 to 2.7.8

https://github.com/ruby/ruby/compare/v2_7_7...v2_7_8

There seems to be no change to syntax.