### PR TITLE
+ builder.rb: reject multi-char gvar names starting with 0

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -594,7 +594,13 @@ module Parser
     end
 
     def gvar(token)
-      n(:gvar, [ value(token).to_sym ],
+      gvar_name = value(token)
+
+      if gvar_name.start_with?('$0') && gvar_name.length > 2
+        diagnostic :error, :gvar_name, { :name => gvar_name }, loc(token)
+      end
+
+      n(:gvar, [ gvar_name.to_sym ],
         variable_map(token))
     end
 

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -72,6 +72,7 @@ module Parser
     :circular_argument_reference  => 'circular argument reference %{var_name}',
     :pm_interp_in_var_name        => 'symbol literal with interpolation is not allowed',
     :lvar_name                    => "`%{name}' is not allowed as a local variable name",
+    :gvar_name                    => '%{name} is not allowed as a global variable name',
     :undefined_lvar               => "no such local variable: `%{name}'",
     :duplicate_variable_name      => 'duplicate variable name %{name}',
     :duplicate_pattern_key        => 'duplicate hash pattern key %{name}',

--- a/lib/parser/ruby33.y
+++ b/lib/parser/ruby33.y
@@ -2520,17 +2520,9 @@ regexp_contents: # nothing
 
      string_dend: tSTRING_DEND
 
-     string_dvar: tGVAR
+     string_dvar: nonlocal_var
                     {
-                      result = @builder.gvar(val[0])
-                    }
-                | tIVAR
-                    {
-                      result = @builder.ivar(val[0])
-                    }
-                | tCVAR
-                    {
-                      result = @builder.cvar(val[0])
+                      result = @builder.accessible(val[0])
                     }
                 | backref
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -11370,4 +11370,18 @@ class TestParser < Minitest::Test
       %q{},
       SINCE_3_3)
   end
+
+  def test_ungettable_gvar
+    assert_diagnoses(
+      [:error, :gvar_name, { :name => '$01234' }],
+      '$01234',
+      '^^^^^^ location',
+      ALL_VERSIONS)
+
+    assert_diagnoses(
+      [:error, :gvar_name, { :name => '$01234' }],
+      '"#$01234"',
+      '  ^^^^^^ location',
+      ALL_VERSIONS)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@bd04676.

Closes https://github.com/whitequark/parser/issues/935