### PR TITLE
+ ruby33.y: parse qualified const with brace block as a method call

### DIFF
--- a/lib/parser/ruby33.y
+++ b/lib/parser/ruby33.y
@@ -469,6 +469,14 @@ rule
                       result      = @builder.block(method_call,
                                       begin_t, args, body, end_t)
                     }
+                | primary_value tCOLON2 tCONSTANT tLCURLY brace_body tRCURLY
+                    {
+                      method_call = @builder.call_method(val[0], val[1], val[2],
+                                        nil, [], nil)
+
+                      args, body = val[4]
+                      result = @builder.block(method_call, val[3], args, body, val[5])
+                    }
                 | kSUPER command_args
                     {
                       result = @builder.keyword_cmd(:super, val[0],

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -11308,4 +11308,18 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_3_2)
   end
+
+  def test_ruby_bug_18878
+    assert_parses(
+      s(:block,
+        s(:send,
+          s(:const, nil, :Foo), :Bar),
+        s(:args,
+          s(:procarg0,
+            s(:arg, :a))),
+        s(:int, 42)),
+      'Foo::Bar { |a| 42 }',
+      %q{},
+      SINCE_3_3)
+  end
 end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/933