### PR TITLE
+ builder.rb: warn `it` in a block with no ordinary params.

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -660,6 +660,13 @@ module Parser
         end
 
         unless @parser.static_env.declared?(name)
+          if @parser.version == 33 &&
+              name == :it &&
+              @parser.context.in_block &&
+              !@parser.max_numparam_stack.has_ordinary_params?
+            diagnostic :warning, :ambiguous_it_call, nil, node.loc.expression
+          end
+
           return n(:send, [ nil, name ],
             var_send_map(node))
         end

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -86,6 +86,7 @@ module Parser
     # Parser warnings
     :useless_else            => 'else without rescue is useless',
     :duplicate_hash_key      => 'key is duplicated and overwritten',
+    :ambiguous_it_call       => '`it` calls without arguments refers to the first block param',
 
     # Parser errors that are not Ruby errors
     :invalid_encoding        => 'literal contains escape sequences incompatible with UTF-8',

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -11409,4 +11409,35 @@ class TestParser < Minitest::Test
       '  ^^^^^^ location',
       ALL_VERSIONS)
   end
+
+  def test_it_warning_in_33
+    refute_diagnoses(
+      'if false; it; end',
+      ALL_VERSIONS)
+    refute_diagnoses(
+      'def foo; it; end',
+      ALL_VERSIONS)
+    assert_diagnoses(
+      [:warning, :ambiguous_it_call, {}],
+      '0.times { it }',
+      '          ^^ location',
+      ['3.3'])
+    refute_diagnoses(
+      '0.times { || it }',
+      ALL_VERSIONS)
+    refute_diagnoses(
+      '0.times { |_n| it }',
+      ALL_VERSIONS)
+    assert_diagnoses(
+      [:warning, :ambiguous_it_call, {}],
+      '0.times { it; it = 1; it }',
+      '          ^^ location',
+      ['3.3'])
+    refute_diagnoses(
+      '0.times { it = 1; it }',
+      ALL_VERSIONS)
+    refute_diagnoses(
+      'it = 1; 0.times { it }',
+      ALL_VERSIONS)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@ae76c8a.

Closes https://github.com/whitequark/parser/issues/957.