### PR TITLE
- lexer-strings.rb: avoid an exception on utf8 surrogate pair codepoints

### DIFF
--- a/lib/parser/lexer-strings.rl
+++ b/lib/parser/lexer-strings.rl
@@ -429,6 +429,15 @@ class Parser::LexerStrings
           break
         end
 
+        # UTF-16 surrogate pairs. These are actually accepted before Ruby 2.4
+        # but can't be represented in the AST. Make them a syntax error in
+        # all versions instead, Ruby would raise an exception otherwise.
+        if codepoint & 0xfffff800 == 0xd800
+          diagnostic :error, :invalid_unicode_escape, nil,
+                     range(codepoint_s, codepoint_s + codepoint_str.length)
+          break
+        end
+
         @escape += codepoint.chr(Encoding::UTF_8)
         codepoint_s += codepoint_str.length
       end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -5755,6 +5755,25 @@ class TestParser < Minitest::Test
       SINCE_1_9)
   end
 
+  def test_codepoint_surrogate
+    assert_diagnoses(
+      [:error, :invalid_unicode_escape],
+      %q{"\u{D800}"},
+      %q{    ~~~~ location})
+
+    assert_diagnoses(
+      [:error, :invalid_unicode_escape],
+      %q{"\u{DFFF}"},
+      %q{    ~~~~ location})
+
+    [
+      %q{"\u{D7FF}"},
+      %q{"\u{E000}"},
+    ].each do |code|
+      refute_diagnoses(code)
+    end
+  end
+
   def test_on_error
     assert_diagnoses(
       [:error, :unexpected_token, { :token => 'tIDENTIFIER' }],


### PR DESCRIPTION
Closes #855

Starting from Ruby 2.4, these are a syntax error but I don't see an easy way of representing such strings. Right now the parser actually crashses (in all versions) so I'd say it's an improvement.

Output of executing `puts "\u{D800}"` on all ruby versions:
<details><summary>Output</summary>
<p>

```
===================1.8===================
u{D800}
===================1.9===================
���
===================2.0===================
���
===================2.1===================
���
===================2.2===================
���
===================2.3===================
���
===================2.4===================
surrogate.rb:1: invalid Unicode codepoint
puts "\u{D800}"
         ^
===================2.5===================
surrogate.rb:1: invalid Unicode codepoint
puts "\u{D800}"
         ^~~~
===================2.6===================
surrogate.rb:1: invalid Unicode codepoint
puts "\u{D800}"
         ^~~~
===================2.7===================
surrogate.rb:1: invalid Unicode codepoint
puts "\u{D800}"
         ^~~~
===================3.0===================
surrogate.rb:1: invalid Unicode codepoint
puts "\u{D800}"
         ^~~~
===================3.1===================
surrogate.rb:1: invalid Unicode codepoint
puts "\u{D800}"
         ^~~~
===================3.2===================
surrogate.rb: --> surrogate.rb
invalid Unicode codepoint
> 1  puts "\u{D800}"
surrogate.rb:1: invalid Unicode codepoint (SyntaxError)
puts "\u{D800}"
             ^

===================3.3===================
surrogate.rb: 
surrogate.rb:1: invalid Unicode codepoint (SyntaxError)
puts "\u{D800}"
             ^

===================3.4===================
surrogate.rb: --> surrogate.rb

invalid Unicode escape sequence

> 1  puts "\u{D800}"

surrogate.rb:1: syntax error found (SyntaxError)
> 1 | puts "\u{D800}"
    |          ^~~~ invalid Unicode escape sequence
  2 | 
```

</p>
</details> 

I used this script to check that `integer.chr` behaves the same on all ruby versions:
```rb
bounds = []
valid1 = true
valid2 = true
(0..(0x110000 - 1)).each do |num|
  begin
    valid1 = valid2
    num.chr(Encoding::UTF_8)
    valid2 = true
  rescue RangeError
    valid2 = false
  ensure
    bounds << num if valid1 != valid2
  end
end
puts bounds
```

<details><summary>Output</summary>
<p>

```
===================1.8===================
num_char.rb:7: uninitialized constant Encoding (NameError)
        from num_char.rb:4:in `each'
        from num_char.rb:4
===================1.9===================
55296
57344
===================2.0===================
55296
57344
===================2.1===================
55296
57344
===================2.2===================
55296
57344
===================2.3===================
55296
57344
===================2.4===================
55296
57344
===================2.5===================
55296
57344
===================2.6===================
55296
57344
===================2.7===================
55296
57344
===================3.0===================
55296
57344
===================3.1===================
55296
57344
===================3.2===================
55296
57344
===================3.3===================
55296
57344
===================3.4===================
55296
57344
```

</p>
</details> 