### PR TITLE
- builder.rb: emit `kwargs` node for `indexasgn` when opted in

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1192,6 +1192,10 @@ module Parser
     end
 
     def index_asgn(receiver, lbrack_t, indexes, rbrack_t)
+      if self.class.emit_kwargs
+        rewrite_hash_args_to_kwargs(indexes)
+      end
+
       if self.class.emit_index
         n(:indexasgn, [ receiver, *indexes ],
           index_map(receiver, lbrack_t, rbrack_t))

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -3625,6 +3625,33 @@ class TestParser < Minitest::Test
     Parser::Builders::Default.emit_index = true
   end
 
+  def test_send_index_asgn_kwarg
+    assert_parses(
+      s(:indexasgn,
+        s(:lvar, :foo),
+        s(:kwargs,
+          s(:pair,
+            s(:sym, :kw),
+            s(:send, nil, :arg))),
+        s(:int, 3)),
+      %q{foo[:kw => arg] = 3})
+  end
+
+  def test_send_index_asgn_kwarg_legacy
+    Parser::Builders::Default.emit_kwargs = false
+    assert_parses(
+      s(:indexasgn,
+        s(:lvar, :foo),
+        s(:hash,
+          s(:pair,
+            s(:sym, :kw),
+            s(:send, nil, :arg))),
+        s(:int, 3)),
+      %q{foo[:kw => arg] = 3})
+  ensure
+    Parser::Builders::Default.emit_kwargs = true
+  end
+
   def test_send_lambda
     assert_parses(
       s(:block, s(:lambda),


### PR DESCRIPTION
Noticed while looking into https://github.com/whitequark/parser/issues/1002