### PR TITLE
Replace whitequark blog links with archive URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ with Parser:
 
 [clang-like]: http://clang.llvm.org/diagnostics.html
 [ast]: https://rubygems.org/gems/ast
-[insane-lexer]: http://whitequark.org/blog/2013/04/01/ruby-hacking-guide-ch-11-finite-state-lexer/
-[rewriting]: http://whitequark.org/blog/2013/04/26/lets-play-with-ruby-code/
+[insane-lexer]: http://web.archive.org/web/20210621201915/http://whitequark.org/blog/2013/04/01/ruby-hacking-guide-ch-11-finite-state-lexer/
+[rewriting]: http://web.archive.org/web/20220123050223/http://whitequark.org/blog/2013/04/26/lets-play-with-ruby-code/
 
 ## Documentation
 


### PR DESCRIPTION
Unfortunately, whitequark's amazing blog has been down since early 2022 as far as I can tell. These blog posts are great resources still for understanding parts of this gem, so I've replaced the broken blog links in the README with the most recent working Internet Archive links.