### PR TITLE
* Bump 3.2 branch to 3.2.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0.6", "3.1.4", "3.2.2", "3.3.0", "jruby-9.2"]
+        ruby: ["3.0.6", "3.1.4", "3.2.3", "3.3.0", "jruby-9.2"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"
             test_command: "bundle exec rake test || true"
           - ruby: "truffleruby"
             test_command: "bundle exec rake test || true"
-          - ruby: "3.2.2"
+          - ruby: "3.2.3"
             test_command: "./ci/run_rubocop_specs || true"
           - ruby: "3.3.0"
             test_command: "./ci/run_rubocop_specs || true"

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -102,7 +102,7 @@ module Parser
     CurrentRuby = Ruby31
 
   when /^3\.2\./
-    current_version = '3.2.2'
+    current_version = '3.2.3'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby32', current_version
     end

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -833,7 +833,7 @@ class Parser::Lexer
 
     if !@static_env.nil? && @static_env.declared?(tok)
       fnext expr_endfn; fbreak;
-    elsif @version >= 33 && tok =~ /\A_[1-9]\z/
+    elsif @version >= 32 && tok =~ /\A_[1-9]\z/
       fnext expr_endfn; fbreak;
     else
       fnext *arg_or_cmdarg(cmd_state); fbreak;

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -10501,7 +10501,7 @@ class TestParser < Minitest::Test
         [:error, :unexpected_token, { :token => 'tDSTAR' }]
       ],
       'p { [_1 **2] }',
-      %w[3.0 3.1 3.2])
+      %w[3.0 3.1])
 
     assert_parses(
       s(:numblock,
@@ -10512,7 +10512,7 @@ class TestParser < Minitest::Test
             s(:int, 2)))),
       'p { [_1 **2] }',
       %q{},
-      SINCE_3_3)
+      SINCE_3_2)
   end
 
   def test_endless_setter


### PR DESCRIPTION
Ruby 3.2.3 has been released:
https://www.ruby-lang.org/en/news/2024/01/18/ruby-3-2-3-released/

Bump 3.2 branch from 3.2.2 to 3.2.3
https://github.com/ruby/ruby/compare/v3_2_2...v3_2_3

Thas PR is backport #926 to Ruby 3.2 branch.
cf. https://github.com/ruby/ruby/commit/465eb7418d7ed91f5f0c75da77765c7f5ef8354f