### PR TITLE
* Bump maintenance branches to 3.3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1.7", "3.2.11", "3.3.11", "3.4.1", "jruby-9.4"]
+        ruby: ["3.1.7", "3.2.11", "3.3.12", "3.4.1", "jruby-9.4"]
         test_command: ["bundle exec rake test"]
         include:
           - ruby: "head"
@@ -26,7 +26,7 @@ jobs:
             test_command: "bundle exec rake test || true"
           - ruby: "3.2.11"
             test_command: "./ci/run_rubocop_specs || true"
-          - ruby: "3.3.11"
+          - ruby: "3.3.12"
             test_command: "./ci/run_rubocop_specs || true"
           - ruby: "3.4.1"
             test_command: "./ci/run_rubocop_specs || true"

--- a/lib/parser/current.rb
+++ b/lib/parser/current.rb
@@ -111,7 +111,7 @@ module Parser
     CurrentRuby = Ruby32
 
   when /^3\.3\./
-    current_version = '3.3.11'
+    current_version = '3.3.12'
     if RUBY_VERSION != current_version
       warn_syntax_deviation 'parser/ruby33', current_version
     end


### PR DESCRIPTION
Ruby 3.3.12 has been released:
https://www.ruby-lang.org/en/news/2026/07/16/ruby-3-3-12-released/

Bump 3.3 branch from 3.3.11 to 3.3.12:
https://github.com/ruby/ruby/compare/v3_3_11...v3_3_12

There seems to be no change to syntax.