### PR TITLE
Document the current state of the project in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ equivalent source code from Parser's ASTs.
 Sponsored by [Evil Martians](http://evilmartians.com).
 MacRuby and RubyMotion support sponsored by [CodeClimate](http://codeclimate.com).
 
+> [!WARNING]  
+> The `parser` gem is only compatible with the syntax of Ruby 3.3 and lower. For Ruby 3.4 and later, please use the [`Prism::Translation::Parser`](https://github.com/ruby/prism/blob/main/docs/parser_translation.md) instead.
+> Starting in Ruby 3.4, Prism is the parser used in Ruby itself and can produce AST that is identical to the output of the `parser` gem. If you only need to parse Ruby 3.3 (or greater) and don't require compatibility with the `parser` gem AST, also consider using the native Prism AST.
+> See this [GitHub issue](https://github.com/whitequark/parser/issues/1046) for more details.
+
 ## Installation
 
     $ gem install parser


### PR DESCRIPTION
Because of https://github.com/whitequark/parser/issues/1046. It will look like this:

> [!WARNING]  
> The `parser` gem can only correctly parse Ruby code up to and including Ruby 3.3. For Ruby 3.4 and later, please use the [Prism translation parser](https://github.com/ruby/prism/blob/main/docs/parser_translation.md) instead.
> Starting in Ruby 3.4, Prism is the parser used in Ruby itself and can produces AST that is identical to the output of `parser`. If you only need to parse Ruby 3.3 (or greater), also consider using the native Prism AST.
> See this [GitHub issue](https://github.com/whitequark/parser/issues/1046) for more details.

I think this makes sense?