### PR TITLE
+ ruby34.y: allow circular argument references

### DIFF
--- a/lib/parser/ruby34.y
+++ b/lib/parser/ruby34.y
@@ -47,14 +47,12 @@ preclow
 rule
 
          program:   {
-                      @current_arg_stack.push(nil)
                       @max_numparam_stack.push(static: true)
                     }
                   top_compstmt
                     {
                       result = val[1]
 
-                      @current_arg_stack.pop
                       @max_numparam_stack.pop
                     }
 
@@ -270,7 +268,6 @@ rule
                                  val[1], val[2], val[3])
 
                       local_pop
-                      @current_arg_stack.pop
                       @context.in_def = ctx.in_def
                     }
                 | defs_head f_opt_paren_args tEQL endless_command
@@ -282,7 +279,6 @@ rule
                                  val[1], val[2], val[3])
 
                       local_pop
-                      @current_arg_stack.pop
                       @context.in_def = ctx.in_def
                     }
                 | backref tOP_ASGN command_rhs
@@ -362,7 +358,6 @@ rule
         def_name: fname
                     {
                       local_push
-                      @current_arg_stack.push(nil)
 
                       result = [ val[0], @context.dup ]
                       @context.in_def = true
@@ -911,7 +906,6 @@ rule
                                  val[1], val[2], val[3])
 
                       local_pop
-                      @current_arg_stack.pop
                       @context.in_def = ctx.in_def
                     }
                 | defs_head f_opt_paren_args tEQL endless_arg
@@ -923,7 +917,6 @@ rule
                                  val[1], val[2], val[3])
 
                       local_pop
-                      @current_arg_stack.pop
                       @context.in_def = ctx.in_def
                     }
                 | primary
@@ -1382,7 +1375,6 @@ rule
                                   val[2], val[3])
 
                       local_pop
-                      @current_arg_stack.pop
                       @context.in_def = ctx.in_def
                     }
                 | defs_head f_arglist bodystmt kEND
@@ -1392,7 +1384,6 @@ rule
                                   val[2], val[3])
 
                       local_pop
-                      @current_arg_stack.pop
                       @context.in_def = ctx.in_def
                     }
                 | kBREAK
@@ -1655,14 +1646,12 @@ opt_block_args_tail:
  block_param_def: tPIPE opt_bv_decl tPIPE
                     {
                       @max_numparam_stack.has_ordinary_params!
-                      @current_arg_stack.set(nil)
                       @context.in_argdef = false
                       result = @builder.args(val[0], val[1], val[2])
                     }
                 | tPIPE block_param opt_bv_decl tPIPE
                     {
                       @max_numparam_stack.has_ordinary_params!
-                      @current_arg_stack.set(nil)
                       @context.in_argdef = false
                       result = @builder.args(val[0], val[1].concat(val[2]), val[3])
                     }
@@ -2848,13 +2837,11 @@ f_opt_paren_args: f_paren_args
 
       f_arg_asgn: f_norm_arg
                     {
-                      @current_arg_stack.set(val[0][0])
                       result = val[0]
                     }
 
       f_arg_item: f_arg_asgn
                     {
-                      @current_arg_stack.set(0)
                       result = @builder.arg(val[0])
                     }
                 | tLPAREN f_margs rparen
@@ -2879,7 +2866,6 @@ f_opt_paren_args: f_paren_args
 
                       @max_numparam_stack.has_ordinary_params!
 
-                      @current_arg_stack.set(val[0][0])
                       @context.in_argdef = false
 
                       result = val[0]
@@ -2887,13 +2873,11 @@ f_opt_paren_args: f_paren_args
 
             f_kw: f_label arg_value
                     {
-                      @current_arg_stack.set(nil)
                       @context.in_argdef = true
                       result = @builder.kwoptarg(val[0], val[1])
                     }
                 | f_label
                     {
-                      @current_arg_stack.set(nil)
                       @context.in_argdef = true
                       result = @builder.kwarg(val[0])
                     }
@@ -2949,14 +2933,12 @@ f_opt_paren_args: f_paren_args
 
            f_opt: f_arg_asgn f_eq arg_value
                     {
-                      @current_arg_stack.set(0)
                       @context.in_argdef = true
                       result = @builder.optarg(val[0], val[1], val[2])
                     }
 
      f_block_opt: f_arg_asgn f_eq primary_value
                     {
-                      @current_arg_stack.set(0)
                       @context.in_argdef = true
                       result = @builder.optarg(val[0], val[1], val[2])
                     }

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7946,25 +7946,25 @@ class TestParser < Minitest::Test
       [:error, :circular_argument_reference, { :var_name => 'foo' }],
       %q{def m(foo = foo) end},
       %q{            ^^^ location},
-      SINCE_2_7)
+      SINCE_2_7 - SINCE_3_4)
 
     assert_diagnoses(
       [:error, :circular_argument_reference, { :var_name => 'foo' }],
       %q{def m(foo: foo) end},
       %q{           ^^^ location},
-      SINCE_2_7)
+      SINCE_2_7 - SINCE_3_4)
 
     assert_diagnoses(
       [:error, :circular_argument_reference, { :var_name => 'foo' }],
       %q{m { |foo = foo| } },
       %q{           ^^^ location},
-      SINCE_2_7)
+      SINCE_2_7 - SINCE_3_4)
 
     assert_diagnoses(
       [:error, :circular_argument_reference, { :var_name => 'foo' }],
       %q{m { |foo: foo| } },
       %q{          ^^^ location},
-      SINCE_2_7)
+      SINCE_2_7 - SINCE_3_4)
 
     # Traversing
 
@@ -7972,19 +7972,19 @@ class TestParser < Minitest::Test
       [:error, :circular_argument_reference, { :var_name => 'foo' }],
       %q{def m(foo = class << foo; end) end},
       %q{                     ^^^ location},
-      SINCE_2_7)
+      SINCE_2_7 - SINCE_3_4)
 
     assert_diagnoses(
       [:error, :circular_argument_reference, { :var_name => 'foo' }],
       %q{def m(foo = def foo.m; end); end},
       %q{                ^^^ location},
-      SINCE_2_7)
+      SINCE_2_7 - SINCE_3_4)
 
     assert_diagnoses(
       [:error, :circular_argument_reference, { :var_name => 'foo' }],
       %q{m { |foo = proc { 1 + foo }| } },
       %q{                      ^^^ location},
-      SINCE_2_7)
+      SINCE_2_7 - SINCE_3_4)
 
     # Valid cases
 
@@ -8000,6 +8000,20 @@ class TestParser < Minitest::Test
       'm { |foo = proc { || 1 + foo }| }'
     ].each do |code|
       refute_diagnoses(code, SINCE_2_7)
+    end
+  end
+
+  def test_circular_argument_reference_error_since_34
+    [      
+      %q{def m(foo = foo) end},
+      %q{def m(foo: foo) end},
+      %q{m { |foo = foo| } },
+      %q{m { |foo: foo| } },
+      %q{def m(foo = class << foo; end) end},
+      %q{def m(foo = def foo.m; end); end},
+      %q{m { |foo = proc { 1 + foo }| } },
+    ].each do |code|
+      refute_diagnoses(code, SINCE_3_4)
     end
   end
 


### PR DESCRIPTION
Closes #1019

This track upstream commit https://github.com/ruby/ruby/commit/cbc83c4a9221110a94c670d07ed5b23548202cf2