### PR TITLE
+ ruby{33,34}.y: allow blocks inherit anonymous args.

### DIFF
--- a/lib/parser/ruby33.y
+++ b/lib/parser/ruby33.y
@@ -1101,7 +1101,7 @@ rule
                       end
 
                       if @context.in_dynamic_block? && context.in_def &&
-                        @static_env.declared_anonymous_blockarg? && @static_env.parent_has_anonymous_blockarg?
+                        @static_env.declared_anonymous_blockarg_in_current_scpe? && @static_env.parent_has_anonymous_blockarg?
                         diagnostic :error, :ambiguous_anonymous_blockarg, nil, val[0]
                       end
 
@@ -1142,7 +1142,7 @@ rule
                       end
 
                       if @context.in_dynamic_block? && context.in_def &&
-                        @static_env.declared_anonymous_restarg? && @static_env.parent_has_anonymous_restarg?
+                        @static_env.declared_anonymous_restarg_in_current_scope? && @static_env.parent_has_anonymous_restarg?
                         diagnostic :error, :ambiguous_anonymous_restarg, nil, val[0]
                       end
 
@@ -3059,7 +3059,7 @@ f_opt_paren_args: f_paren_args
                       end
 
                       if @context.in_dynamic_block? && context.in_def &&
-                        @static_env.declared_anonymous_kwrestarg? && @static_env.parent_has_anonymous_kwrestarg?
+                        @static_env.declared_anonymous_kwrestarg_in_current_scope? && @static_env.parent_has_anonymous_kwrestarg?
                         diagnostic :error, :ambiguous_anonymous_kwrestarg, nil, val[0]
                       end
 

--- a/lib/parser/ruby34.y
+++ b/lib/parser/ruby34.y
@@ -1101,7 +1101,7 @@ rule
                       end
 
                       if @context.in_dynamic_block? && context.in_def &&
-                        @static_env.declared_anonymous_blockarg? && @static_env.parent_has_anonymous_blockarg?
+                        @static_env.declared_anonymous_blockarg_in_current_scpe? && @static_env.parent_has_anonymous_blockarg?
                         diagnostic :error, :ambiguous_anonymous_blockarg, nil, val[0]
                       end
 
@@ -1142,7 +1142,7 @@ rule
                       end
 
                       if @context.in_dynamic_block? && context.in_def &&
-                        @static_env.declared_anonymous_restarg? && @static_env.parent_has_anonymous_restarg?
+                        @static_env.declared_anonymous_restarg_in_current_scope? && @static_env.parent_has_anonymous_restarg?
                         diagnostic :error, :ambiguous_anonymous_restarg, nil, val[0]
                       end
 
@@ -3059,7 +3059,7 @@ f_opt_paren_args: f_paren_args
                       end
 
                       if @context.in_dynamic_block? && context.in_def &&
-                        @static_env.declared_anonymous_kwrestarg? && @static_env.parent_has_anonymous_kwrestarg?
+                        @static_env.declared_anonymous_kwrestarg_in_current_scope? && @static_env.parent_has_anonymous_kwrestarg?
                         diagnostic :error, :ambiguous_anonymous_kwrestarg, nil, val[0]
                       end
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -11497,4 +11497,34 @@ class TestParser < Minitest::Test
       %q{},
       ALL_VERSIONS)
   end
+
+  def test_parser_bug_19370
+    refute_diagnoses(
+      'def b(&) ->() {c(&)} end',
+      SINCE_3_3)
+
+    refute_diagnoses(
+      'def b(*) ->() {c(*)} end',
+      SINCE_3_3)
+
+    refute_diagnoses(
+      'def b(a, *) ->() {c(1, *)} end',
+      SINCE_3_3)
+
+    refute_diagnoses(
+      'def b(*) ->(a) {c(*)} end',
+      SINCE_3_3)
+
+    refute_diagnoses(
+      'def b(**) ->() {c(**)} end',
+      SINCE_3_3)
+
+    refute_diagnoses(
+      'def b(k:, **) ->() {c(k: 1, **)} end',
+      SINCE_3_3)
+
+    refute_diagnoses(
+      'def b(**) ->(k:) {c(**)} end',
+      SINCE_3_3)
+  end
 end


### PR DESCRIPTION
This commit tracks upstream commit ruby/ruby@596db9c.

Closes https://github.com/whitequark/parser/issues/963.

Unfortunately there are 0 tests for `anonymous <PARAM> parameter is also used within block` error message in the ruby/ruby repo.

<details>
<summary>A small script to verify this behaviour</summary>

