### PR TITLE
+ builder.rb: extract named captures only from static regexes.

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -2261,6 +2261,10 @@ module Parser
 
     def static_regexp_node(node)
       if node.type == :regexp
+        if @parser.version >= 33 && node.children[0..-2].any? { |child| child.type != :str }
+          return nil
+        end
+
         parts, options = node.children[0..-2], node.children[-1]
         static_regexp(parts, options)
       end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -3788,6 +3788,25 @@ class TestParser < Minitest::Test
       %q{                ~~ selector (match_with_lvasgn)
         |~~~~~~~~~~~~~~~~~~~~~~~~ expression (match_with_lvasgn)},
       SINCE_1_9)
+
+    assert_parses(
+      s(:begin,
+        s(:match_with_lvasgn,
+          s(:regexp,
+            s(:str, "(?<a>a)"),
+            s(:regopt)),
+          s(:str, "a")),
+        s(:send,
+          s(:regexp,
+            s(:begin),
+            s(:str, "(?<b>b)"),
+            s(:regopt)), :=~,
+          s(:str, "b")),
+        s(:lvar, :a),
+        s(:send, nil, :b)),
+      %q{/(?<a>a)/ =~ 'a'; /#{}(?<b>b)/ =~ 'b'; a; b},
+      %q{},
+      SINCE_3_3)
   end
 
   def test_non_lvar_injecting_match


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@a607d62.

Closes https://github.com/whitequark/parser/issues/956.