### PR TITLE
Fix crash on \c/\M- escapes with an invalid byte on a UTF-8 source

### DIFF
--- a/lib/parser/lexer-strings.rl
+++ b/lib/parser/lexer-strings.rl
@@ -445,7 +445,11 @@ class Parser::LexerStrings
   end
 
   def read_post_meta_or_ctrl_char(p)
-    @escape = source_buffer.slice(p - 1, 1).chr
+    # \c and \M- escapes operate on the raw byte value of their target, not on
+    # a Unicode codepoint, so read it as a raw byte here: the source buffer's
+    # own encoding (eg. UTF-8) would otherwise make `.ord` below raise on a
+    # byte that isn't valid on its own in that encoding (eg. \c\xFF).
+    @escape = source_buffer.slice(p - 1, 1).chr.b
 
     if @version >= 27 && ((0..8).include?(@escape.ord) || (14..31).include?(@escape.ord))
       diagnostic :fatal, :invalid_escape
@@ -477,11 +481,16 @@ class Parser::LexerStrings
   end
 
   def slash_c_char
-    @escape = encode_escape(@escape[0].ord & 0x9f)
+    # @escape may already carry the source encoding (eg. via encode_escape,
+    # which force_encodes a raw byte without validating it), so read its
+    # value as a raw byte here rather than as a character in that encoding:
+    # a \c/\M control/meta escape operates on bytes, and .ord on a string
+    # that isn't valid in its tagged encoding raises ArgumentError.
+    @escape = encode_escape(@escape.b[0].ord & 0x9f)
   end
 
   def slash_m_char
-    @escape = encode_escape(@escape[0].ord | 0x80)
+    @escape = encode_escape(@escape.b[0].ord | 0x80)
   end
 
   def emit_character_constant

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -11070,6 +11070,56 @@ class TestParser < Minitest::Test
       SINCE_3_1)
   end
 
+  # Same escapes as test_control_meta_escape_chars_in_regexp__since_31, but
+  # from a UTF-8 source (the common case, and what these literals actually
+  # have by default unless the source is forced to ascii-8bit as above).
+  # \x9F on its own isn't valid UTF-8, so this can't successfully parse to a
+  # :str node the way the ascii-8bit case does; it must instead raise a
+  # graceful diagnostic rather than crash with an unhandled ArgumentError.
+  def test_control_meta_escape_chars_in_regexp_from_utf8_source
+    assert_diagnoses(
+      [:error, :invalid_encoding],
+      %q{/\c\xFF/},
+      %q{},
+      SINCE_3_1)
+
+    assert_diagnoses(
+      [:error, :invalid_encoding],
+      %q{/\c\M-\xFF/},
+      %q{},
+      SINCE_3_1)
+
+    assert_diagnoses(
+      [:error, :invalid_encoding],
+      %q{/\C-\xFF/},
+      %q{},
+      SINCE_3_1)
+
+    assert_diagnoses(
+      [:error, :invalid_encoding],
+      %q{/\C-\M-\xFF/},
+      %q{},
+      SINCE_3_1)
+
+    assert_diagnoses(
+      [:error, :invalid_encoding],
+      %q{/\M-\xFF/},
+      %q{},
+      SINCE_3_1)
+
+    assert_diagnoses(
+      [:error, :invalid_encoding],
+      %q{/\M-\C-\xFF/},
+      %q{},
+      SINCE_3_1)
+
+    assert_diagnoses(
+      [:error, :invalid_encoding],
+      %q{/\M-\c\xFF/},
+      %q{},
+      SINCE_3_1)
+  end
+
   def test_forward_arg_with_open_args
     assert_diagnoses_many(
       [


### PR DESCRIPTION
## What

Parsing a control/meta escape (`\c`, `\M-`) whose target byte isn't valid on its own in the source's encoding — eg. `\c\xFF` from a UTF-8 source — crashes with an unhandled `ArgumentError: invalid byte sequence in UTF-8`, instead of the existing, already-handled `:invalid_encoding` diagnostic that similar escapes like `\M-a` already raise gracefully.

Reported downstream at rubocop, where a Ruby source file simply containing `/\c\xFF/` as a regex literal (part of MRI's own regexp test suite) crashes rubocop entirely: https://github.com/rubocop/rubocop/issues/15457

## Why

`read_post_meta_or_ctrl_char`, `slash_c_char` and `slash_m_char` all call `.ord` on `@escape` without controlling its encoding. `@escape` usually carries the source buffer's own encoding (UTF-8 by default), and either that byte directly, or the result of `encode_escape()` applying the `\c`/`\M-` bit operations to it and `force_encoding`-ing the result back to the source's encoding, can be invalid on its own in that encoding.

`\c` and `\M-` escapes operate on the raw byte value of their target, not on a Unicode codepoint, so this reads `@escape`'s value via `String#b` instead, which never raises regardless of whether the byte happens to be valid in the source's encoding.

## Verification

- Full test suite: 1125 runs, 567214 assertions, 0 failures, 0 errors (was 1124 runs before this PR's added test).
- Added a parser-level regression test (`test_control_meta_escape_chars_in_regexp_from_utf8_source`) covering all 7 `\c`/`\M-`/`\C-` + `\xFF` combinations from a UTF-8 source (the common case) — confirmed it reproduces the exact crash on unmodified code and passes with the fix.
- The existing lexer-level test for these escapes (`test_meta_control_hex_escaped_char`, targeting an old Ruby version) and the existing parser-level test (`test_control_meta_escape_chars_in_regexp__since_31`) both still pass unmodified — the latter only exercises an `ascii-8bit`-forced source, which is why it never caught this in the first place.
- Manually checked that already-working escapes (`\ca`, `\x41`, `\x7f`) and already-gracefully-erroring ones (`\M-a`, `\M-\C-a`) are unaffected.

I'm not marking this as closing rubocop/rubocop#15457 directly since that repo depends on a released version of this gem; leaving it linked for context instead.

---
Disclosure: this PR was prepared with the assistance of Claude Code (Anthropic). The investigation, root-cause diagnosis, fix, and verification steps described above were done and checked by me.