### PR TITLE
+ ruby33.y: extract p_assoc and p_in rules

### DIFF
--- a/lib/parser/ruby33.y
+++ b/lib/parser/ruby33.y
@@ -332,39 +332,35 @@ rule
                     {
                       result = @builder.not_op(val[0], nil, val[1], nil)
                     }
-                | arg tASSOC
+                | arg p_assoc
                     {
                       @lexer.state = :expr_beg
                       @lexer.command_start = false
                       @pattern_variables.push
                       @pattern_hash_keys.push
-
-                      result = @context.in_kwarg
                       @context.in_kwarg = true
                     }
                   p_top_expr_body
                     {
                       @pattern_variables.pop
                       @pattern_hash_keys.pop
-                      @context.in_kwarg = val[2]
-                      result = @builder.match_pattern(val[0], val[1], val[3])
+                      assoc_t, @context.in_kwarg = val[1]
+                      result = @builder.match_pattern(val[0], assoc_t, val[3])
                     }
-                | arg kIN
+                | arg p_in
                     {
                       @lexer.state = :expr_beg
                       @lexer.command_start = false
                       @pattern_variables.push
                       @pattern_hash_keys.push
-
-                      result = @context.in_kwarg
                       @context.in_kwarg = true
                     }
                   p_top_expr_body
                     {
                       @pattern_variables.pop
                       @pattern_hash_keys.pop
-                      @context.in_kwarg = val[2]
-                      result = @builder.match_pattern_p(val[0], val[1], val[3])
+                      in_t, @context.in_kwarg = val[1]
+                      result = @builder.match_pattern_p(val[0], in_t, val[3])
                     }
                 | arg =tLBRACE_ARG
 
@@ -1918,7 +1914,17 @@ opt_block_args_tail:
                     }
                 | case_body
 
-     p_case_body: kIN
+         p_assoc: tASSOC
+                    {
+                      result = [ val[0], @context.in_kwarg ]
+                    }
+
+            p_in: kIN
+                    {
+                      result = [ val[0], @context.in_kwarg ]
+                    }
+
+     p_case_body: p_in
                     {
                       @lexer.state = :expr_beg
                       @lexer.command_start = false
@@ -1936,7 +1942,8 @@ opt_block_args_tail:
                     }
                   compstmt p_cases
                     {
-                      result = [ @builder.in_pattern(val[0], *val[2], val[3], val[5]),
+                      in_t = val[0][0]
+                      result = [ @builder.in_pattern(in_t, *val[2], val[3], val[5]),
                                  *val[6] ]
                     }
 


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@3b05238.

Closes https://github.com/whitequark/parser/issues/951.

Racc doesn't have access to a result of a `p_assoc` rule in the last mid-rule of the diff (probably because of a lookahead?) and so it can't read `$ctxt.in_kwarg`. If that's true for Lrama then it's a very nasty bug that I don't see exactly how to reproduce :(. It could be something like this:

```ruby
def foo a: case 1; in 1; then 1; end, b:
  p 42
end
```

that gets rejected (this particular snippet is accepted by MRI which is correct). It could even be a UB if generated code reads uninitialised memory and transmutes it to `ctxt` (then it becomes a heisenbug) but I hope Ruby CI runs ASAN for all of its tests.