### PR TITLE
- lexer.rl: handle CLRF as a line separator

### DIFF
--- a/lib/parser/lexer.rl
+++ b/lib/parser/lexer.rl
@@ -545,7 +545,7 @@ class Parser::Lexer
     @newline_s = p
   }
 
-  c_nl       = '\n' $ do_nl;
+  c_nl       = ('\r\n' | '\n') $ do_nl;
   c_space    = [ \t\r\f\v];
   c_space_nl = c_space | c_nl;
 
@@ -1995,7 +1995,7 @@ class Parser::Lexer
 
       # Here we use '\n' instead of w_newline to not modify @newline_s
       # and eventually properly emit tNL
-      (c_space* w_space_comment '\n')+
+      (c_space* w_space_comment ('\r\n' | '\n'))+
       => {
         if @version < 27
           # Ruby before 2.7 doesn't support comments before leading dot.

--- a/lib/parser/lexer/literal.rb
+++ b/lib/parser/lexer/literal.rb
@@ -208,7 +208,7 @@ module Parser
       end
 
       unless @buffer.empty?
-        emit(:tSTRING_CONTENT, @buffer, @buffer_s, @buffer_e)
+        emit(:tSTRING_CONTENT, @buffer.gsub("\r\n", "\n"), @buffer_s, @buffer_e)
 
         clear_buffer
         extend_content

--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -187,7 +187,7 @@ module Parser
           raise ArgumentError, 'Source::Buffer is immutable'
         end
 
-        @source = input.gsub("\r\n".freeze, "\n".freeze).freeze
+        @source = input.freeze
 
         if !@source.ascii_only? &&
            @source.encoding != Encoding::UTF_32LE &&

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -1012,9 +1012,9 @@ class TestLexer < Minitest::Test
                    :tIDENTIFIER,     "a",          [0, 1],
                    :tEQL,            "=",          [2, 3],
                    :tSTRING_BEG,     "<<\"",       [4, 7],
-                   :tSTRING_CONTENT, "ABCDEF\r\n", [9, 17],
-                   :tSTRING_END,     "E",          [17, 20],
-                   :tNL,             nil,          [8, 9])
+                   :tSTRING_CONTENT, "ABCDEF\r\n", [10, 19],
+                   :tSTRING_END,     "E",          [19, 23],
+                   :tNL,             nil,          [9, 10])
   end
 
   def test_heredoc_with_identifier_ending_newline__19
@@ -3188,9 +3188,9 @@ class TestLexer < Minitest::Test
   def test_bug_heredoc_cr_lf
     assert_scanned("<<FIN\r\nfoo\r\nFIN\r\n",
                    :tSTRING_BEG,     "<<\"",  [0, 5],
-                   :tSTRING_CONTENT, "foo\n", [6, 10],
-                   :tSTRING_END,     "FIN",   [10, 13],
-                   :tNL,             nil,     [5, 6])
+                   :tSTRING_CONTENT, "foo\n", [7, 12],
+                   :tSTRING_END,     "FIN",   [12, 16],
+                   :tNL,             nil,     [6, 7])
   end
 
   def test_bug_eh_symbol_no_newline

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -5610,7 +5610,7 @@ class TestParser < Minitest::Test
       assert_equal s(:lvar, :foo),
                    ast
 
-      assert_equal range.call(1, 4),
+      assert_equal range.call(2, 5),
                    ast.loc.expression
     end
   end


### PR DESCRIPTION
Closes https://github.com/whitequark/parser/issues/1020.

```ruby
3.3.1 :004 > Parser::CurrentRuby.parse("1\r\n2\r\n3").children[2].loc
 => #<Parser::Source::Map::Operator:0x00000001222f0f80 @expression=#<Parser::Source::Range (string) 6...7>, @node=s(:int, 3), @operator=nil>

3.3.1 :005 > Parser::CurrentRuby.parse("1\r\n2\r\n3").children[2].loc.expression.source
 => "3"
```

A few notes:

1. If `\r\n` is a line separator `parser` still emits `tNL` token with location of the `\n` character
2. `tSTRING_CONTENT` tokens now have proper locations, but the content doesn't include `\r` part of `\r\n` (because `eval(%{"\r\n"})` is just `"\n"`), so `.source` of their locations doesn't match string content. I guess it's fine, the same happens with all escape sequences anyway.

If it doesn't break Rubocop's test suite I guess it's safe to merge it as is.

@kddnewton Could you take a look at this please? Does it fix Prism's translator?