### PR TITLE
Supress warnings during parsing

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -2263,7 +2263,12 @@ module Parser
         source
       end
 
-      Regexp.new(source, (Regexp::EXTENDED if options.children.include?(:x)))
+      begin
+        old_verbose, $VERBOSE = $VERBOSE, nil
+        Regexp.new(source, (Regexp::EXTENDED if options.children.include?(:x)))
+      ensure
+        $VERBOSE = old_verbose
+      end
     end
 
     def static_regexp_node(node)

--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -116,12 +116,21 @@ class Parser::Lexer
     @emit_integer_if = lambda { |chars, p| emit(:tINTEGER,   chars, @ts, @te - 2); p - 2 }
     @emit_integer_rescue = lambda { |chars, p| emit(:tINTEGER,   chars, @ts, @te - 6); p - 6 }
 
-    @emit_float = lambda { |chars, p| emit(:tFLOAT,     Float(chars)); p }
-    @emit_imaginary_float = lambda { |chars, p| emit(:tIMAGINARY, Complex(0, Float(chars))); p }
-    @emit_float_if =     lambda { |chars, p| emit(:tFLOAT,     Float(chars), @ts, @te - 2); p - 2 }
-    @emit_float_rescue = lambda { |chars, p| emit(:tFLOAT,     Float(chars), @ts, @te - 6); p - 6 }
+    @emit_float = lambda { |chars, p| emit(:tFLOAT,     construct_float(chars)); p }
+    @emit_imaginary_float = lambda { |chars, p| emit(:tIMAGINARY, Complex(0, construct_float(chars))); p }
+    @emit_float_if =     lambda { |chars, p| emit(:tFLOAT,     construct_float(chars), @ts, @te - 2); p - 2 }
+    @emit_float_rescue = lambda { |chars, p| emit(:tFLOAT,     construct_float(chars), @ts, @te - 6); p - 6 }
 
     reset
+  end
+
+  def construct_float(chars)
+    begin
+      old_verbose, $VERBOSE = $VERBOSE, nil
+      Float(chars)
+    ensure
+      $VERBOSE = old_verbose
+    end
   end
 
   def reset(reset_state=true)


### PR DESCRIPTION
User input can contain arbitrary regexes.
Something like `Parser::CurrentRuby.parse("/[\177\01\1778]/")` shows a warning:
> character class has duplicated range: /[\x7f\x01\x7f8]/

I'm interested in getting the warning count in the RuboCop test suite down and since it has a few regex cops there are quite a few warnings of that kind as well. They are unactionable, RuboCop instead emulates these warnings by inspecting the ast parsing the regexp with the `regexp_parser` gem.

-------

Also noticed the same for floats:
`Parser::CurrentRuby.parse("9.9999e999")`
> Float 9.9999e999 out of range