### PR TITLE
* bump Racc to 1.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gemspec
 # Workaround for bug in Bundler on JRuby
 # See https://github.com/bundler/bundler/issues/4157
 gem 'ast', '>= 1.1', '< 3.0'
-gem 'racc', '1.7.0'
+gem 'racc', '1.7.1'


### PR DESCRIPTION
Racc 1.7.1 has been released:
https://github.com/ruby/racc/releases/tag/v1.7.1