### PR TITLE
* Bump 3.1 branch to 3.1.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0.7", "3.1.5", "3.2.4", "3.3.1", "jruby-9.2"]
+        ruby: ["3.0.7", "3.1.6", "3.2.4", "3.3.1", "jruby-9.2"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -93,7 +93,7 @@ module Parser
     CurrentRuby = Ruby30
 
   when /^3\.1\./
-    current_version = '3.1.5'
+    current_version = '3.1.6'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby31', current_version
     end


### PR DESCRIPTION
Ruby 3.1.6 has been released:
https://www.ruby-lang.org/en/news/2024/05/29/ruby-3-1-6-released/

Bump 3.1 branch from 3.1.5 to 3.1.6:
https://github.com/ruby/ruby/compare/v3_1_5...v3_1_6

There seems to be no change to the syntax.