### PR TITLE
- Fix `ruby-parse` with a folder ending in `.rb`

### DIFF
--- a/lib/parser/runner.rb
+++ b/lib/parser/runner.rb
@@ -242,7 +242,12 @@ module Parser
 
     def process_files
       @files.each do |filename|
-        source = File.read(filename).force_encoding(@parser.default_encoding)
+        source = begin
+          File.read(filename).force_encoding(@parser.default_encoding)
+        rescue Errno::EISDIR
+          # Will happen for a folder called `foo.rb`. Just catch this here, it's cheaper than checking every file.
+          next
+        end
 
         buffer = Parser::Source::Buffer.new(filename)
 

--- a/test/test_runner_parse.rb
+++ b/test/test_runner_parse.rb
@@ -58,4 +58,13 @@ class TestRunnerParse < Minitest::Test
     assert_prints ['--emit-ruby', '-', { stdin_data: '123' }],
                   's(:int, 123)'
   end
+
+  def test_folder_with_rb_extension
+    Dir.mktmpdir do |tmp_dir|
+      Dir.mkdir("#{tmp_dir}/foo.rb")
+      File.write("#{tmp_dir}/foo.rb/bar.rb", "123")
+
+      assert_prints [tmp_dir], '(int 123)'
+    end
+  end
 end


### PR DESCRIPTION
It's just checking that the path ends with `.rb`, which can happen with folders.

For example: https://github.com/chef/chef/tree/1ea245124173f803af628abd70adc87baa70a873/knife/spec/data/client.d_02/foo.rb