### PR TITLE
* YARD docs for Parser::CurrentRuby and Parser::Base#version

### DIFF
--- a/lib/parser/base.rb
+++ b/lib/parser/base.rb
@@ -13,6 +13,9 @@ module Parser
   # @!attribute [r] static_env
   #  @return [Parser::StaticEnvironment]
   #
+  # @!attribute [r] version
+  #  @return [Integer]
+  #
   class Base < Racc::Parser
     ##
     # Parses a string of Ruby code and returns the AST. If the source

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -134,4 +134,13 @@ module Parser
     require_relative 'ruby33'
     CurrentRuby = Ruby33
   end
+  # @!parse
+  #  ##
+  #  # @api public
+  #  #
+  #  # Parser for the running version of Ruby. NOTE: Supports only Ruby <= 3.3. To parse Ruby 3.4+, please use the prism gem. You can also use them in conjunction to support multiple versions using a backwards-compatible AST.
+  #  #
+  #  # @see https://ruby.github.io/prism/rb/docs/ruby_api_md.html prism gem documentation
+  #  # @see https://github.com/whitequark/parser/blob/master/doc/PRISM_TRANSLATION.md Guide to using prism and parser together.
+  #  class ::Parser::CurrentRuby < ::Parser::Base; end
 end


### PR DESCRIPTION
Documentation changes:

* Add YARD docs for `Parser::CurrentRuby`:
  * Document the transition for users seeking Ruby 3.4 support
  * Allow IDE tools like Solargraph to understand the invocation and results from Parser::Current.parse() to provide auto-completion and type checking

* Add type info for `Parser::Base#version`