```sh
set -x

$RUN 'def b(&) ->(&) {c(&)} end'
$RUN 'def b(*) ->(*) {c(*)} end'
$RUN 'def b(a, *) ->(*) {c(1, *)} end'
$RUN 'def b(*) ->(a, *) {c(*)} end'
$RUN 'def b(**) ->(**) {c(**)} end'
$RUN 'def b(k:, **) ->(**) {c(k: 1, **)} end'
$RUN 'def b(**) ->(k:, **) {c(**)} end'
echo

$RUN 'def b(&) ->(&) {c()} end'
$RUN 'def b(*) ->(*) {c()} end'
$RUN 'def b(**) ->(**) {c()} end'
echo

$RUN 'def b(&) ->() {c(&)} end'
$RUN 'def b(*) ->() {c(*)} end'
$RUN 'def b(a, *) ->() {c(1, *)} end'
$RUN 'def b(*) ->(a) {c(*)} end'
$RUN 'def b(**) ->() {c(**)} end'
$RUN 'def b(k:, **) ->() {c(k: 1, **)} end'
$RUN 'def b(**) ->(k:) {c(**)} end'
```
</details>

Ruby 3.3.0 (only inputs in the 2nd group are valid):

<details>
<summary>Details</summary>

```
+ ruby -cve 'def b(&) ->(&) {c(&)} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-e:1: anonymous block parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(*) ->(*) {c(*)} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-e:1: anonymous rest parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(a, *) ->(*) {c(1, *)} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-e:1: anonymous rest parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(*) ->(a, *) {c(*)} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-e:1: anonymous rest parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(**) ->(**) {c(**)} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-e:1: anonymous keyword rest parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(k:, **) ->(**) {c(k: 1, **)} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-e:1: anonymous keyword rest parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(**) ->(k:, **) {c(**)} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-e:1: anonymous keyword rest parameter is also used within block
-e: compile error (SyntaxError)
+ echo

+ ruby -cve 'def b(&) ->(&) {c()} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
Syntax OK
+ ruby -cve 'def b(*) ->(*) {c()} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
Syntax OK
+ ruby -cve 'def b(**) ->(**) {c()} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
Syntax OK
+ echo

+ ruby -cve 'def b(&) ->() {c(&)} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-e:1: anonymous block parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(*) ->() {c(*)} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-e:1: anonymous rest parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(a, *) ->() {c(1, *)} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-e:1: anonymous rest parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(*) ->(a) {c(*)} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-e:1: anonymous rest parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(**) ->() {c(**)} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-e:1: anonymous keyword rest parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(k:, **) ->() {c(k: 1, **)} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-e:1: anonymous keyword rest parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(**) ->(k:) {c(**)} end'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-e:1: anonymous keyword rest parameter is also used within block
-e: compile error (SyntaxError)
```

</details>

Ruby 3.3.1 (the 2nd and the 3rd groups are valid):

<details>
<summary>Details</summary>

```
+ ruby -cve 'def b(&) ->(&) {c(&)} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
-e:1: anonymous block parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(*) ->(*) {c(*)} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
-e:1: anonymous rest parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(a, *) ->(*) {c(1, *)} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
-e:1: anonymous rest parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(*) ->(a, *) {c(*)} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
-e:1: anonymous rest parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(**) ->(**) {c(**)} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
-e:1: anonymous keyword rest parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(k:, **) ->(**) {c(k: 1, **)} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
-e:1: anonymous keyword rest parameter is also used within block
-e: compile error (SyntaxError)
+ ruby -cve 'def b(**) ->(k:, **) {c(**)} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
-e:1: anonymous keyword rest parameter is also used within block
-e: compile error (SyntaxError)
+ echo

+ ruby -cve 'def b(&) ->(&) {c()} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Syntax OK
+ ruby -cve 'def b(*) ->(*) {c()} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Syntax OK
+ ruby -cve 'def b(**) ->(**) {c()} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Syntax OK
+ echo

+ ruby -cve 'def b(&) ->() {c(&)} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Syntax OK
+ ruby -cve 'def b(*) ->() {c(*)} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Syntax OK
+ ruby -cve 'def b(a, *) ->() {c(1, *)} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Syntax OK
+ ruby -cve 'def b(*) ->(a) {c(*)} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Syntax OK
+ ruby -cve 'def b(**) ->() {c(**)} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Syntax OK
+ ruby -cve 'def b(k:, **) ->() {c(k: 1, **)} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Syntax OK
+ ruby -cve 'def b(**) ->(k:) {c(**)} end'
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Syntax OK
```

</details>

This patch (mirrors 3.3.1, thus also groups 2 and 3 are valid):

