### PR TITLE
Document parser/prism migration path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ MacRuby and RubyMotion support sponsored by [CodeClimate](http://codeclimate.com
 > The `parser` gem is only compatible with the syntax of Ruby 3.3 and lower. For Ruby 3.4 and later, please use the [`Prism::Translation::Parser`](https://github.com/ruby/prism/blob/main/docs/parser_translation.md) instead.
 > Starting in Ruby 3.4, Prism is the parser used in Ruby itself and can produce AST that is identical to the output of the `parser` gem. If you only need to parse Ruby 3.3 (or greater) and don't require compatibility with the `parser` gem AST, also consider using the native Prism AST.
 > See this [GitHub issue](https://github.com/whitequark/parser/issues/1046) for more details.
+> For a guide on how to use `parser` for older versions and `prism` for newer ones, please see [this guide](./doc/PRISM_TRANSLATION.md).
 
 ## Installation
 

--- a/doc/AST_FORMAT.md
+++ b/doc/AST_FORMAT.md
@@ -1209,7 +1209,7 @@ def f(*a: b); end
 ### Block with numbered parameters
 
 Ruby 2.7 introduced a feature called "numbered parameters".
-Numbered and ordinal parameters are mutually exclusive, so if the block
+Numbered, implicit it, and ordinal parameters are mutually exclusive, so if the block
 has only numbered parameters it also has a different AST node.
 
 Note that the second child represents a total number of numbered parameters.
@@ -1225,6 +1225,24 @@ s(:numblock,
 "proc { _1 + _3 }"
       ~ begin   ~ end
  ~~~~~~~~~~~~~~~~ expression
+~~~
+
+## Block with implicit it parameter (prism only)
+
+Ruby 3.4 introduced a feature called the "implicit it parameter".
+Implicit it, numbered, and ordinal parameters are mutually exclusive, so if the block
+only has the implicit it parameter it also has a different AST node.
+
+The second child will always be the symbol `it`.
+
+Format:
+
+~~~
+s(:itblock,
+  s(:send, nil, :proc), :it,
+  s(:send, s(:lvar, :it)))
+"proc { it }"
+ ~~~~~~~~~~~ expression
 ~~~
 
 ## Forward arguments

--- a/doc/PRISM_TRANSLATION.md
+++ b/doc/PRISM_TRANSLATION.md
@@ -1,0 +1,89 @@
+# Usage in conjunction with the Prism Parser Translator
+
+Because `parser` only parses Ruby <= 3.3 and `prism` only Ruby >= 3.3, if you want to continue parsing both old and new versions, you need to depend on both `parser` and `prism`.
+
+## Using `prism` when parsing with an explicit Ruby verion
+
+```rb
+require 'parser'
+require 'prism'
+
+def parser_for_ruby_version(ruby_version)
+  case ruby_version
+  when 3.1
+    require 'parser/ruby31'
+    Parser::Ruby31
+  when 3.2
+    require 'parser/ruby32'
+    Parser::Ruby32
+  when 3.3
+    Prism::Translation::Parser33
+  when 3.4
+    Prism::Translation::Parser34
+  else
+    raise 'Unknown Ruby version'
+  end
+end
+
+parser_for_ruby_version(3.4).parse(<<~RUBY)
+  puts 'Hello World!'
+RUBY
+```
+
+## Using `prism` when parsing ruby for the currently running Ruby version
+
+If you are using `Parser::CurrentRuby`, you need to do similar branching logic. Do note that `prism` has no concept of a parser for the currently executing ruby version. As an alternative, you can manually extract the necessary version from the `RUBY_VERSION` constant:
+
+```rb
+def parser_for_current_ruby
+  code_version = RUBY_VERSION.to_f
+
+  if code_version <= 3.3
+    require 'parser/current'
+    Parser::CurrentRuby
+  else
+    require 'prism'
+    case code_version
+    when 3.3
+      Prism::Translation::Parser33
+    when 3.4
+      Prism::Translation::Parser34
+    else
+      warn "Unknown Ruby version #{code_version}, using 3.4 as a fallback"
+      Prism::Translation::Parser34
+    end
+  end
+end
+
+parser_for_current_ruby.parse(<<~RUBY)
+  puts 'Hello World!'
+RUBY
+```
+
+## Using a custom builder
+
+If you are providing a custom builder (see [Customization](./CUSTOMIZATION.md)), you must create a copy that behaves the same for `prism`, but inherits from a different base class. This is because the builder used internally by `prism` has more functionality for more modern node types, which is lacking in the builder from `parser`.
+
+```rb
+# Use a module to not duplicate the implementation
+module BuilderExtensions
+  def self.inherited(base)
+    # Always emit the most modern format available
+    base.modernize
+  end
+end
+
+class BuilderParser < Parser::Builders::Default
+  include BuilderExtensions
+end
+
+class BuilderPrism < Prism::Translation::Parser::Builder
+  include BuilderExtensions
+end
+```
+
+You can then conditionally use the proper builder class, branching on the version of ruby that will get analyzed.
+
+## New node types
+
+As new syntax gets added to Ruby, the `prism` gem may emit nodes that have no counterpart in the `parser` gem. These nodes will be documented [in the usual place](./AST_FORMAT.md) but are otherwise not supported or emitted by the `parser` gem.


### PR DESCRIPTION
Ref https://github.com/whitequark/parser/pull/1071#issuecomment-2736283700

cc @bbatsov

I'm not a good technical writer so this can probably use some grease here and there. I think I've got the main points that can come up. I also added `itblock` to the ast docs and marked it was prism-only.

This only focuses on the translation layer, not on using prism standalone.