### PR TITLE
Bump parser current_version patch version for ruby 3.4

### DIFF
--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -120,7 +120,7 @@ module Parser
     CurrentRuby = Ruby33
 
   when /^3\.4\./
-    current_version = '3.4.0'
+    current_version = '3.4.1'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby34', current_version
     end


### PR DESCRIPTION
Fix https://github.com/whitequark/parser/issues/1056

I was getting this warning from the gem i18n-tasks:
```
warning: parser/current is loading parser/ruby34, which recognizes
3.4.0-compliant syntax, but you are running 3.4.1.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
```

I made the following PR:
https://github.com/glebm/i18n-tasks/pull/613

But perhaps fixing it in the parser repository is better.