### PR TITLE
Fix an error for flip-flop with beginless or endless ranges

### DIFF
--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -4740,6 +4740,22 @@ class TestParser < Minitest::Test
         |      ~~ operator (iflipflop)})
 
     assert_parses(
+      s(:if, s(:iflipflop, s(:lvar, :foo), s(:nil)),
+        nil, nil),
+      %q{if foo..nil; end},
+      %q{   ~~~~~~~~ expression (iflipflop)
+        |      ~~ operator (iflipflop)},
+      %w(1.8))
+
+    assert_parses(
+      s(:if, s(:iflipflop, s(:nil), s(:lvar, :bar)),
+        nil, nil),
+      %q{if nil..bar; end},
+      %q{   ~~~~~~~~ expression (iflipflop)
+        |      ~~ operator (iflipflop)},
+      %w(1.8))
+
+    assert_parses(
       s(:not, s(:begin, s(:iflipflop, s(:lvar, :foo), s(:lvar, :bar)))),
       %q{!(foo..bar)},
       %q{  ~~~~~~~~ expression (begin.iflipflop)
@@ -4754,6 +4770,26 @@ class TestParser < Minitest::Test
       SINCE_1_9)
   end
 
+  def test_cond_iflipflop_with_endless_range
+    assert_parses(
+      s(:if, s(:iflipflop, s(:lvar, :foo), nil),
+        nil, nil),
+      %q{if foo..; end},
+      %q{   ~~~~~ expression (iflipflop)
+        |      ~~ operator (iflipflop)},
+      SINCE_2_6)
+  end
+
+  def test_cond_iflipflop_with_beginless_range
+    assert_parses(
+      s(:if, s(:iflipflop, nil, s(:lvar, :bar)),
+        nil, nil),
+      %q{if ..bar; end},
+      %q{   ~~~~~ expression (iflipflop)
+        |   ~~ operator (iflipflop)},
+      SINCE_2_7)
+  end
+
   def test_cond_eflipflop
     assert_parses(
       s(:if, s(:eflipflop, s(:lvar, :foo), s(:lvar, :bar)),
@@ -4761,6 +4797,22 @@ class TestParser < Minitest::Test
       %q{if foo...bar; end},
       %q{   ~~~~~~~~~ expression (eflipflop)
         |      ~~~ operator (eflipflop)})
+
+    assert_parses(
+      s(:if, s(:eflipflop, s(:lvar, :foo), s(:nil)),
+        nil, nil),
+      %q{if foo...nil; end},
+      %q{   ~~~~~~~~~ expression (eflipflop)
+        |      ~~~ operator (eflipflop)},
+      %w(1.8))
+
+    assert_parses(
+      s(:if, s(:eflipflop, s(:nil), s(:lvar, :bar)),
+        nil, nil),
+      %q{if nil...bar; end},
+      %q{   ~~~~~~~~~ expression (eflipflop)
+        |      ~~~ operator (eflipflop)},
+      %w(1.8))
 
     assert_parses(
       s(:not, s(:begin, s(:eflipflop, s(:lvar, :foo), s(:lvar, :bar)))),
@@ -4775,6 +4827,26 @@ class TestParser < Minitest::Test
       %q{  ~~~~~~~~~ expression (begin.eflipflop)
         |     ~~~ operator (begin.eflipflop)},
       SINCE_1_9)
+  end
+
+  def test_cond_eflipflop_with_endless_range
+    assert_parses(
+      s(:if, s(:eflipflop, s(:lvar, :foo), nil),
+        nil, nil),
+      %q{if foo...; end},
+      %q{   ~~~~~~ expression (eflipflop)
+        |      ~~~ operator (eflipflop)},
+      SINCE_2_6)
+  end
+
+  def test_cond_eflipflop_with_beginless_range
+    assert_parses(
+      s(:if, s(:eflipflop, nil, s(:lvar, :bar)),
+        nil, nil),
+      %q{if ...bar; end},
+      %q{   ~~~~~~ expression (eflipflop)
+        |   ~~~ operator (eflipflop)},
+      SINCE_2_7)
   end
 
   def test_cond_match_current_line


### PR DESCRIPTION
This PR resolves https://github.com/rubocop/rubocop/issues/12198.

```console
$ ruby-parse -e 'if foo..; end'
Failed on: (fragment:0)
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/parser-3.2.2.3/lib/parser/builders/default.rb:1676:
in `check_condition': undefined method `type' for nil (NoMethodError)

      case cond.type
               ^^^^^
        from /Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/parser-3.2.2.3/lib/parser/builders/default.rb:1707:
        in `check_condition'
        from /Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/parser-3.2.2.3/lib/parser/builders/default.rb:1275:
        in `condition'
```

I'm not sure if there's any significance to using the flip-flop syntax with `nil`, but by using beginless or endless ranges and explicitly specifying `nil`, the following current behaviors are made compatible:

## `iflipflop` with explicitly `nil`

```console
$ ruby-parse -e 'if foo..nil ; end'
(if
  (iflipflop
    (send nil :foo)
    (nil)) nil nil)
```

```console
$ ruby-parse -e 'if nil..bar ; end'
(if
  (iflipflop
    (nil)
    (send nil :bar)) nil nil)
```

## `eflipflop` with explicitly `nil`

```console
$ ruby-parse -e 'if foo...nil ; end'
(if
  (eflipflop
    (send nil :foo)
    (nil)) nil nil)
```

```console
$ ruby-parse -e 'if nil...bar ; end'
(if
  (eflipflop
    (nil)
    (send nil :bar)) nil nil)
```

The difference in the flip-flop with beginless or endless ranges is that `s(:nil)` is replaced by `nil` in the flip-flop ASTs.

This is reflected in the tests.