### PR TITLE
+ ruby33.y: accept expr_value in sclass definition.

### DIFF
--- a/lib/parser/ruby33.y
+++ b/lib/parser/ruby33.y
@@ -1331,7 +1331,7 @@ rule
                       local_pop
                       @context.in_class = ctx.in_class
                     }
-                | k_class tLSHFT expr term
+                | k_class tLSHFT expr_value term
                     {
                       @context.in_def = false
                       @context.in_class = false


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@fe74674.

Closes https://github.com/whitequark/parser/issues/955.