### PR TITLE
add tests for duplicate variable name check with p_rest

### DIFF
--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -9797,6 +9797,18 @@ class TestParser < Minitest::Test
       %q{0 => [a, a]},
       %q{         ^ location},
       SINCE_3_0)
+
+    assert_diagnoses(
+      [:error, :duplicate_variable_name, { :name => 'a' }],
+      %q{0 in [a, *a]},
+      %q{          ^ location},
+      SINCE_3_3)
+
+    assert_diagnoses(
+      [:error, :duplicate_variable_name, { :name => 'a' }],
+      %q{0 in [*a, a, b, *b]},
+      %q{          ^ location},
+      SINCE_3_3)
   end
 
   def test_pattern_matching_duplicate_hash_keys


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/921.

We already reject duplicate variable in pattern-matching like `0 => [a, *a]` and bugs are not back-ported to previous versions of parser, so this PR only includes tests.