### PR TITLE
* assert that version-specific checks actually run against at least one version

### DIFF
--- a/test/parse_helper.rb
+++ b/test/parse_helper.rb
@@ -79,6 +79,8 @@ module ParseHelper
   # )
   # ~~~
   def assert_parses(ast, code, source_maps='', versions=ALL_VERSIONS)
+    refute_operator(versions, :empty?)
+
     with_versions(versions) do |version, parser|
       try_parsing(ast, code, parser, source_maps, version)
     end
@@ -160,6 +162,8 @@ module ParseHelper
   #     |     ~~~ highlights (0)})
   # ~~~
   def assert_diagnoses(diagnostic, code, source_maps='', versions=ALL_VERSIONS)
+    refute_operator(versions, :empty?)
+
     with_versions(versions) do |version, parser|
       source_file = Parser::Source::Buffer.new('(assert_diagnoses)', source: code)
 
@@ -217,6 +221,8 @@ module ParseHelper
   #   SINCE_2_4)
   # ~~~
   def assert_diagnoses_many(diagnostics, code, versions=ALL_VERSIONS)
+    refute_operator(versions, :empty?)
+
     with_versions(versions) do |version, parser|
       source_file = Parser::Source::Buffer.new('(assert_diagnoses_many)', source: code)
 
@@ -242,6 +248,8 @@ module ParseHelper
   end
 
   def refute_diagnoses(code, versions=ALL_VERSIONS)
+    refute_operator(versions, :empty?)
+
     with_versions(versions) do |version, parser|
       source_file = Parser::Source::Buffer.new('(refute_diagnoses)', source: code)
 
@@ -258,6 +266,8 @@ module ParseHelper
   end
 
   def assert_context(context, code, versions=ALL_VERSIONS)
+    refute_operator(versions, :empty?)
+
     with_versions(versions) do |version, parser|
       source_file = Parser::Source::Buffer.new('(assert_context)', source: code)
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -2239,7 +2239,7 @@ class TestParser < Minitest::Test
         s(:lvar, :var)),
       %q{def f(var = defined?(var)) var end},
       %q{},
-      SINCE_2_7 - SINCE_2_1)
+      SINCE_2_1 - SINCE_2_7)
 
     assert_parses(
       s(:def, :f,
@@ -2247,7 +2247,7 @@ class TestParser < Minitest::Test
         s(:lvar, :var)),
       %q{def f(var: defined?(var)) var end},
       %q{},
-      SINCE_2_7 - SINCE_2_1)
+      SINCE_2_1 - SINCE_2_7)
 
     assert_parses(
       s(:block,
@@ -5721,7 +5721,7 @@ class TestParser < Minitest::Test
         s(:str, "")),
       %q{/\xa8/n =~ ""}.dup.force_encoding(Encoding::UTF_8),
       %{},
-      SINCE_3_1 - SINCE_1_9)
+      SINCE_1_9 - SINCE_3_1)
   end
 
   #
@@ -6626,7 +6626,7 @@ class TestParser < Minitest::Test
         s(:str, "#")),
       %q{[/()\\1/, ?#]},
       %q{},
-      SINCE_3_1 - SINCE_1_9)
+      SINCE_1_9 - SINCE_3_1)
   end
 
   def test_parser_bug_272
@@ -8160,7 +8160,7 @@ class TestParser < Minitest::Test
       [:error, :unexpected_token, { :token => 'tDOT3' }],
       %q{def foo ...; end},
       %q{        ^^^ location},
-      SINCE_3_1 - SINCE_2_7)
+      SINCE_2_7 - SINCE_3_1)
   end
 
   def test_trailing_forward_arg


### PR DESCRIPTION
It's easy to invert version subtraction and then not test anything
Not like I almost did that myself or anything 🙃