### PR TITLE
* Bump maintenance branches to 3.3.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0.7", "3.1.6", "3.2.4", "3.3.2", "jruby-9.2"]
+        ruby: ["3.0.7", "3.1.6", "3.2.4", "3.3.3", "jruby-9.2"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"
@@ -26,7 +26,7 @@ jobs:
             test_command: "bundle exec rake test || true"
           - ruby: "3.2.4"
             test_command: "./ci/run_rubocop_specs || true"
-          - ruby: "3.3.2"
+          - ruby: "3.3.3"
             test_command: "./ci/run_rubocop_specs || true"
     steps:
     - uses: actions/checkout@v4

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -111,7 +111,7 @@ module Parser
     CurrentRuby = Ruby32
 
   when /^3\.3\./
-    current_version = '3.3.2'
+    current_version = '3.3.3'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby33', current_version
     end


### PR DESCRIPTION
Ruby 3.3.3 has been released:
https://www.ruby-lang.org/en/news/2024/06/12/ruby-3-3-3-released/

Bump 3.3 branch from 3.3.2 to 3.3.3:
https://github.com/ruby/ruby/compare/v3_3_2...v3_3_3

There seems to be no change to the syntax.