### PR TITLE
* Bump Racc to 1.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gemspec
 # Workaround for bug in Bundler on JRuby
 # See https://github.com/bundler/bundler/issues/4157
 gem 'ast', '>= 1.1', '< 3.0'
-gem 'racc', '1.7.3'
+gem 'racc', '1.8.0'


### PR DESCRIPTION
Racc 1.8.0 has been released and this PR bumps Racc to 1.8.0: https://github.com/ruby/racc/releases/tag/v1.8.0