### PR TITLE
Raise a more specific error when encountering an unknown magic comment encoding

### DIFF
--- a/lib/parser.rb
+++ b/lib/parser.rb
@@ -59,6 +59,7 @@ module Parser
 
   require 'parser/syntax_error'
   require 'parser/clobbering_error'
+  require 'parser/unknown_encoding_in_magic_comment_error'
   require 'parser/diagnostic'
   require 'parser/diagnostic/engine'
 

--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -46,6 +46,7 @@ module Parser
       # magic encoding comment or UTF-8 BOM. `string` can be in any encoding.
       #
       # @param [String]  string
+      # @raise [Parser::UnknownEncodingInMagicComment] if the encoding is not recognized
       # @return [String, nil] encoding name, if recognized
       #
       def self.recognize_encoding(string)
@@ -66,7 +67,11 @@ module Parser
         return nil if encoding_line.nil? || encoding_line[0] != '#'
 
         if (result = ENCODING_RE.match(encoding_line))
-          Encoding.find(result[3] || result[4] || result[6])
+          begin
+            Encoding.find(result[3] || result[4] || result[6])
+          rescue ArgumentError => e
+            raise Parser::UnknownEncodingInMagicComment, e.message
+          end
         else
           nil
         end

--- a/lib/parser/unknown_encoding_in_magic_comment_error.rb
+++ b/lib/parser/unknown_encoding_in_magic_comment_error.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Parser
+  ##
+  # {Parser::UnknownEncodingInMagicComment} is raised when a magic encoding
+  # comment is encountered that the currently running Ruby version doesn't
+  # recognize. It inherits from {ArgumentError} since that is the exception
+  # Ruby itself raises when trying to execute a file with an unknown encoding.
+  # As such, it is also not a {Parser::SyntaxError}.
+  #
+  # @api public
+  #
+  class UnknownEncodingInMagicComment < ArgumentError
+  end
+end

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -60,9 +60,10 @@ class TestEncoding < Minitest::Test
     assert_equal Encoding::UTF_8, recognize('# coding: utf-8-unix')
     assert_equal Encoding::UTF_8, recognize('# coding: utf-8-mac')
 
-    assert_raises(ArgumentError) do
+    e = assert_raises(ArgumentError) do
       assert_nil recognize('# coding: utf-8-dicks')
     end
+    assert(e.is_a?(Parser::UnknownEncodingInMagicComment))
   end
 
   def test_parse_18_invalid_enc


### PR DESCRIPTION
Closes #998

Let me know if I should tweak the docs for the exception in some way.

I also know that this library still targets Ruby 2.0. CI only seems to test against somewhat recent versions. I used the old begin/end syntax since I know that omitting the begin was added somewhere between but other than that I haven't tested on older versions.