### PR TITLE
+ ruby33.y: extract arg_splat rule.

### DIFF
--- a/lib/parser/ruby33.y
+++ b/lib/parser/ruby33.y
@@ -1116,7 +1116,17 @@ rule
                     {
                       result = [ val[0] ]
                     }
-                | tSTAR arg_value
+                | arg_splat
+                | args tCOMMA arg_value
+                    {
+                      result = val[0] << val[2]
+                    }
+                | args tCOMMA arg_splat
+                    {
+                      result = val[0].concat(val[2])
+                    }
+
+       arg_splat: tSTAR arg_value
                     {
                       result = [ @builder.splat(val[0], val[1]) ]
                     }
@@ -1127,22 +1137,6 @@ rule
                       end
 
                       result = [ @builder.forwarded_restarg(val[0]) ]
-                    }
-                | args tCOMMA arg_value
-                    {
-                      result = val[0] << val[2]
-                    }
-                | args tCOMMA tSTAR arg_value
-                    {
-                      result = val[0] << @builder.splat(val[2], val[3])
-                    }
-                | args tCOMMA tSTAR
-                    {
-                      if !@static_env.declared_anonymous_restarg?
-                        diagnostic :error, :no_anonymous_restarg, nil, val[2]
-                      end
-
-                      result = val[0] << @builder.forwarded_restarg(val[2])
                     }
 
         mrhs_arg: mrhs


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@11c2aa0.

Closes https://github.com/whitequark/parser/issues/959