### PR TITLE
* Bump maintenance branches to 3.2.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1.7", "3.2.10", "3.3.10", "3.4.1", "jruby-9.4"]
+        ruby: ["3.1.7", "3.2.11", "3.3.11", "3.4.1", "jruby-9.4"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"
             test_command: "bundle exec rake test || true"
           - ruby: "truffleruby"
             test_command: "bundle exec rake test || true"
-          - ruby: "3.2.9"
+          - ruby: "3.2.11"
             test_command: "./ci/run_rubocop_specs || true"
           - ruby: "3.3.11"
             test_command: "./ci/run_rubocop_specs || true"

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -102,7 +102,7 @@ module Parser
     CurrentRuby = Ruby31
 
   when /^3\.2\./
-    current_version = '3.2.10'
+    current_version = '3.2.11'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby32', current_version
     end


### PR DESCRIPTION
Ruby 3.2.11 has been released:
https://www.ruby-lang.org/en/news/2026/03/27/ruby-3-2-11-released/

Bump 3.2 branch from 3.2.10 to 3.2.11:
https://github.com/ruby/ruby/compare/v3_2_10...v3_2_11

There seems to be no change to syntax.