### PR TITLE
Use `AST::Processor::Mixin` instead of deprecated `AST::Processor`

### DIFF
--- a/lib/parser/ast/processor.rb
+++ b/lib/parser/ast/processor.rb
@@ -6,7 +6,9 @@ module Parser
     ##
     # @api public
     #
-    class Processor < ::AST::Processor
+    class Processor
+      include ::AST::Processor::Mixin
+
       def process_regular_node(node)
         node.updated(nil, process_all(node))
       end


### PR DESCRIPTION
This PR uses `AST::Processor::Mixin` instead of deprecated `AST::Processor` API:

```ruby
# This class includes {AST::Processor::Mixin}; however, it is
# deprecated, since the module defines all of the behaviors that
# the processor includes.  Any new libraries should use
# {AST::Processor::Mixin} instead of subclassing this.
#
# @deprecated Use {AST::Processor::Mixin} instead.
```

https://github.com/whitequark/ast/blob/v2.4.2/lib/ast/processor.rb#L2-L7

There is an imcompatibility where the inheritance no longer includes `AST::Processor`, but the impact is expected to be negligible.