### PR TITLE
- lexer.rl: accept tabs before closing heredoc delimiter

### DIFF
--- a/lib/parser/lexer/literal.rb
+++ b/lib/parser/lexer/literal.rb
@@ -6,6 +6,7 @@ module Parser
   class Lexer::Literal
     DELIMITERS = { '(' => ')', '[' => ']', '{' => '}', '<' => '>' }
     SPACE = ' '.ord
+    TAB = "\t".ord
 
     TYPES = {
     # type       start token     interpolate?
@@ -247,7 +248,7 @@ module Parser
         # E
         # because there are not enough leading spaces in the closing delimiter.
         delimiter.end_with?(@end_delim) &&
-          delimiter.sub(/#{Regexp.escape(@end_delim)}\z/, '').bytes.all? { |c| c == SPACE }
+          delimiter.sub(/#{Regexp.escape(@end_delim)}\z/, '').bytes.all? { |c| c == SPACE || c == TAB }
       elsif @indent
         @end_delim == delimiter.lstrip
       else

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -11488,4 +11488,12 @@ class TestParser < Minitest::Test
       'def b(**) ->(**) {c()} end',
       SINCE_3_3)
   end
+
+  def test_parser_bug_989
+    assert_parses(
+      s(:str, "\t\tcontent\n"),
+      "\t<<-HERE\n\t\tcontent\n\tHERE",
+      %q{},
+      ALL_VERSIONS)
+  end
 end

--- a/test/test_runner_rewrite.rb
+++ b/test/test_runner_rewrite.rb
@@ -10,11 +10,11 @@ require (BASE_DIR + 'helper').expand_path
 
 class TestRunnerRewrite < Minitest::Test
   def assert_rewriter_output(path, args, input: 'input.rb', output: 'output.rb', expected_output: '', expected_error: '')
-    @ruby_rewrite = BASE_DIR.expand_path + '../bin/ruby-rewrite'
-    @test_dir     = BASE_DIR + path
+    @ruby_rewrite = ::BASE_DIR.expand_path + '../bin/ruby-rewrite'
+    @test_dir     = ::BASE_DIR + path
     @fixtures_dir = @test_dir + 'fixtures'
 
-    Dir.mktmpdir("parser", BASE_DIR.expand_path.to_s) do |tmp_dir|
+    Dir.mktmpdir("parser", ::BASE_DIR.expand_path.to_s) do |tmp_dir|
       tmp_dir = Pathname.new(tmp_dir)
       sample_file = tmp_dir + "#{path}.rb"
       sample_file_expanded = sample_file.expand_path


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/989.

The bug is not related to blocks specifically but example from the report can also be parsed now:

```
$ /bin/cat test.rb
foo do
	<<~DESC
		bar
	DESC
end

$ bin/ruby-parse --33 test.rb
(block
  (send nil :foo)
  (args)
  (str "bar\n"))
```