### PR TITLE
+ ruby34.y: reject `return` in singleton class

### DIFF
--- a/lib/parser/context.rb
+++ b/lib/parser/context.rb
@@ -24,6 +24,7 @@ module Parser
       in_class
       in_block
       in_lambda
+      cant_return
     ]
 
     def initialize
@@ -38,6 +39,7 @@ module Parser
       @in_class = false
       @in_block = false
       @in_lambda = false
+      @cant_return = false
     end
 
     attr_accessor(*FLAGS)

--- a/lib/parser/ruby34.y
+++ b/lib/parser/ruby34.y
@@ -366,6 +366,7 @@ rule
 
                       result = [ val[0], @context.dup ]
                       @context.in_def = true
+                      @context.cant_return = false
                     }
 
        defn_head: k_def def_name
@@ -1319,6 +1320,7 @@ rule
                 | k_class cpath superclass
                     {
                       @context.in_class = true
+                      @context.cant_return = true
                       local_push
                     }
                     bodystmt kEND
@@ -1334,11 +1336,13 @@ rule
 
                       local_pop
                       @context.in_class = ctx.in_class
+                      @context.cant_return = ctx.cant_return
                     }
                 | k_class tLSHFT expr_value term
                     {
                       @context.in_def = false
                       @context.in_class = false
+                      @context.cant_return = true
                       local_push
                     }
                     bodystmt kEND
@@ -1350,10 +1354,12 @@ rule
                       local_pop
                       @context.in_def = ctx.in_def
                       @context.in_class = ctx.in_class
+                      @context.cant_return = ctx.cant_return
                     }
                 | k_module cpath
                     {
                       @context.in_class = true
+                      @context.cant_return = true
                       local_push
                     }
                     bodystmt kEND
@@ -1367,6 +1373,7 @@ rule
 
                       local_pop
                       @context.in_class = ctx.in_class
+                      @context.cant_return = ctx.cant_return
                     }
                 | defn_head f_arglist bodystmt kEND
                     {
@@ -1425,7 +1432,7 @@ rule
 
         k_return: kRETURN
                     {
-                      if @context.in_class && !@context.in_def && !(context.in_block || context.in_lambda)
+                      if @context.cant_return && !(context.in_block || context.in_lambda)
                         diagnostic :error, :invalid_return, nil, val[0]
                       end
                     }


### PR DESCRIPTION
This tracks upstream commit https://github.com/ruby/ruby/commit/e642ddf7ae86e306674559ae745823fdbf56ea10

Closes #1029.

Note that `in_class` is now unused for 3.4 as far as I can tell. Ruby uses it in `begin_definition` helper but I don't think there's something equivalent with ragel here, or I just don't know about it. Kept around to keep it closer to upstream.

Tested against https://github.com/eliotsykes/real-world-rails and https://github.com/jeromedalbert/real-world-ruby-apps, got no unexpected syntax errors.