### PR TITLE
update CI config (bump JRuby version, drop MRI 3.0 branch)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0.7", "3.1.6", "3.2.6", "3.3.7", "jruby-9.2"]
+        ruby: ["3.1.6", "3.2.6", "3.3.7", "jruby-9.4"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"


### PR DESCRIPTION
Github has updated its images and so `ubuntu-latest` is now `ubuntu-24.04`.

[There's no pre-built JRuby 9.2 for `ubuntu-24.04`](https://github.com/ruby/ruby-builder/releases/tag/toolcache), so this PR bumps it to 9.4.

Additionally, MRI 3.0 is EOL.