### PR TITLE
* Bump maintenance branches to 3.2.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0.7", "3.1.6", "3.2.5", "3.3.5", "jruby-9.2"]
+        ruby: ["3.0.7", "3.1.6", "3.2.6", "3.3.5", "jruby-9.2"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"
             test_command: "bundle exec rake test || true"
           - ruby: "truffleruby"
             test_command: "bundle exec rake test || true"
-          - ruby: "3.2.5"
+          - ruby: "3.2.6"
             test_command: "./ci/run_rubocop_specs || true"
           - ruby: "3.3.5"
             test_command: "./ci/run_rubocop_specs || true"

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -102,7 +102,7 @@ module Parser
     CurrentRuby = Ruby31
 
   when /^3\.2\./
-    current_version = '3.2.5'
+    current_version = '3.2.6'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby32', current_version
     end


### PR DESCRIPTION
Closes #1043.

Ruby 3.2.6 has been released:
https://www.ruby-lang.org/en/news/2024/10/30/ruby-3-2-6-released/

Bump 3.2 branch from 3.2.5 to 3.2.6:
https://github.com/ruby/ruby/compare/v3_2_5...v3_2_6

There seems to be no change to the syntax.