### PR TITLE
Suppress Ruby 3.4's warning

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -94,16 +94,15 @@ module Parser
       #
       def self.reencode_string(input)
         original_encoding = input.encoding
-        detected_encoding = recognize_encoding(input.force_encoding(Encoding::BINARY))
+        dup_input = input.dup
+        detected_encoding = recognize_encoding(dup_input.force_encoding(Encoding::BINARY))
 
         if detected_encoding.nil?
-          input.force_encoding(original_encoding)
+          dup_input.force_encoding(original_encoding)
         elsif detected_encoding == Encoding::BINARY
           input
         else
-          input.
-            force_encoding(detected_encoding).
-            encode(Encoding::UTF_8)
+          dup_input.force_encoding(detected_encoding).encode(Encoding::UTF_8)
         end
       end
 


### PR DESCRIPTION
Starting with Ruby 3.4, there is a gradual plan to freeze strings: https://bugs.ruby-lang.org/issues/20205#note-35

This PR suppresses the following Ruby 3.4's warning:

```console
/Users/koic/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/parser-3.3.4.0/lib/parser/source/buffer.rb:97:
warning: literal string will be frozen in the future
```