### PR TITLE
* ruby33.y: extract string_dend

### DIFF
--- a/lib/parser/ruby33.y
+++ b/lib/parser/ruby33.y
@@ -2510,13 +2510,15 @@ regexp_contents: # nothing
                       @lexer.cmdarg.push(false)
                       @lexer.cond.push(false)
                     }
-                    compstmt tSTRING_DEND
+                    compstmt string_dend
                     {
                       @lexer.cmdarg.pop
                       @lexer.cond.pop
 
                       result = @builder.begin(val[0], val[2], val[3])
                     }
+
+     string_dend: tSTRING_DEND
 
      string_dvar: tGVAR
                     {


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/931.

Error recovery is a nice-to-have feature that doesn't have to match MRI 1-to-1, if you want to improve it without sacrificing readability/similarity with parse.y feel free to send a PR.

This PR is only about replicating derivations.