### PR TITLE
+ ruby33.y: allow semicolon in parenthesis at the first argument of command call

### DIFF
--- a/lib/parser/ruby33.y
+++ b/lib/parser/ruby33.y
@@ -1207,21 +1207,13 @@ rule
 
                       result = @builder.begin_keyword(val[0], val[2], val[3])
                     }
-                | tLPAREN_ARG stmt
+                | tLPAREN_ARG compstmt
                     {
                       @lexer.state = :expr_endarg
                     }
-                    rparen
+                    tRPAREN
                     {
                       result = @builder.begin(val[0], val[1], val[3])
-                    }
-                | tLPAREN_ARG
-                    {
-                      @lexer.state = :expr_endarg
-                    }
-                    opt_nl tRPAREN
-                    {
-                      result = @builder.begin(val[0], nil, val[3])
                     }
                 | tLPAREN compstmt tRPAREN
                     {

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -11322,4 +11322,52 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_3_3)
   end
+
+  def test_ruby_bug_19281
+    assert_parses(
+      s(:send, nil, :p,
+        s(:begin,
+          s(:int, 1),
+          s(:int, 2)),
+        s(:begin,
+          s(:int, 3)),
+        s(:begin,
+          s(:int, 4))),
+      'p (1;2),(3),(4)',
+      %q{},
+      SINCE_3_3)
+
+    assert_parses(
+      s(:send, nil, :p,
+        s(:begin),
+        s(:begin),
+        s(:begin)),
+      'p (;),(),()',
+      %q{},
+      SINCE_3_3)
+
+    assert_parses(
+      s(:send,
+        s(:send, nil, :a), :b,
+        s(:begin,
+          s(:int, 1),
+          s(:int, 2)),
+        s(:begin,
+          s(:int, 3)),
+        s(:begin,
+          s(:int, 4))),
+      'a.b (1;2),(3),(4)',
+      %q{},
+      SINCE_3_3)
+
+    assert_parses(
+      s(:send,
+        s(:send, nil, :a), :b,
+        s(:begin),
+        s(:begin),
+        s(:begin)),
+      'a.b (;),(),()',
+      %q{},
+      SINCE_3_3)
+  end
 end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/934