<details>
<summary>Details</summary>

```
+ bin/ruby-parse --33 -e 'def b(&) ->(&) {c(&)} end'
(fragment:0):1:19: error: anonymous block parameter is also used within block
(fragment:0):1: def b(&) ->(&) {c(&)} end
(fragment:0):1:                   ^
+ bin/ruby-parse --33 -e 'def b(*) ->(*) {c(*)} end'
(fragment:0):1:19: error: anonymous rest parameter is also used within block
(fragment:0):1: def b(*) ->(*) {c(*)} end
(fragment:0):1:                   ^
+ bin/ruby-parse --33 -e 'def b(a, *) ->(*) {c(1, *)} end'
(fragment:0):1:25: error: anonymous rest parameter is also used within block
(fragment:0):1: def b(a, *) ->(*) {c(1, *)} end
(fragment:0):1:                         ^
+ bin/ruby-parse --33 -e 'def b(*) ->(a, *) {c(*)} end'
(fragment:0):1:22: error: anonymous rest parameter is also used within block
(fragment:0):1: def b(*) ->(a, *) {c(*)} end
(fragment:0):1:                      ^
+ bin/ruby-parse --33 -e 'def b(**) ->(**) {c(**)} end'
(fragment:0):1:21: error: anonymous keyword rest parameter is also used within block
(fragment:0):1: def b(**) ->(**) {c(**)} end
(fragment:0):1:                     ^~
+ bin/ruby-parse --33 -e 'def b(k:, **) ->(**) {c(k: 1, **)} end'
(fragment:0):1:31: error: anonymous keyword rest parameter is also used within block
(fragment:0):1: def b(k:, **) ->(**) {c(k: 1, **)} end
(fragment:0):1:                               ^~
+ bin/ruby-parse --33 -e 'def b(**) ->(k:, **) {c(**)} end'
(fragment:0):1:25: error: anonymous keyword rest parameter is also used within block
(fragment:0):1: def b(**) ->(k:, **) {c(**)} end
(fragment:0):1:                         ^~
+ echo

+ bin/ruby-parse --33 -e 'def b(&) ->(&) {c()} end'
(def :b
  (args
    (blockarg nil))
  (block
    (lambda)
    (args
      (blockarg nil))
    (send nil :c)))
+ bin/ruby-parse --33 -e 'def b(*) ->(*) {c()} end'
(def :b
  (args
    (restarg))
  (block
    (lambda)
    (args
      (restarg))
    (send nil :c)))
+ bin/ruby-parse --33 -e 'def b(**) ->(**) {c()} end'
(def :b
  (args
    (kwrestarg))
  (block
    (lambda)
    (args
      (kwrestarg))
    (send nil :c)))
+ echo

+ bin/ruby-parse --33 -e 'def b(&) ->() {c(&)} end'
(def :b
  (args
    (blockarg nil))
  (block
    (lambda)
    (args)
    (send nil :c
      (block-pass nil))))
+ bin/ruby-parse --33 -e 'def b(*) ->() {c(*)} end'
(def :b
  (args
    (restarg))
  (block
    (lambda)
    (args)
    (send nil :c
      (forwarded-restarg))))
+ bin/ruby-parse --33 -e 'def b(a, *) ->() {c(1, *)} end'
(def :b
  (args
    (arg :a)
    (restarg))
  (block
    (lambda)
    (args)
    (send nil :c
      (int 1)
      (forwarded-restarg))))
+ bin/ruby-parse --33 -e 'def b(*) ->(a) {c(*)} end'
(def :b
  (args
    (restarg))
  (block
    (lambda)
    (args
      (arg :a))
    (send nil :c
      (forwarded-restarg))))
+ bin/ruby-parse --33 -e 'def b(**) ->() {c(**)} end'
(def :b
  (args
    (kwrestarg))
  (block
    (lambda)
    (args)
    (send nil :c
      (kwargs
        (forwarded-kwrestarg)))))
+ bin/ruby-parse --33 -e 'def b(k:, **) ->() {c(k: 1, **)} end'
(def :b
  (args
    (kwarg :k)
    (kwrestarg))
  (block
    (lambda)
    (args)
    (send nil :c
      (kwargs
        (pair
          (sym :k)
          (int 1))
        (forwarded-kwrestarg)))))
+ bin/ruby-parse --33 -e 'def b(**) ->(k:) {c(**)} end'
(def :b
  (args
    (kwrestarg))
  (block
    (lambda)
    (args
      (kwarg :k))
    (send nil :c
      (kwargs
        (forwarded-kwrestarg)))))
```

</details>