### PR TITLE
* Add Racc to runtime dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gemspec
 # Workaround for bug in Bundler on JRuby
 # See https://github.com/bundler/bundler/issues/4157
 gem 'ast', '>= 1.1', '< 3.0'
+gem 'racc', '1.7.0'

--- a/parser.gemspec
+++ b/parser.gemspec
@@ -27,10 +27,10 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_dependency             'ast',       '~> 2.4.1'
+  spec.add_dependency             'racc'
 
   spec.add_development_dependency 'bundler',   '>= 1.15', '< 3.0.0'
   spec.add_development_dependency 'rake',      '~> 13.0.1'
-  spec.add_development_dependency 'racc',      '= 1.7.0'
   spec.add_development_dependency 'cliver',    '~> 0.3.2'
 
   spec.add_development_dependency 'yard'


### PR DESCRIPTION
Follow up https://github.com/ruby/ruby/pull/7877.

Ruby 3.3.0dev is set to promote Racc to a bundled gem. Therefore, this PR adds Racc to runtime dependencies to prevents the following error in RuboCop:

```console
bundle exec rake internal_investigation

rake aborted!
LoadError: cannot load such file -- racc/parser
<internal:/usr/local/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:37:in `require'
<internal:/usr/local/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:37:in `require'
/usr/local/bundle/gems/parser-3.2.2.1/lib/parser.rb:12:in `<top (required)>'
<internal:/usr/local/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:37:in `require'
<internal:/usr/local/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:37:in `require'
/usr/local/bundle/gems/rubocop-ast-1.29.0/lib/rubocop/ast.rb:3:in `<top (required)>'
/usr/local/bundle/gems/rubocop-ast-1.29.0/lib/rubocop-ast.rb:3:in `require_relative'
/usr/local/bundle/gems/rubocop-ast-1.29.0/lib/rubocop-ast.rb:3:in `<top (required)>'
```

https://app.circleci.com/pipelines/github/rubocop/rubocop/9387/workflows/c308ef87-1373-4c0a-b90d-a22ea57860e3/jobs/279345

Since the Parser gem supports Ruby 2.0.0 and above, So, Racc runtime version is not specified to accept older Racc versions. Development version of Racc 1.7.0 has been added to the Gemfile.