### PR TITLE
Fix incorrect required_ruby_version

### DIFF
--- a/parser.gemspec
+++ b/parser.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency             'ast',       '~> 2.4.1'
   spec.add_dependency             'racc'


### PR DESCRIPTION
This gem has used String#delete_suffix which was introduced at Ruby 2.5. https://github.com/whitequark/parser/blob/95d26953ebe823211845fb84cb93c18cd501f561/lib/parser/lexer/literal.rb#L250

Ref. https://github.com/ruby/ruby/blob/ruby_2_5/NEWS

So, even Ruby 2.0 can be installed now, however it will not work.