### PR TITLE
- Supports Ruby 2.0+ runtime

### DIFF
--- a/lib/parser/lexer/literal.rb
+++ b/lib/parser/lexer/literal.rb
@@ -247,7 +247,7 @@ module Parser
         # E
         # because there are not enough leading spaces in the closing delimiter.
         delimiter.end_with?(@end_delim) &&
-          delimiter.delete_suffix(@end_delim).bytes.all? { |c| c == SPACE }
+          delimiter.sub(/#{@end_delim}\z/, '').bytes.all? { |c| c == SPACE }
       elsif @indent
         @end_delim == delimiter.lstrip
       else

--- a/parser.gemspec
+++ b/parser.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_dependency             'ast',       '~> 2.4.1'
   spec.add_dependency             'racc'


### PR DESCRIPTION
This is an alternative approach to the changes in #985. The Parser gem may be required to operate across as many Ruby versions as possible. The use of `delete_suffix` starts from Parser version 3.3.0.0. Therefore, by replacing `delete_suffix` with `sub`, and releasing Parser 3.3.0.1, supporting Ruby 2.0 would be feasible.