### PR TITLE
Numbered parameters are valid for pattern matching pinning

### DIFF
--- a/lib/parser/ruby27.y
+++ b/lib/parser/ruby27.y
@@ -2152,11 +2152,12 @@ opt_block_args_tail:
        p_var_ref: tCARET tIDENTIFIER
                     {
                       name = val[1][0]
+                      lvar = @builder.accessible(@builder.ident(val[1]))
+
                       unless static_env.declared?(name)
                         diagnostic :error, :undefined_lvar, { :name => name }, val[1]
                       end
 
-                      lvar = @builder.accessible(@builder.ident(val[1]))
                       result = @builder.pin(val[0], lvar)
                     }
 

--- a/lib/parser/ruby30.y
+++ b/lib/parser/ruby30.y
@@ -2225,11 +2225,12 @@ opt_block_args_tail:
        p_var_ref: tCARET tIDENTIFIER
                     {
                       name = val[1][0]
+                      lvar = @builder.accessible(@builder.ident(val[1]))
+
                       unless static_env.declared?(name)
                         diagnostic :error, :undefined_lvar, { :name => name }, val[1]
                       end
 
-                      lvar = @builder.accessible(@builder.ident(val[1]))
                       result = @builder.pin(val[0], lvar)
                     }
 

--- a/lib/parser/ruby31.y
+++ b/lib/parser/ruby31.y
@@ -2323,11 +2323,12 @@ opt_block_args_tail:
        p_var_ref: tCARET tIDENTIFIER
                     {
                       name = val[1][0]
+                      lvar = @builder.accessible(@builder.ident(val[1]))
+
                       unless static_env.declared?(name)
                         diagnostic :error, :undefined_lvar, { :name => name }, val[1]
                       end
 
-                      lvar = @builder.accessible(@builder.ident(val[1]))
                       result = @builder.pin(val[0], lvar)
                     }
 

--- a/lib/parser/ruby32.y
+++ b/lib/parser/ruby32.y
@@ -2332,11 +2332,12 @@ opt_block_args_tail:
        p_var_ref: tCARET tIDENTIFIER
                     {
                       name = val[1][0]
+                      lvar = @builder.accessible(@builder.ident(val[1]))
+
                       unless static_env.declared?(name)
                         diagnostic :error, :undefined_lvar, { :name => name }, val[1]
                       end
 
-                      lvar = @builder.accessible(@builder.ident(val[1]))
                       result = @builder.pin(val[0], lvar)
                     }
 

--- a/lib/parser/ruby33.y
+++ b/lib/parser/ruby33.y
@@ -2278,11 +2278,12 @@ opt_block_args_tail:
        p_var_ref: tCARET tIDENTIFIER
                     {
                       name = val[1][0]
+                      lvar = @builder.accessible(@builder.ident(val[1]))
+
                       unless static_env.declared?(name)
                         diagnostic :error, :undefined_lvar, { :name => name }, val[1]
                       end
 
-                      lvar = @builder.accessible(@builder.ident(val[1]))
                       result = @builder.pin(val[0], lvar)
                     }
 

--- a/lib/parser/ruby34.y
+++ b/lib/parser/ruby34.y
@@ -2285,11 +2285,12 @@ opt_block_args_tail:
        p_var_ref: tCARET tIDENTIFIER
                     {
                       name = val[1][0]
+                      lvar = @builder.accessible(@builder.ident(val[1]))
+
                       unless static_env.declared?(name)
                         diagnostic :error, :undefined_lvar, { :name => name }, val[1]
                       end
 
-                      lvar = @builder.accessible(@builder.ident(val[1]))
                       result = @builder.pin(val[0], lvar)
                     }
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -9567,6 +9567,56 @@ class TestParser < Minitest::Test
     )
   end
 
+  def test_pattern_matching_numbered_parameter
+    assert_parses(
+      s(:numblock,
+        s(:send,
+          s(:int, 1), :then), 1,
+        s(:match_pattern,
+          s(:int, 1),
+          s(:pin,
+            s(:lvar, :_1)))),
+      %q{1.then { 1 in ^_1 }},
+      %q{},
+      %w(2.7)
+    )
+
+    assert_parses(
+      s(:numblock,
+        s(:send,
+          s(:int, 1), :then), 1,
+        s(:match_pattern_p,
+          s(:int, 1),
+          s(:pin,
+            s(:lvar, :_1)))),
+      %q{1.then { 1 in ^_1 }},
+      %q{},
+      SINCE_3_0
+    )
+
+    assert_parses(
+      s(:case_match,
+        s(:int, 0),
+        s(:in_pattern,
+          s(:match_var, :_1), nil, nil), nil),
+      %q{case 0; in _1; end},
+      %q{},
+      %w(2.7)
+    )
+
+    assert_diagnoses(
+      [:error, :reserved_for_numparam, { :name => '_1' }],
+      %q{case 0; in _1; end},
+      %q{           ^^ location},
+      SINCE_3_0)
+
+    assert_diagnoses(
+      [:error, :undefined_lvar, { :name => '_1' }],
+      %q{case 0; in ^_1; end},
+      %q{            ^^ location},
+      SINCE_2_7)
+  end
+
   def assert_pattern_matching_defines_local_variables(match_code, lvar_names, versions = SINCE_2_7)
     code = "case 1; #{match_code}; then [#{lvar_names.join(', ')}]; end"
 


### PR DESCRIPTION
The following is how different versions behave:
```rb
# Valid only in 2.7
case 0; in _1; end
1.then { 1 in _1 }

# Valid in no versions
case 0; in ^_1; end

# Valid in all versions
1.then { 1 in ^_1 }
```

`@builder.accessible` makes the numparam visible to the environment, so it must be called first