### PR TITLE
- builder.rb: fix hash value omission considering some local vars as constants

### DIFF
--- a/lib/parser/builders/default.rb
+++ b/lib/parser/builders/default.rb
@@ -524,10 +524,10 @@ module Parser
 
       label = value(key_t)
       value =
-        if label =~ /\A[[:lower:]]/
-          n(:ident, [ label.to_sym ], Source::Map::Variable.new(value_l))
-        else
+        if label =~ /\A[[:upper:]]/
           n(:const, [ nil, label.to_sym ], Source::Map::Constant.new(nil, value_l, value_l))
+        else
+          n(:ident, [ label.to_sym ], Source::Map::Variable.new(value_l))
         end
       pair_keyword(key_t, accessible(value))
     end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -10242,6 +10242,30 @@ class TestParser < Minitest::Test
       SINCE_3_1)
 
     assert_parses(
+      s(:begin,
+        s(:lvasgn, :foo,
+          s(:int, 1)),
+        s(:hash,
+          s(:pair,
+            s(:sym, :foo),
+            s(:lvar, :foo)))),
+      %q{foo = 1; {foo:}},
+      %q{},
+      SINCE_3_1)
+
+    assert_parses(
+      s(:begin,
+        s(:lvasgn, :_foo,
+          s(:int, 1)),
+        s(:hash,
+          s(:pair,
+            s(:sym, :_foo),
+            s(:lvar, :_foo)))),
+      %q{_foo = 1; {_foo:}},
+      %q{},
+      SINCE_3_1)
+
+    assert_parses(
       s(:hash,
         s(:pair, s(:sym, :BAR), s(:const, nil, :BAR))),
       %q{{BAR:}},


### PR DESCRIPTION
A constant always start in uppercase but a local will not always start with lowercase. `_foo` and `💎` are both valid local variables.