### PR TITLE
- Fix errros in the ascii specs of RuboCop

### DIFF
--- a/lib/parser/source/buffer.rb
+++ b/lib/parser/source/buffer.rb
@@ -94,15 +94,16 @@ module Parser
       #
       def self.reencode_string(input)
         original_encoding = input.encoding
-        dup_input = input.dup
-        detected_encoding = recognize_encoding(dup_input.force_encoding(Encoding::BINARY))
+        detected_encoding = recognize_encoding(input.force_encoding(Encoding::BINARY))
 
         if detected_encoding.nil?
-          dup_input.force_encoding(original_encoding)
+          input.force_encoding(original_encoding)
         elsif detected_encoding == Encoding::BINARY
           input
         else
-          dup_input.force_encoding(detected_encoding).encode(Encoding::UTF_8)
+          input.
+            force_encoding(detected_encoding).
+            encode(Encoding::UTF_8)
         end
       end
 


### PR DESCRIPTION
Follow up https://github.com/whitequark/parser/pull/1031#issuecomment-2257868932 and reverts #1028.

This PR fixes the following error:

```console
$ ci/run_rubocop_specs
(snip)

==> Failed Examples

rspec  # RuboCop::Cop::Lint::PercentStringArray with binary encoded source adds an offense and corrects when tokens contain quotes
rspec  # RuboCop::Cop::Lint::PercentStringArray with binary encoded source accepts if tokens contain no quotes
rspec './spec/rubocop/cop/layout/end_of_line_spec.rb[1:3:6:2]' # RuboCop::Cop::Layout::EndOfLine when EnforcedStyle is lf and the default external encoding is US_ASCII can inspect non-UTF-8 encoded source with proper encoding comment
rspec './spec/rubocop/cop/layout/end_of_line_spec.rb[1:3:5:2]' # RuboCop::Cop::Layout::EndOfLine when EnforcedStyle is lf and there are many lines ending with CR+LF can inspect non-UTF-8 encoded source with proper encoding comment
rspec './spec/rubocop/cop/layout/end_of_line_spec.rb[1:2:6:2]' # RuboCop::Cop::Layout::EndOfLine when EnforcedStyle is crlf and the default external encoding is US_ASCII can inspect non-UTF-8 encoded source with proper encoding comment
rspec './spec/rubocop/cop/layout/end_of_line_spec.rb[1:2:5:2]' # RuboCop::Cop::Layout::EndOfLine when EnforcedStyle is crlf and there are many lines ending with LF can inspect non-UTF-8 encoded source with proper encoding comment
rspec './spec/rubocop/cop/lint/percent_symbol_array_spec.rb[1:1:11:2]' # RuboCop::Cop::Lint::PercentSymbolArray detecting colons or commas in a %i/%I string with binary encoded source accepts if tokens contain no quotes
rspec './spec/rubocop/cop/lint/percent_symbol_array_spec.rb[1:1:11:1]' # RuboCop::Cop::Lint::PercentSymbolArray detecting colons or commas in a %i/%I string with binary encoded source registers an offense and corrects when tokens contain quotes
```

#1028 has an issue with the fix, causing RuboCop's CI to fail.

This PR prioritizes avoiding CI failures, so for now, it reverts the above change.

Improvements for handling warnings in Ruby 3.4.0dev and displaying clear results when whitequark/parser fails in the RuboCop CI matrix will be addressed separately.