### PR TITLE
* Bump Racc to 1.7.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gemspec
 # Workaround for bug in Bundler on JRuby
 # See https://github.com/bundler/bundler/issues/4157
 gem 'ast', '>= 1.1', '< 3.0'
-gem 'racc', '1.7.1'
+gem 'racc', '1.7.3'


### PR DESCRIPTION
Racc 1.7.3 has been released and this PR bumps Racc to 1.7.3.
https://github.com/ruby/racc/releases/tag/v1.7.3

`racc` is specified in the gemspec, it might be possible to remove the `racc` dependency from the Gemfile, although a specific version is still being specified, maintaining previous practices.