### PR TITLE
* Bump maintenance branches to 3.2.8 and 3.1.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1.6", "3.2.7", "3.3.7", "3.4.1", "jruby-9.4"]
+        ruby: ["3.1.7", "3.2.8", "3.3.7", "3.4.1", "jruby-9.4"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"
             test_command: "bundle exec rake test || true"
           - ruby: "truffleruby"
             test_command: "bundle exec rake test || true"
-          - ruby: "3.2.7"
+          - ruby: "3.2.8"
             test_command: "./ci/run_rubocop_specs || true"
           - ruby: "3.3.7"
             test_command: "./ci/run_rubocop_specs || true"

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -93,7 +93,7 @@ module Parser
     CurrentRuby = Ruby30
 
   when /^3\.1\./
-    current_version = '3.1.6'
+    current_version = '3.1.7'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby31', current_version
     end
@@ -102,7 +102,7 @@ module Parser
     CurrentRuby = Ruby31
 
   when /^3\.2\./
-    current_version = '3.2.7'
+    current_version = '3.2.8'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby32', current_version
     end


### PR DESCRIPTION
These Rubies have been released.

- https://www.ruby-lang.org/en/news/2025/03/26/ruby-3-2-8-released/
- https://www.ruby-lang.org/en/news/2025/03/26/ruby-3-1-7-released/

## Ruby 3.2 branch

Bump 3.2 branch from 3.2.7 to 3.2.8

https://github.com/ruby/ruby/compare/v3_2_7...v3_2_8

There seems to be no change to syntax.

## Ruby 3.1 branch

Bump 3.1 branch from 3.1.6 to 3.1.7

https://github.com/ruby/ruby/compare/v3_1_6...v3_1_7

There seems to be no change to syntax.