### PR TITLE
+ builder.rb: disallow kwargs and blocks in indexasgn for Ruby 3.4

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1192,6 +1192,15 @@ module Parser
     end
 
     def index_asgn(receiver, lbrack_t, indexes, rbrack_t)
+      if @parser.version >= 34 && (last = indexes.last)
+        if kwargs?(last)
+          diagnostic :error, :invalid_arg_in_index_assign, { :type => "keyword"}, last.loc.expression
+        end
+        if last.type == :block_pass
+          diagnostic :error, :invalid_arg_in_index_assign, { :type => "block"}, last.loc.expression
+        end
+      end
+
       if self.class.emit_kwargs
         rewrite_hash_args_to_kwargs(indexes)
       end

--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -1192,6 +1192,10 @@ module Parser
     end
 
     def index_asgn(receiver, lbrack_t, indexes, rbrack_t)
+      if self.class.emit_kwargs
+        rewrite_hash_args_to_kwargs(indexes)
+      end
+
       if self.class.emit_index
         n(:indexasgn, [ receiver, *indexes ],
           index_map(receiver, lbrack_t, rbrack_t))

--- a/lib/parser/messages.rb
+++ b/lib/parser/messages.rb
@@ -85,6 +85,7 @@ module Parser
     :ambiguous_anonymous_restarg   => 'anonymous rest parameter is also used within block',
     :ambiguous_anonymous_kwrestarg => 'anonymous keyword rest parameter is also used within block',
     :ambiguous_anonymous_blockarg  => 'anonymous block parameter is also used within block',
+    :invalid_arg_in_index_assign   => '%{type} argument given in index assignment',
 
     # Parser warnings
     :useless_else            => 'else without rescue is useless',

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -3625,6 +3625,33 @@ class TestParser < Minitest::Test
     Parser::Builders::Default.emit_index = true
   end
 
+  def test_send_index_asgn_kwarg
+    assert_parses(
+      s(:indexasgn,
+        s(:lvar, :foo),
+        s(:kwargs,
+          s(:pair,
+            s(:sym, :kw),
+            s(:send, nil, :arg))),
+        s(:int, 3)),
+      %q{foo[:kw => arg] = 3})
+  end
+
+  def test_send_index_asgn_kwarg_legacy
+    Parser::Builders::Default.emit_kwargs = false
+    assert_parses(
+      s(:indexasgn,
+        s(:lvar, :foo),
+        s(:hash,
+          s(:pair,
+            s(:sym, :kw),
+            s(:send, nil, :arg))),
+        s(:int, 3)),
+      %q{foo[:kw => arg] = 3})
+  ensure
+    Parser::Builders::Default.emit_kwargs = true
+  end
+
   def test_send_lambda
     assert_parses(
       s(:block, s(:lambda),


### PR DESCRIPTION
Builds on top of #1053. Closes #1001, #1002

This tracks upstream commit https://github.com/ruby/ruby/commit/df5ef282337764508a1e1d93459d7a280e46647c and https://github.com/ruby/ruby/commit/0d5b16599a4ad606619228623299b931c48b597b