### PR TITLE
* bump 3.4 branch, remove 3.0 from CI (EOL)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0.7", "3.1.6", "3.2.6", "3.3.6", "jruby-9.2"]
+        ruby: ["3.1.6", "3.2.6", "3.3.6", "3.4.1", "jruby-9.2"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"
             test_command: "bundle exec rake test || true"
           - ruby: "truffleruby"
             test_command: "bundle exec rake test || true"
-          - ruby: "3.2.6"
-            test_command: "./ci/run_rubocop_specs || true"
           - ruby: "3.3.6"
+            test_command: "./ci/run_rubocop_specs || true"
+          - ruby: "3.4.1"
             test_command: "./ci/run_rubocop_specs || true"
     steps:
     - uses: actions/checkout@v4

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -120,7 +120,7 @@ module Parser
     CurrentRuby = Ruby33
 
   when /^3\.4\./
-    current_version = '3.4.0'
+    current_version = '3.4.1'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby34', current_version
     end
@@ -130,8 +130,8 @@ module Parser
 
   else # :nocov:
     # Keep this in sync with released Ruby.
-    warn_syntax_deviation 'parser/ruby33', '3.3.x'
-    require_relative 'ruby33'
-    CurrentRuby = Ruby33
+    warn_syntax_deviation 'parser/ruby34', '3.4.x'
+    require_relative 'ruby34'
+    CurrentRuby = Ruby34
   end
 end


### PR DESCRIPTION
No grammar changes: https://github.com/ruby/ruby/compare/v3_4_0...v3_4_1

Closes https://github.com/whitequark/parser/issues/1056.