### PR TITLE
- builder.rb: correctly handle `...` forwarding to super with explicit block

### DIFF
--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -8163,6 +8163,30 @@ class TestParser < Minitest::Test
       SINCE_3_1 - SINCE_2_7)
   end
 
+  def test_forward_args_super_with_block
+    [
+      %q{def foo(...) super(...) {}; end},
+      %q{def foo(...) super(a, ...) {}; end},
+      %q{def foo(...) super(a, b, ...) {}; end},
+    ].each do |code|
+      # https://bugs.ruby-lang.org/issues/20392
+      refute_diagnoses(code, %w(3.3))
+      assert_diagnoses(
+        [:error, :block_and_blockarg],
+        code,
+        %q{},
+        SINCE_2_7 - %w(3.3))
+    end
+
+    [
+      %q{def foo(...) super {}; end},
+      %q{def foo(...) super() {}; end},
+      %q{def foo(...) super(a) {}; end},
+      %q{def foo(...) super(a, b) {}; end},
+    ].each do |code|
+      refute_diagnoses(code, SINCE_2_7)
+    end
+  end
   def test_trailing_forward_arg
     assert_parses(
       s(:def, :foo,


### PR DESCRIPTION
Closes #1004

Upstream commit https://github.com/ruby/ruby/commit/a850cd1a87bef738c40d9c550fb8823699083f2e is specific to 3.3, previous versions already did not allow this.
See https://bugs.ruby-lang.org/issues/20392 for a bit more info.
    
But since the super node has has a different shape, it behaved unexpectedly in earlier ruby versions already.
    
It allowed forwarding with zero and one arguments and failed for more. Now it correctly rejects as invalid syntax, except in Ruby 3.3, that fix has not been backported.